### PR TITLE
[feat] endMeeting, getMeeting 구현

### DIFF
--- a/src/main/java/com/flodiback/domain/meeting/meeting/entity/Meeting.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/entity/Meeting.java
@@ -47,4 +47,9 @@ public class Meeting {
         this.title = title;
         this.status = status != null ? status : MeetingStatus.IN_PROGRESS;
     }
+
+    public void end() {
+        this.status = MeetingStatus.COMPLETED;
+        this.endedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -1,11 +1,16 @@
 package com.flodiback.domain.meeting.meeting.service;
 
+import java.util.NoSuchElementException;
+
 import org.springframework.stereotype.Service;
 
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
 import com.flodiback.domain.meeting.meeting.dto.MeetingDetailResponse;
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,16 +19,51 @@ import lombok.RequiredArgsConstructor;
 public class MeetingService {
 
     private final MeetingRepository meetingRepository;
+    private final ProjectRepository projectRepository;
 
     public CreateMeetingResponse create(CreateMeetingRequest req) {
-        throw new UnsupportedOperationException("TODO");
+        Project project = null;
+        if (req.projectId() != null) {
+            project = projectRepository
+                    .findById(req.projectId())
+                    .orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        }
+
+        Meeting meeting = Meeting.builder().project(project).title(req.title()).build();
+        meetingRepository.save(meeting);
+
+        return new CreateMeetingResponse(
+                meeting.getId(),
+                project != null ? project.getId() : null,
+                meeting.getTitle(),
+                meeting.getStartedAt(),
+                meeting.getStatus());
     }
 
     public MeetingDetailResponse end(Long id) {
-        throw new UnsupportedOperationException("TODO");
+        Meeting meeting =
+                meetingRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회의입니다."));
+
+        meeting.end();
+        meetingRepository.save(meeting);
+
+        return toDetailResponse(meeting);
     }
 
     public MeetingDetailResponse getById(Long id) {
-        throw new UnsupportedOperationException("TODO");
+        Meeting meeting =
+                meetingRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회의입니다."));
+
+        return toDetailResponse(meeting);
+    }
+
+    private MeetingDetailResponse toDetailResponse(Meeting meeting) {
+        return new MeetingDetailResponse(
+                meeting.getId(),
+                meeting.getProject() != null ? meeting.getProject().getId() : null,
+                meeting.getTitle(),
+                meeting.getStartedAt(),
+                meeting.getEndedAt(),
+                meeting.getStatus());
     }
 }

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -3,6 +3,7 @@ package com.flodiback.domain.meeting.meeting.service;
 import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MeetingService {
 
     private final MeetingRepository meetingRepository;
@@ -50,6 +52,7 @@ public class MeetingService {
         return toDetailResponse(meeting);
     }
 
+    @Transactional(readOnly = true)
     public MeetingDetailResponse getById(Long id) {
         Meeting meeting =
                 meetingRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회의입니다."));

--- a/src/main/java/com/flodiback/domain/project/project/repository/ProjectRepository.java
+++ b/src/main/java/com/flodiback/domain/project/project/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package com.flodiback.domain.project.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flodiback.domain.project.project.entity.Project;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {}

--- a/src/test/java/com/flodiback/domain/meeting/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meeting/service/MeetingServiceTest.java
@@ -1,0 +1,164 @@
+package com.flodiback.domain.meeting.meeting.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
+import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
+import com.flodiback.domain.meeting.meeting.dto.MeetingDetailResponse;
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.global.enums.MeetingStatus;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingServiceTest {
+
+    @InjectMocks
+    private MeetingService meetingService;
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    // ─── create ───────────────────────────────────────────
+
+    @Test
+    void create_projectId없으면_project_null로_미팅생성() {
+        // given
+        CreateMeetingRequest req = new CreateMeetingRequest(null, "테스트 회의");
+        given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        CreateMeetingResponse response = meetingService.create(req);
+
+        // then
+        verify(projectRepository, never()).findById(any());
+        verify(meetingRepository).save(any(Meeting.class));
+        assertThat(response.projectId()).isNull();
+        assertThat(response.title()).isEqualTo("테스트 회의");
+        assertThat(response.status()).isEqualTo(MeetingStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void create_유효한_projectId면_미팅생성() {
+        // given
+        Project project = Project.builder().name("테스트 프로젝트").build();
+        CreateMeetingRequest req = new CreateMeetingRequest(1L, "테스트 회의");
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        CreateMeetingResponse response = meetingService.create(req);
+
+        // then
+        verify(projectRepository).findById(1L);
+        verify(meetingRepository).save(any(Meeting.class));
+        assertThat(response.title()).isEqualTo("테스트 회의");
+        assertThat(response.status()).isEqualTo(MeetingStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void create_존재하지않는_projectId면_예외발생() {
+        // given
+        CreateMeetingRequest req = new CreateMeetingRequest(999L, "테스트 회의");
+        given(projectRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> meetingService.create(req))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 프로젝트입니다.");
+
+        verify(meetingRepository, never()).save(any());
+    }
+
+    // ─── end ──────────────────────────────────────────────
+
+    @Test
+    void end_유효한_id면_회의종료() {
+        // given
+        Meeting meeting = Meeting.builder().title("테스트 회의").build();
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        MeetingDetailResponse response = meetingService.end(1L);
+
+        // then
+        verify(meetingRepository).save(meeting);
+        assertThat(response.status()).isEqualTo(MeetingStatus.COMPLETED);
+        assertThat(response.endedAt()).isNotNull();
+    }
+
+    @Test
+    void end_이미_종료된_회의도_덮어쓰기() {
+        // given
+        Meeting meeting = Meeting.builder().title("테스트 회의").build();
+        meeting.end(); // 미리 종료
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        MeetingDetailResponse response = meetingService.end(1L);
+
+        // then
+        verify(meetingRepository).save(meeting);
+        assertThat(response.status()).isEqualTo(MeetingStatus.COMPLETED);
+    }
+
+    @Test
+    void end_존재하지않는_id면_예외발생() {
+        // given
+        given(meetingRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> meetingService.end(999L))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 회의입니다.");
+
+        verify(meetingRepository, never()).save(any());
+    }
+
+    // ─── getById ──────────────────────────────────────────
+
+    @Test
+    void getById_유효한_id면_회의반환() {
+        // given
+        Meeting meeting = Meeting.builder().title("테스트 회의").build();
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+
+        // when
+        MeetingDetailResponse response = meetingService.getById(1L);
+
+        // then
+        assertThat(response.title()).isEqualTo("테스트 회의");
+        assertThat(response.status()).isEqualTo(MeetingStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void getById_존재하지않는_id면_예외발생() {
+        // given
+        given(meetingRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> meetingService.getById(999L))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 회의입니다.");
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #7 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #7 

---

**📝 작업 내용**

endMeeting, getMeeting 비즈니스 로직을 구현했습니다.

endMeeting은 이미 종료된 회의도 덮어쓰기 허용(멱등성 없음)하는 방향으로 결정했으며, Meeting 엔티티에 도메인

메서드 end()를 추가해 상태 변경을 캡슐화했습니다.

---

**✅ 주요 변경 사항**

1. Meeting.end() 도메인 메서드 추가 — status = COMPLETED, endedAt = now() 설정

2. MeetingService.end() 구현 — 존재하지 않는 id 시 NoSuchElementException, 이미 종료된 회의도 덮어쓰기 허용

3. MeetingService.getById() 구현 — 존재하지 않는 id 시 NoSuchElementException

4. ProjectRepository 추가 — JpaRepository<Project, Long> 상속

---

**🧪 테스트 결과**

./gradlew cleanTest test

# BUILD SUCCESSFUL

- 로컬 테스트 통과

- 관련 시나리오 수동 확인

---

**👀 리뷰 포인트 (선택)**

- end() 호출 시 이미 COMPLETED 상태인 회의도 덮어쓰기 허용 — 의도된 설계이나 추후 요구사항 변경 시 검증 로직

추가 필요

- toDetailResponse() 헬퍼 메서드로 end(), getById() 응답 변환 공통화

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
