### PR TITLE
[feat] 회의 API 엔드포인트 스켈레톤 작성

### DIFF
--- a/src/main/java/com/flodiback/domain/meeting/meeting/controller/MeetingController.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/controller/MeetingController.java
@@ -1,0 +1,39 @@
+package com.flodiback.domain.meeting.meeting.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
+import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
+import com.flodiback.domain.meeting.meeting.dto.MeetingDetailResponse;
+import com.flodiback.domain.meeting.meeting.service.MeetingService;
+import com.flodiback.global.rsData.RsData;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/v1/meetings")
+@RequiredArgsConstructor
+public class MeetingController {
+
+    private final MeetingService service;
+
+    @PostMapping
+    public ResponseEntity<RsData<CreateMeetingResponse>> createMeeting(@RequestBody CreateMeetingRequest req) {
+        CreateMeetingResponse response = service.create(req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(RsData.of("201-1", "회의가 생성되었습니다.", response));
+    }
+
+    @PutMapping("/{id}/end")
+    public ResponseEntity<RsData<MeetingDetailResponse>> endMeeting(@PathVariable Long id) {
+        MeetingDetailResponse response = service.end(id);
+        return ResponseEntity.ok(RsData.of("200-1", "회의가 종료되었습니다.", response));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<RsData<MeetingDetailResponse>> getMeeting(@PathVariable Long id) {
+        MeetingDetailResponse response = service.getById(id);
+        return ResponseEntity.ok(RsData.of("200-1", "회의 조회 성공.", response));
+    }
+}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/dto/CreateMeetingRequest.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/dto/CreateMeetingRequest.java
@@ -1,0 +1,3 @@
+package com.flodiback.domain.meeting.meeting.dto;
+
+public record CreateMeetingRequest(Long projectId, String title) {}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/dto/CreateMeetingResponse.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/dto/CreateMeetingResponse.java
@@ -1,0 +1,8 @@
+package com.flodiback.domain.meeting.meeting.dto;
+
+import java.time.LocalDateTime;
+
+import com.flodiback.global.enums.MeetingStatus;
+
+public record CreateMeetingResponse(
+        Long id, Long projectId, String title, LocalDateTime startedAt, MeetingStatus status) {}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/dto/MeetingDetailResponse.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/dto/MeetingDetailResponse.java
@@ -1,0 +1,8 @@
+package com.flodiback.domain.meeting.meeting.dto;
+
+import java.time.LocalDateTime;
+
+import com.flodiback.global.enums.MeetingStatus;
+
+public record MeetingDetailResponse(
+        Long id, Long projectId, String title, LocalDateTime startedAt, LocalDateTime endedAt, MeetingStatus status) {}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/entity/Meeting.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/entity/Meeting.java
@@ -23,8 +23,8 @@ public class Meeting {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "project_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "project_id", nullable = true) // 프로젝트가 없어도 미팅 시작 가능
     private Project project;
 
     @Column(name = "title", length = 200)

--- a/src/main/java/com/flodiback/domain/meeting/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/repository/MeetingRepository.java
@@ -1,0 +1,7 @@
+package com.flodiback.domain.meeting.meeting.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+
+public interface MeetingRepository extends JpaRepository<Meeting, Long> {}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -1,0 +1,29 @@
+package com.flodiback.domain.meeting.meeting.service;
+
+import org.springframework.stereotype.Service;
+
+import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
+import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
+import com.flodiback.domain.meeting.meeting.dto.MeetingDetailResponse;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingService {
+
+    private final MeetingRepository meetingRepository;
+
+    public CreateMeetingResponse create(CreateMeetingRequest req) {
+        throw new UnsupportedOperationException("TODO");
+    }
+
+    public MeetingDetailResponse end(Long id) {
+        throw new UnsupportedOperationException("TODO");
+    }
+
+    public MeetingDetailResponse getById(Long id) {
+        throw new UnsupportedOperationException("TODO");
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #1 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #1 

---

**📝 작업 내용**

회의 API의 스켈레톤을 구성했습니다. Controller / Service / Repository / DTO 계층을 분리하여 구조를 잡았으며,

실제 비즈니스 로직은 추후 구현 예정입니다.

또한 프로젝트 없이도 미팅을 시작할 수 있도록 Meeting.project FK를 nullable로 변경했습니다.

---

**✅ 주요 변경 사항**

1. MeetingController - POST /api/v1/meetings, PUT /api/v1/meetings/{id}/end, GET /api/v1/meetings/{id}

엔드포인트 추가

2. MeetingService - create(), end(), getById() 스텁 구현 (UnsupportedOperationException)

3. MeetingRepository - JpaRepository<Meeting, Long> 상속

4. DTO 3종 추가 - CreateMeetingRequest, CreateMeetingResponse, MeetingDetailResponse

5. Meeting.project - optional = false → optional = true, nullable = true 로 변경

---

**🧪 테스트 결과**

# 현재 스켈레톤 단계로 별도 테스트 없음

- 로컬 테스트 통과

- 관련 시나리오 수동 확인

---

**👀 리뷰 포인트 (선택)**

- Meeting.project nullable 허용 여부 — ERD 상 project_id NOT NULL이었으나 "프로젝트 없이 미팅 시작 가능"

요구사항으로 변경. DDL 마이그레이션 스크립트도 함께 수정 필요

- 엔드포인트 응답 메시지 문구 통일 여부

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
