### PR TITLE
[Feat] 회의 도메인 api 구현-createMeeting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ description = "flodi-back"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,37 @@ plugins {
     id("org.springframework.boot") version "3.5.14"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.diffplug.spotless") version "8.1.0"
+    jacoco
+}
+
+jacoco {
+    toolVersion = "0.8.14"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+    }
+
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) {
+                exclude(
+                    "**/dto/**",
+                    "**/config/**",
+                    "**/*Application*",
+                    "**/Q*"
+                )
+            }
+        })
+    )
+}
+
+tasks.test {
+    finalizedBy(tasks.jacocoTestReport)
 }
 
 spotless {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,47 +3,6 @@ plugins {
     id("org.springframework.boot") version "3.5.14"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.diffplug.spotless") version "8.1.0"
-    jacoco
-}
-
-
-jacoco {
-    // Jacoco 버전 (2026년 기준 최신 안정화 버전 권장)
-    toolVersion = "0.8.12"
-}
-
-tasks.jacocoTestReport {
-    // 2. 리포트 생성 전 테스트가 반드시 실행되도록 설정
-    dependsOn(tasks.test)
-
-    reports {
-        // html 리포트 활성화 (브라우저로 볼 용도)
-        html.required.set(true)
-        // xml 리포트 활성화 (SonarQube 등 연동용)
-        xml.required.set(true)
-
-        // 리포트 저장 위치를 바꾸고 싶다면 (기본값은 build/reports/jacoco)
-        // html.outputLocation.set(layout.buildDirectory.dir("jacocoHtml"))
-    }
-
-    // 3. 리포트에서 제외할 클래스 설정 (QueryDSL, DTO 등)
-    classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/dto/**",
-                    "**/config/**",
-                    "**/*Application*",
-                    "**/Q*" // QueryDSL용
-                )
-            }
-        })
-    )
-}
-
-tasks.test {
-    // 4. 테스트 완료 후 자동으로 Jacoco 리포트 생성
-    finalizedBy(tasks.jacocoTestReport)
 }
 
 spotless {
@@ -101,7 +60,7 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
+    testImplementation("com.tngtech.archunit:archunit-junit5:1.4.2")
     testCompileOnly("org.projectlombok:lombok")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testAnnotationProcessor("org.projectlombok:lombok")

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -1,11 +1,16 @@
 package com.flodiback.domain.meeting.meeting.service;
 
+import java.util.NoSuchElementException;
+
 import org.springframework.stereotype.Service;
 
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
 import com.flodiback.domain.meeting.meeting.dto.MeetingDetailResponse;
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,9 +19,25 @@ import lombok.RequiredArgsConstructor;
 public class MeetingService {
 
     private final MeetingRepository meetingRepository;
+    private final ProjectRepository projectRepository;
 
     public CreateMeetingResponse create(CreateMeetingRequest req) {
-        throw new UnsupportedOperationException("TODO");
+        Project project = null;
+        if (req.projectId() != null) {
+            project = projectRepository
+                    .findById(req.projectId())
+                    .orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        }
+
+        Meeting meeting = Meeting.builder().project(project).title(req.title()).build();
+        meetingRepository.save(meeting);
+
+        return new CreateMeetingResponse(
+                meeting.getId(),
+                project != null ? project.getId() : null,
+                meeting.getTitle(),
+                meeting.getStartedAt(),
+                meeting.getStatus());
     }
 
     public MeetingDetailResponse end(Long id) {

--- a/src/main/java/com/flodiback/domain/project/project/repository/ProjectRepository.java
+++ b/src/main/java/com/flodiback/domain/project/project/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package com.flodiback.domain.project.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flodiback.domain.project.project.entity.Project;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {}

--- a/src/test/java/com/flodiback/domain/meeting/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meeting/service/MeetingServiceTest.java
@@ -1,0 +1,87 @@
+package com.flodiback.domain.meeting.meeting.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
+import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.global.enums.MeetingStatus;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingServiceTest {
+
+    @InjectMocks
+    private MeetingService meetingService;
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Test
+    void create_projectId없으면_project_null로_미팅생성() {
+        // given
+        CreateMeetingRequest req = new CreateMeetingRequest(null, "테스트 회의");
+        given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        CreateMeetingResponse response = meetingService.create(req);
+
+        // then
+        verify(projectRepository, never()).findById(any());
+        verify(meetingRepository).save(any(Meeting.class));
+        assertThat(response.projectId()).isNull();
+        assertThat(response.title()).isEqualTo("테스트 회의");
+        assertThat(response.status()).isEqualTo(MeetingStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void create_유효한_projectId면_미팅생성() {
+        // given
+        Project project = Project.builder().name("테스트 프로젝트").build();
+        CreateMeetingRequest req = new CreateMeetingRequest(1L, "테스트 회의");
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        CreateMeetingResponse response = meetingService.create(req);
+
+        // then
+        verify(projectRepository).findById(1L);
+        verify(meetingRepository).save(any(Meeting.class));
+        assertThat(response.title()).isEqualTo("테스트 회의");
+        assertThat(response.status()).isEqualTo(MeetingStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void create_존재하지않는_projectId면_예외발생() {
+        // given
+        CreateMeetingRequest req = new CreateMeetingRequest(999L, "테스트 회의");
+        given(projectRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> meetingService.create(req))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 프로젝트입니다.");
+
+        verify(meetingRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #이슈번호
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #이슈번호

---

**📝 작업 내용**

createMeeting 비즈니스 로직을 구현하고 단위 테스트를 작성했습니다.

projectId가 없어도 미팅을 시작할 수 있도록 nullable로 처리했으며, 존재하지 않는 projectId 전달 시 예외를

발생시킵니다.

또한 Java 25와 호환되지 않던 Jacoco를 제거하고 ArchUnit을 1.4.2로 업그레이드해 전체 테스트가 정상 통과하도록

했습니다.

---

**✅ 주요 변경 사항**

1. MeetingService.create() 구현 — projectId nullable 처리, 존재하지 않는 projectId 시 NoSuchElementException

2. ProjectRepository 신규 추가 — JpaRepository<Project, Long> 상속

3. MeetingServiceTest 단위 테스트 3케이스 추가 — projectId null / 유효 / 존재하지 않는 경우

4. build.gradle.kts — Jacoco 제거, ArchUnit 1.3.0 → 1.4.2 업그레이드 (Java 25 지원)

---

**🧪 테스트 결과**

./gradlew cleanTest test

- BUILD SUCCESSFUL — 8 tests completed, 0 failed

- 로컬 테스트 통과

- 관련 시나리오 수동 확인

---

**👀 리뷰 포인트 (선택)**

- projectId = null일 때 미팅 생성을 허용하는 것이 맞는지 — ERD 상 project_id NOT NULL이었으나 요구사항으로

nullable 변경, Flyway 마이그레이션 스크립트 수정 필요

- Jacoco 제거로 커버리지 리포트가 없어짐 — 추후 Java 25 지원 버전으로 재도입 여부 논의 필요

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
