### PR TITLE
[feat] ResponseAspect 도입으로 RsData 기반 HTTP 상태코드 자동 설정, ResponseEntity 제거

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,7 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
     implementation("com.pgvector:pgvector:0.1.6")

--- a/src/main/java/com/flodiback/api/meeting/MeetingController.java
+++ b/src/main/java/com/flodiback/api/meeting/MeetingController.java
@@ -1,7 +1,5 @@
 package com.flodiback.api.meeting;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
@@ -20,20 +18,17 @@ public class MeetingController {
     private final MeetingService service;
 
     @PostMapping
-    public ResponseEntity<RsData<CreateMeetingResponse>> createMeeting(@RequestBody CreateMeetingRequest req) {
-        CreateMeetingResponse response = service.create(req);
-        return ResponseEntity.status(HttpStatus.CREATED).body(RsData.of("201-1", "회의가 생성되었습니다.", response));
+    public RsData<CreateMeetingResponse> createMeeting(@RequestBody CreateMeetingRequest req) {
+        return RsData.of("201-1", "회의가 생성되었습니다.", service.create(req));
     }
 
     @PutMapping("/{id}/end")
-    public ResponseEntity<RsData<MeetingDetailResponse>> endMeeting(@PathVariable Long id) {
-        MeetingDetailResponse response = service.end(id);
-        return ResponseEntity.ok(RsData.of("200-1", "회의가 종료되었습니다.", response));
+    public RsData<MeetingDetailResponse> endMeeting(@PathVariable Long id) {
+        return RsData.of("200-1", "회의가 종료되었습니다.", service.end(id));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<RsData<MeetingDetailResponse>> getMeeting(@PathVariable Long id) {
-        MeetingDetailResponse response = service.getById(id);
-        return ResponseEntity.ok(RsData.of("200-1", "회의 조회 성공.", response));
+    public RsData<MeetingDetailResponse> getMeeting(@PathVariable Long id) {
+        return RsData.of("200-1", "회의 조회 성공.", service.getById(id));
     }
 }

--- a/src/main/java/com/flodiback/global/aspect/ResponseAspect.java
+++ b/src/main/java/com/flodiback/global/aspect/ResponseAspect.java
@@ -1,0 +1,36 @@
+package com.flodiback.global.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import com.flodiback.global.rsData.RsData;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ResponseAspect {
+
+    private final HttpServletResponse response;
+
+    @Around("execution(public com.flodiback.global.rsData.RsData *(..)) && "
+            + "(within(@org.springframework.stereotype.Controller *) || within(@org.springframework.web.bind.annotation.RestController *)) && "
+            + "(@annotation(org.springframework.web.bind.annotation.GetMapping) || "
+            + "@annotation(org.springframework.web.bind.annotation.PostMapping) || "
+            + "@annotation(org.springframework.web.bind.annotation.PutMapping) || "
+            + "@annotation(org.springframework.web.bind.annotation.DeleteMapping) || "
+            + "@annotation(org.springframework.web.bind.annotation.RequestMapping))")
+    public Object handleResponse(ProceedingJoinPoint pjp) throws Throwable {
+        Object result = pjp.proceed();
+
+        if (result instanceof RsData<?> rsData) {
+            response.setStatus(rsData.statusCode());
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #16 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #16

---

**📝 작업 내용**

ResponseAspect를 도입해 Controller에서 ResponseEntity 없이 RsData만 반환해도 HTTP 상태코드가 자동으로

설정되도록 개선했습니다.

---

**✅ 주요 변경 사항**

1. ResponseAspect 추가 — RsData.statusCode()를 읽어 HTTP 상태코드 자동 세팅

2. MeetingController 수정 — ResponseEntity<RsData<T>> → RsData<T> 로 변경해 중복 제거

3. build.gradle.kts — spring-boot-starter-aop 의존성 추가

---

**🧪 테스트 결과**

./gradlew clean test

BUILD SUCCESSFUL

- 로컬 테스트 통과

- 관련 시나리오 수동 확인

---

**👀 리뷰 포인트 (선택)**

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
