### PR TITLE
feat: STT 발화 수신 internal API 구현

### DIFF
--- a/src/main/java/com/flodiback/api/speech/InternalSpeechController.java
+++ b/src/main/java/com/flodiback/api/speech/InternalSpeechController.java
@@ -1,0 +1,32 @@
+package com.flodiback.api.speech;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flodiback.domain.speech.dto.InternalSpeechRequest;
+import com.flodiback.domain.speech.dto.InternalSpeechResponse;
+import com.flodiback.domain.speech.service.InternalSpeechService;
+import com.flodiback.global.rsData.RsData;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1")
+public class InternalSpeechController {
+
+    private final InternalSpeechService internalSpeechService;
+
+    @PostMapping("/speech")
+    public ResponseEntity<RsData<InternalSpeechResponse>> receiveSpeech(
+            @Valid @RequestBody InternalSpeechRequest request) {
+        // Python 봇에서 전달한 STT 결과를 저장 처리로 넘긴다.
+        InternalSpeechResponse response = internalSpeechService.saveSpeech(request);
+
+        return ResponseEntity.ok(RsData.of("200-1", "발화가 저장되었습니다.", response));
+    }
+}

--- a/src/main/java/com/flodiback/api/speech/InternalSpeechController.java
+++ b/src/main/java/com/flodiback/api/speech/InternalSpeechController.java
@@ -24,7 +24,7 @@ public class InternalSpeechController {
     @PostMapping("/speech")
     public ResponseEntity<RsData<InternalSpeechResponse>> receiveSpeech(
             @Valid @RequestBody InternalSpeechRequest request) {
-        // Python 봇에서 전달한 STT 결과를 저장 처리로 넘긴다.
+        // Discord 봇에서 전달한 STT 결과를 저장 처리로 넘긴다.
         InternalSpeechResponse response = internalSpeechService.saveSpeech(request);
 
         return ResponseEntity.ok(RsData.of("200-1", "발화가 저장되었습니다.", response));

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/entity/Utterance.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/entity/Utterance.java
@@ -2,8 +2,6 @@ package com.flodiback.domain.meeting.meetinglog.entity;
 
 import java.time.LocalDateTime;
 
-import org.hibernate.annotations.CreationTimestamp;
-
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
 
 import jakarta.persistence.*;
@@ -35,15 +33,16 @@ public class Utterance {
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @CreationTimestamp
-    @Column(name = "spoken_at", nullable = false, updatable = false)
+    @Column(name = "spoken_at", nullable = false)
     private LocalDateTime spokenAt;
 
     @Builder
-    public Utterance(Meeting meeting, String speakerName, String speakerDiscordId, String content) {
+    public Utterance(
+            Meeting meeting, String speakerName, String speakerDiscordId, String content, LocalDateTime spokenAt) {
         this.meeting = meeting;
         this.speakerName = speakerName;
         this.speakerDiscordId = speakerDiscordId;
         this.content = content;
+        this.spokenAt = spokenAt != null ? spokenAt : LocalDateTime.now();
     }
 }

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
@@ -1,0 +1,7 @@
+package com.flodiback.domain.meeting.meetinglog.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
+
+public interface UtteranceRepository extends JpaRepository<Utterance, Long> {}

--- a/src/main/java/com/flodiback/domain/speech/dto/InternalSpeechRequest.java
+++ b/src/main/java/com/flodiback/domain/speech/dto/InternalSpeechRequest.java
@@ -20,5 +20,5 @@ public record InternalSpeechRequest(
         // STT가 변환한 발화 텍스트입니다.
         @NotBlank String text,
 
-        // Python 봇이 발화를 감지한 시각입니다.
+        // Discord 봇이 발화를 감지한 시각입니다.
         @NotNull LocalDateTime timestamp) {}

--- a/src/main/java/com/flodiback/domain/speech/dto/InternalSpeechRequest.java
+++ b/src/main/java/com/flodiback/domain/speech/dto/InternalSpeechRequest.java
@@ -1,0 +1,24 @@
+package com.flodiback.domain.speech.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record InternalSpeechRequest(
+        // STT 결과가 연결될 회의 ID입니다.
+        @JsonProperty("meeting_id") @NotNull Long meetingId,
+
+        // Discord에서 화자를 식별하는 사용자 ID입니다.
+        @JsonProperty("speaker_discord_id") @NotBlank String speakerDiscordId,
+
+        // 회의록에 표시할 화자 이름입니다.
+        @JsonProperty("speaker_name") @NotBlank String speakerName,
+
+        // STT가 변환한 발화 텍스트입니다.
+        @NotBlank String text,
+
+        // Python 봇이 발화를 감지한 시각입니다.
+        @NotNull LocalDateTime timestamp) {}

--- a/src/main/java/com/flodiback/domain/speech/dto/InternalSpeechResponse.java
+++ b/src/main/java/com/flodiback/domain/speech/dto/InternalSpeechResponse.java
@@ -1,0 +1,10 @@
+package com.flodiback.domain.speech.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record InternalSpeechResponse(
+        // 저장된 발화 ID입니다.
+        @JsonProperty("utterance_id") Long utteranceId,
+
+        // 발화가 저장된 회의 ID입니다.
+        @JsonProperty("meeting_id") Long meetingId) {}

--- a/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
@@ -1,0 +1,46 @@
+package com.flodiback.domain.speech.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
+import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
+import com.flodiback.domain.speech.dto.InternalSpeechRequest;
+import com.flodiback.domain.speech.dto.InternalSpeechResponse;
+import com.flodiback.global.exception.ServiceException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InternalSpeechService {
+
+    private final MeetingRepository meetingRepository;
+    private final UtteranceRepository utteranceRepository;
+
+    @Transactional
+    public InternalSpeechResponse saveSpeech(InternalSpeechRequest request) {
+        // 발화는 반드시 기존 회의에 연결되어야 하므로 회의를 먼저 조회한다.
+        Meeting meeting = meetingRepository
+                .findById(request.meetingId())
+                .orElseThrow(() -> new ServiceException("404-1", "회의를 찾을 수 없습니다."));
+
+        // Python 봇이 넘긴 발화 시각을 spoken_at으로 저장한다.
+        Utterance utterance = Utterance.builder()
+                .meeting(meeting)
+                .speakerDiscordId(request.speakerDiscordId())
+                .speakerName(request.speakerName())
+                .content(request.text())
+                .spokenAt(request.timestamp())
+                .build();
+
+        Utterance savedUtterance = utteranceRepository.save(utterance);
+
+        // TODO: 호출어("AI야", "봇아", "클로드야") 감지 후 GLM AI Gateway 스트리밍 응답 흐름을 연결한다.
+        // 현재 1차 범위에서는 STT 발화 저장까지만 처리한다.
+
+        return new InternalSpeechResponse(savedUtterance.getId(), meeting.getId());
+    }
+}

--- a/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
@@ -27,7 +27,7 @@ public class InternalSpeechService {
                 .findById(request.meetingId())
                 .orElseThrow(() -> new ServiceException("404-1", "회의를 찾을 수 없습니다."));
 
-        // Python 봇이 넘긴 발화 시각을 spoken_at으로 저장한다.
+        // Discord 봇이 넘긴 발화 시각을 spoken_at으로 저장한다.
         Utterance utterance = Utterance.builder()
                 .meeting(meeting)
                 .speakerDiscordId(request.speakerDiscordId())

--- a/src/test/java/com/flodiback/api/speech/InternalSpeechControllerTest.java
+++ b/src/test/java/com/flodiback/api/speech/InternalSpeechControllerTest.java
@@ -1,0 +1,151 @@
+package com.flodiback.api.speech;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
+import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.global.enums.MeetingStatus;
+
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest(properties = {"spring.flyway.enabled=false", "spring.jpa.hibernate.ddl-auto=create-drop"})
+@AutoConfigureMockMvc
+@Transactional
+class InternalSpeechControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private UtteranceRepository utteranceRepository;
+
+    private Meeting meeting;
+
+    @BeforeEach
+    void setUp() {
+        // 발화 저장 테스트를 위해 최소 프로젝트와 회의를 먼저 만든다.
+        Project project = Project.builder()
+                .name("Flodi")
+                .description("Discord AI 회의 에이전트")
+                .techStack("Spring Boot")
+                .build();
+        entityManager.persist(project);
+
+        meeting = Meeting.builder()
+                .project(project)
+                .title("MVP 회의")
+                .status(MeetingStatus.IN_PROGRESS)
+                .build();
+        entityManager.persist(meeting);
+        entityManager.flush();
+    }
+
+    @Test
+    void receiveSpeech_savesUtteranceFromSnakeCaseRequest() throws Exception {
+        String requestBody = """
+                {
+                  "meeting_id": %d,
+                  "speaker_discord_id": "123456789",
+                  "speaker_name": "김철수",
+                  "text": "이번 스프린트 목표를 어떻게 잡을까요?",
+                  "timestamp": "2026-04-23T10:30:00"
+                }
+                """
+                .formatted(meeting.getId());
+
+        mockMvc.perform(post("/internal/v1/speech")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data.meeting_id").value(meeting.getId()));
+
+        Utterance savedUtterance = utteranceRepository.findAll().getFirst();
+        assertThat(savedUtterance.getMeeting().getId()).isEqualTo(meeting.getId());
+        assertThat(savedUtterance.getSpeakerDiscordId()).isEqualTo("123456789");
+        assertThat(savedUtterance.getSpeakerName()).isEqualTo("김철수");
+        assertThat(savedUtterance.getContent()).isEqualTo("이번 스프린트 목표를 어떻게 잡을까요?");
+        assertThat(savedUtterance.getSpokenAt()).isEqualTo(LocalDateTime.of(2026, 4, 23, 10, 30));
+    }
+
+    @Test
+    void receiveSpeech_returnsNotFound_whenMeetingDoesNotExist() throws Exception {
+        String requestBody = """
+                {
+                  "meeting_id": 999999,
+                  "speaker_discord_id": "123456789",
+                  "speaker_name": "김철수",
+                  "text": "회의가 없는 경우입니다.",
+                  "timestamp": "2026-04-23T10:30:00"
+                }
+                """;
+
+        mockMvc.perform(post("/internal/v1/speech")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404-1"));
+    }
+
+    @Test
+    void receiveSpeech_returnsBadRequest_whenRequiredTextIsBlank() throws Exception {
+        String requestBody = """
+                {
+                  "meeting_id": %d,
+                  "speaker_discord_id": "123456789",
+                  "speaker_name": "김철수",
+                  "text": "",
+                  "timestamp": "2026-04-23T10:30:00"
+                }
+                """
+                .formatted(meeting.getId());
+
+        mockMvc.perform(post("/internal/v1/speech")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultCode").value("400-1"));
+    }
+
+    @Test
+    void receiveSpeech_savesOnly_whenWakeWordIsIncludedForNow() throws Exception {
+        String requestBody = """
+                {
+                  "meeting_id": %d,
+                  "speaker_discord_id": "123456789",
+                  "speaker_name": "김철수",
+                  "text": "AI야, 인증 방식 뭐로 하기로 했지?",
+                  "timestamp": "2026-04-23T10:30:00"
+                }
+                """
+                .formatted(meeting.getId());
+
+        mockMvc.perform(post("/internal/v1/speech")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"));
+
+        assertThat(utteranceRepository.findAll()).hasSize(1);
+        assertThat(utteranceRepository.findAll().getFirst().getContent()).isEqualTo("AI야, 인증 방식 뭐로 하기로 했지?");
+    }
+}

--- a/src/test/java/com/flodiback/api/speech/InternalSpeechControllerTest.java
+++ b/src/test/java/com/flodiback/api/speech/InternalSpeechControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,8 +70,7 @@ class InternalSpeechControllerTest {
                   "text": "이번 스프린트 목표를 어떻게 잡을까요?",
                   "timestamp": "2026-04-23T10:30:00"
                 }
-                """
-                .formatted(meeting.getId());
+                """.formatted(meeting.getId());
 
         mockMvc.perform(post("/internal/v1/speech")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -79,7 +79,10 @@ class InternalSpeechControllerTest {
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
                 .andExpect(jsonPath("$.data.meeting_id").value(meeting.getId()));
 
-        Utterance savedUtterance = utteranceRepository.findAll().getFirst();
+        List<Utterance> utterances = utteranceRepository.findAll();
+        assertThat(utterances).hasSize(1);
+
+        Utterance savedUtterance = utterances.get(0);
         assertThat(savedUtterance.getMeeting().getId()).isEqualTo(meeting.getId());
         assertThat(savedUtterance.getSpeakerDiscordId()).isEqualTo("123456789");
         assertThat(savedUtterance.getSpeakerName()).isEqualTo("김철수");
@@ -116,8 +119,7 @@ class InternalSpeechControllerTest {
                   "text": "",
                   "timestamp": "2026-04-23T10:30:00"
                 }
-                """
-                .formatted(meeting.getId());
+                """.formatted(meeting.getId());
 
         mockMvc.perform(post("/internal/v1/speech")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -136,8 +138,7 @@ class InternalSpeechControllerTest {
                   "text": "AI야, 인증 방식 뭐로 하기로 했지?",
                   "timestamp": "2026-04-23T10:30:00"
                 }
-                """
-                .formatted(meeting.getId());
+                """.formatted(meeting.getId());
 
         mockMvc.perform(post("/internal/v1/speech")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -145,7 +146,8 @@ class InternalSpeechControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"));
 
-        assertThat(utteranceRepository.findAll()).hasSize(1);
-        assertThat(utteranceRepository.findAll().getFirst().getContent()).isEqualTo("AI야, 인증 방식 뭐로 하기로 했지?");
+        List<Utterance> utterances = utteranceRepository.findAll();
+        assertThat(utterances).hasSize(1);
+        assertThat(utterances.get(0).getContent()).isEqualTo("AI야, 인증 방식 뭐로 하기로 했지?");
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #10 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #10 

---

<html>
<body>
<!--StartFragment-->
<h1>STT 발화 수신 Internal API 구현</h1>

<h3>개념</h3>
<pre><code class="language-java">Discord Bot / Python STT 파이프라인
       ↓
POST /internal/v1/speech
       ↓
서버 InternalSpeechController 수신
       ↓
InternalSpeechService에서 meetingId 기준 회의 조회
       ↓
Utterance 엔티티로 발화 저장
       ↓
저장된 utteranceId, meetingId 반환

Python Bot → Backend → DB 저장 단방향 흐름
</code></pre>

<h3>이번 커밋 요약</h3>
<ul>
  <li>STT 결과를 백엔드로 전달받는 internal API를 추가했다.</li>
  <li>클라이언트 요청은 snake_case JSON을 받도록 DTO에 <code>@JsonProperty</code>를 적용했다.</li>
  <li>수신한 발화를 기존 <code>Meeting</code>에 연결된 <code>Utterance</code>로 저장한다.</li>
  <li>발화 시각은 서버 생성 시간이 아니라 Python Bot이 전달한 <code>timestamp</code>를 저장하도록 변경했다.</li>
  <li>API 레이어는 <code>com.flodiback.api.speech</code>에 두어 HTTP 진입점과 도메인 로직 경계를 분리했다.</li>
</ul>

<h3>추가/변경 파일</h3>
<ul>
  <li><code>InternalSpeechController.java</code> - <code>POST /internal/v1/speech</code> 엔드포인트</li>
  <li><code>InternalSpeechService.java</code> - 회의 조회 후 발화 저장 처리</li>
  <li><code>InternalSpeechRequest.java</code> - STT 발화 수신 요청 DTO</li>
  <li><code>InternalSpeechResponse.java</code> - 저장 결과 응답 DTO</li>
  <li><code>UtteranceRepository.java</code> - 발화 저장용 JPA Repository</li>
  <li><code>Utterance.java</code> - <code>spokenAt</code>을 외부 전달 시각으로 저장하도록 변경</li>
  <li><code>InternalSpeechControllerTest.java</code> - 발화 수신 API 통합 테스트 추가</li>
</ul>

<h3>API 계약</h3>
<pre><code class="language-java">POST /internal/v1/speech

Request:
{
  "meeting_id": 1,
  "speaker_discord_id": "123456789",
  "speaker_name": "김철수",
  "text": "이번 회의 목표를 정해봅시다.",
  "timestamp": "2026-04-23T10:30:00"
}

Response:
{
  "resultCode": "200-1",
  "msg": "발화가 저장되었습니다.",
  "data": {
    "utterance_id": 1,
    "meeting_id": 1
  }
}
</code></pre>

<h3>전체 흐름</h3>
<pre><code class="language-java">[Python Bot - STT 완료]
POST /internal/v1/speech 전송
{
  "meeting_id": 1,
  "speaker_discord_id": "123456789",
  "speaker_name": "김철수",
  "text": "회의 시작하겠습니다.",
  "timestamp": "2026-04-23T10:30:00"
}
          ↓
[InternalSpeechController.receiveSpeech()]
  @Valid로 필수값 검증
  InternalSpeechService.saveSpeech() 호출
          ↓
[InternalSpeechService.saveSpeech()]
  meetingId로 Meeting 조회
  존재하지 않으면 ServiceException("404-1") 발생
          ↓
[Utterance 저장]
  meeting, speakerDiscordId, speakerName, content, spokenAt 저장
          ↓
[응답 반환]
  저장된 utteranceId와 meetingId 반환
</code></pre>

<h3>발화 시간 처리</h3>
<ul>
  <li>기존 <code>Utterance.spokenAt</code>은 <code>@CreationTimestamp</code>로 서버 저장 시각이 들어갔다.</li>
  <li>이번 변경에서는 STT가 실제로 감지한 발화 시각을 저장해야 하므로 요청의 <code>timestamp</code>를 <code>spokenAt</code>에 넣는다.</li>
  <li>빌더 호출 시 <code>spokenAt</code>이 null이면 안전하게 <code>LocalDateTime.now()</code>를 기본값으로 사용한다.</li>
</ul>

<h3>예외 및 검증</h3>
<ul>
  <li><code>meeting_id</code>, <code>timestamp</code>는 <code>@NotNull</code>로 검증한다.</li>
  <li><code>speaker_discord_id</code>, <code>speaker_name</code>, <code>text</code>는 <code>@NotBlank</code>로 검증한다.</li>
  <li>존재하지 않는 회의 ID가 들어오면 <code>404-1</code> 응답을 반환한다.</li>
  <li>필수 문자열이 비어 있으면 공통 예외 처리 흐름을 통해 <code>400-1</code> 응답을 반환한다.</li>
</ul>

<h3>테스트</h3>
<ul>
  <li>snake_case 요청이 정상적으로 역직렬화되고 발화가 저장되는지 검증했다.</li>
  <li>저장된 <code>Utterance</code>가 올바른 <code>Meeting</code>에 연결되는지 검증했다.</li>
  <li>없는 회의 ID 요청 시 <code>404-1</code>이 반환되는지 검증했다.</li>
  <li><code>text</code>가 빈 값이면 <code>400-1</code>이 반환되는지 검증했다.</li>
  <li>현재 MVP 범위에서는 호출어 포함 여부와 관계없이 STT 발화 저장까지만 처리한다.</li>
</ul>

<h3>현재 MVP 범위</h3>
<ul>
  <li>이번 PR은 STT 발화를 DB에 저장하는 1차 수신 파이프라인까지 구현한다.</li>
  <li>호출어 감지, GLM AI Gateway 연동, 스트리밍 응답 연결은 후속 작업으로 남겨두었다.</li>
</ul>
<!--EndFragment-->
</body>
</html>

