### PR TITLE
[Feat] 회의 후 정리 로직 스켈레톤 구현 및 glm관련 설정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ DB_USERNAME=flodiback
 DB_PASSWORD=flodiback
 DISCORD_TOKEN=your_discord_bot_token
 DISCORD_BOT_PREFIX=!
+GLM_API_KEY=your_glm_api_key
+GLM_MODEL=glm-5.1

--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ DISCORD_TOKEN=your_discord_bot_token
 DISCORD_BOT_PREFIX=!
 GLM_API_KEY=your_glm_api_key
 GLM_MODEL=glm-5.1
+GLM_API_URL=grepp_url

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
       GLM_MODEL: ${{ secrets.GLM_MODEL }}
+      GLM_API_URL: ${{ secrets.GLM_API_URL }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
+    env:
+      GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
+      GLM_MODEL: ${{ secrets.GLM_MODEL }}
+
     steps:
       - uses: actions/checkout@v4
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-aop")
-    implementation("ai.z.openapi:zai-sdk:0.3.3")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
     implementation("com.pgvector:pgvector:0.1.6")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-aop")
+    implementation("com.openai:openai-java:2.20.1")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
     implementation("com.pgvector:pgvector:0.1.6")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-aop")
+    implementation("ai.z.openapi:zai-sdk:0.3.3")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-database-postgresql")
     implementation("com.pgvector:pgvector:0.1.6")

--- a/src/main/java/com/flodiback/domain/decision/decision/repository/DecisionRepository.java
+++ b/src/main/java/com/flodiback/domain/decision/decision/repository/DecisionRepository.java
@@ -10,6 +10,7 @@ import com.flodiback.domain.decision.decision.entity.Decision;
 public interface DecisionRepository extends JpaRepository<Decision, Long> {
 
     List<Decision> findByProjectId(Long projectId);
+
     List<Decision> findByProjectIdOrderByIdAsc(Long projectId);
 
     Optional<Decision> findByIdAndProjectId(Long id, Long projectId);

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/AnalysisResult.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/AnalysisResult.java
@@ -2,13 +2,5 @@ package com.flodiback.domain.meeting.analysis.dto;
 
 import java.util.List;
 
-/**
- * LLM 응답을 파싱한 회의 분석 결과입니다.
- *
- * @param summary          전체 회의 요약
- * @param unresolvedItems  미결 사항 (없으면 null)
- * @param worklogs         추출된 워크로그 목록
- * @param decisions        추출된 결정사항 목록
- */
 public record AnalysisResult(
         String summary, String unresolvedItems, List<WorkLogItem> worklogs, List<DecisionItem> decisions) {}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/AnalysisResult.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/AnalysisResult.java
@@ -1,0 +1,14 @@
+package com.flodiback.domain.meeting.analysis.dto;
+
+import java.util.List;
+
+/**
+ * LLM 응답을 파싱한 회의 분석 결과입니다.
+ *
+ * @param summary          전체 회의 요약
+ * @param unresolvedItems  미결 사항 (없으면 null)
+ * @param worklogs         추출된 워크로그 목록
+ * @param decisions        추출된 결정사항 목록
+ */
+public record AnalysisResult(
+        String summary, String unresolvedItems, List<WorkLogItem> worklogs, List<DecisionItem> decisions) {}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/DecisionItem.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/DecisionItem.java
@@ -1,8 +1,3 @@
 package com.flodiback.domain.meeting.analysis.dto;
 
-/**
- * LLM이 추출한 결정사항 항목입니다.
- *
- * @param content 결정 내용
- */
 public record DecisionItem(String content) {}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/DecisionItem.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/DecisionItem.java
@@ -1,0 +1,8 @@
+package com.flodiback.domain.meeting.analysis.dto;
+
+/**
+ * LLM이 추출한 결정사항 항목입니다.
+ *
+ * @param content 결정 내용
+ */
+public record DecisionItem(String content) {}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/WorkLogItem.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/WorkLogItem.java
@@ -1,0 +1,10 @@
+package com.flodiback.domain.meeting.analysis.dto;
+
+/**
+ * LLM이 추출한 워크로그 항목입니다.
+ *
+ * @param assigneeName 담당자 이름
+ * @param task         작업 내용
+ * @param dueDate      마감일 (YYYY-MM-DD 형식, 없으면 null)
+ */
+public record WorkLogItem(String assigneeName, String task, String dueDate) {}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/WorkLogItem.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/WorkLogItem.java
@@ -1,10 +1,3 @@
 package com.flodiback.domain.meeting.analysis.dto;
 
-/**
- * LLM이 추출한 워크로그 항목입니다.
- *
- * @param assigneeName 담당자 이름
- * @param task         작업 내용
- * @param dueDate      마감일 (YYYY-MM-DD 형식, 없으면 null)
- */
 public record WorkLogItem(String assigneeName, String task, String dueDate) {}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
@@ -76,9 +76,6 @@ public class MeetingAnalysisService {
         // result.decisions().forEach(item -> ...);
     }
 
-    /**
-     * context_cache(압축본) + utterances(원문) 를 하나의 문자열로 조합합니다.
-     */
     private String buildContext(Meeting meeting) {
         List<ContextCache> caches = contextCacheRepository.findByMeetingOrderByCreatedAtAsc(meeting);
         List<Utterance> utterances = utteranceRepository.findByMeetingOrderBySpokenAtAsc(meeting);
@@ -97,9 +94,6 @@ public class MeetingAnalysisService {
         return sb.toString();
     }
 
-    /**
-     * GLM을 호출하고 응답을 AnalysisResult로 파싱합니다.
-     */
     private AnalysisResult callGlm(String context) {
         String raw = glmClient.chat(SYSTEM_PROMPT, context);
 

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
@@ -1,0 +1,118 @@
+package com.flodiback.domain.meeting.analysis.service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flodiback.domain.meeting.analysis.dto.AnalysisResult;
+import com.flodiback.domain.meeting.meeting.entity.ContextCache;
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.ContextCacheRepository;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.meeting.meetinglog.entity.MeetingSummary;
+import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
+import com.flodiback.domain.meeting.meetinglog.repository.MeetingSummaryRepository;
+import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
+import com.flodiback.global.client.GlmClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MeetingAnalysisService {
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 회의 내용을 분석하는 어시스턴트입니다.
+            아래 회의 내용을 분석해서 반드시 다음 JSON 형식으로만 응답하세요.
+            마크다운 코드블록 없이 순수 JSON만 반환하세요.
+            {
+              "summary": "전체 회의 요약",
+              "unresolvedItems": "미결 사항 (없으면 null)",
+              "worklogs": [
+                { "assigneeName": "담당자 이름", "task": "작업 내용", "dueDate": "YYYY-MM-DD 또는 null" }
+              ],
+              "decisions": [
+                { "content": "결정 내용" }
+              ]
+            }
+            """;
+
+    private final MeetingRepository meetingRepository;
+    private final ContextCacheRepository contextCacheRepository;
+    private final UtteranceRepository utteranceRepository;
+    private final MeetingSummaryRepository meetingSummaryRepository;
+    private final GlmClient glmClient;
+    private final ObjectMapper objectMapper;
+
+    public void analyze(Long meetingId) {
+        // 1. 회의 조회
+        Meeting meeting =
+                meetingRepository.findById(meetingId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회의입니다."));
+
+        // 2. 컨텍스트 구성
+        String context = buildContext(meeting);
+
+        // 3. GLM 호출 및 응답 파싱
+        AnalysisResult result = callGlm(context);
+
+        // 4. MeetingSummary 저장
+        MeetingSummary summary = MeetingSummary.builder()
+                .meeting(meeting)
+                .summary(result.summary())
+                .unresolvedItems(result.unresolvedItems())
+                .build();
+        meetingSummaryRepository.save(summary);
+
+        // 5. WorkLog 저장 (스켈레톤)
+        // TODO: WorkLogService 구현 후 연동
+        // result.worklogs().forEach(item -> ...);
+
+        // 6. Decision 저장 (스켈레톤)
+        // TODO: DecisionService 구현 후 연동 (embedding 포함)
+        // result.decisions().forEach(item -> ...);
+    }
+
+    /**
+     * context_cache(압축본) + utterances(원문) 를 하나의 문자열로 조합합니다.
+     */
+    private String buildContext(Meeting meeting) {
+        List<ContextCache> caches = contextCacheRepository.findByMeetingOrderByCreatedAtAsc(meeting);
+        List<Utterance> utterances = utteranceRepository.findByMeetingOrderBySpokenAtAsc(meeting);
+
+        StringBuilder sb = new StringBuilder();
+
+        if (!caches.isEmpty()) {
+            sb.append("[이전 대화 요약]\n");
+            caches.forEach(cache -> sb.append(cache.getCompressedText()).append("\n"));
+            sb.append("\n");
+        }
+
+        sb.append("[회의 대화 내용]\n");
+        utterances.forEach(u -> sb.append(String.format("%s: %s\n", u.getSpeakerName(), u.getContent())));
+
+        return sb.toString();
+    }
+
+    /**
+     * GLM을 호출하고 응답을 AnalysisResult로 파싱합니다.
+     */
+    private AnalysisResult callGlm(String context) {
+        String raw = glmClient.chat(SYSTEM_PROMPT, context);
+
+        // GLM이 마크다운 코드블록으로 감쌀 경우 제거
+        String json = raw.strip()
+                .replaceAll("^```json\\s*", "")
+                .replaceAll("^```\\s*", "")
+                .replaceAll("\\s*```$", "");
+
+        try {
+            return objectMapper.readValue(json, AnalysisResult.class);
+        } catch (Exception e) {
+            throw new RuntimeException("GLM 응답 파싱 실패: " + raw, e);
+        }
+    }
+}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/repository/ContextCacheRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/repository/ContextCacheRepository.java
@@ -1,0 +1,13 @@
+package com.flodiback.domain.meeting.meeting.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flodiback.domain.meeting.meeting.entity.ContextCache;
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+
+public interface ContextCacheRepository extends JpaRepository<ContextCache, Long> {
+
+    List<ContextCache> findByMeetingOrderByCreatedAtAsc(Meeting meeting);
+}

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
@@ -4,9 +4,12 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
 
 public interface UtteranceRepository extends JpaRepository<Utterance, Long> {
 
     List<Utterance> findTop20ByMeetingIdOrderBySpokenAtDesc(Long meetingId);
+
+    List<Utterance> findByMeetingOrderBySpokenAtAsc(Meeting meeting);
 }

--- a/src/main/java/com/flodiback/global/client/GlmClient.java
+++ b/src/main/java/com/flodiback/global/client/GlmClient.java
@@ -1,14 +1,12 @@
 package com.flodiback.global.client;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClient;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
 
 /**
  * GLM(Z.AI) API 호출을 담당하는 공용 클라이언트입니다.
@@ -19,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * <pre>
  * glm.api.key=발급받은_API_KEY
  * glm.api.model=glm-5.1
- * glm.api.url=https://api.z.ai/api  # 기본값, 변경 불필요
+ * glm.api.url=https://...  # grepp 게이트웨이 base URL
  * </pre>
  *
  * <h3>사용 예시</h3>
@@ -43,7 +41,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @Component
 public class GlmClient {
 
-    private final RestClient restClient;
+    private final OpenAIClient client;
     private final String model;
 
     public GlmClient(
@@ -51,14 +49,9 @@ public class GlmClient {
             @Value("${glm.api.model}") String model,
             @Value("${glm.api.url}") String apiUrl) {
         this.model = model;
-        this.restClient = RestClient.builder()
-                .baseUrl(apiUrl)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .build();
+        this.client =
+                OpenAIOkHttpClient.builder().apiKey(apiKey).baseUrl(apiUrl).build();
     }
-
-    // ── Chat Completion ──────────────────────────────────────────────────────
 
     /**
      * GLM에 system/user 메시지를 전송하고 응답 텍스트를 반환합니다.
@@ -72,62 +65,14 @@ public class GlmClient {
      * 파싱 전에 코드블록 제거 처리를 권장합니다.
      */
     public String chat(String systemPrompt, String userPrompt) {
-        ChatRequest request = new ChatRequest(
-                model, List.of(new ChatMessage("system", systemPrompt), new ChatMessage("user", userPrompt)), false);
+        ChatCompletionCreateParams params = ChatCompletionCreateParams.builder()
+                .addSystemMessage(systemPrompt)
+                .addUserMessage(userPrompt)
+                .model(model)
+                .build();
 
-        ChatResponse response = restClient
-                .post()
-                .uri("/paas/v4/chat/completions")
-                .body(request)
-                .retrieve()
-                .body(ChatResponse.class);
+        ChatCompletion completion = client.chat().completions().create(params);
 
-        return response.choices().get(0).message().content();
+        return completion.choices().get(0).message().content().orElse("");
     }
-
-    // ── Agent Chat ───────────────────────────────────────────────────────────
-
-    /**
-     * Agent Chat API를 호출하고 어시스턴트 응답 텍스트를 반환합니다.
-     *
-     * <p>Agent Chat은 Z.AI 플랫폼에 미리 구성된 에이전트를 호출합니다.
-     * 에이전트 ID는 Z.AI 콘솔에서 확인할 수 있습니다.
-     *
-     * @param agentId     호출할 에이전트 ID (예: "general_translation")
-     * @param userMessage 사용자 입력 메시지
-     * @return 에이전트가 생성한 응답 텍스트
-     */
-    public String agentChat(String agentId, String userMessage) {
-        AgentRequest request = new AgentRequest(
-                agentId, List.of(new AgentMessage("user", List.of(new AgentContent("text", userMessage)))), false);
-
-        AgentResponse response =
-                restClient.post().uri("/v1/agents").body(request).retrieve().body(AgentResponse.class);
-
-        List<AgentMessage> messages = response.choices().get(0).messages();
-        return messages.get(messages.size() - 1).content().toString();
-    }
-
-    // ── Chat Completion 요청/응답 ─────────────────────────────────────────────
-
-    private record ChatRequest(String model, List<ChatMessage> messages, boolean stream) {}
-
-    private record ChatMessage(String role, String content) {}
-
-    private record ChatResponse(List<ChatChoice> choices) {}
-
-    private record ChatChoice(ChatMessage message) {}
-
-    // ── Agent Chat 요청/응답 ──────────────────────────────────────────────────
-
-    private record AgentRequest(
-            @JsonProperty("agent_id") String agentId, List<AgentMessage> messages, boolean stream) {}
-
-    private record AgentMessage(String role, Object content) {}
-
-    private record AgentContent(String type, String text) {}
-
-    private record AgentResponse(List<AgentChoice> choices) {}
-
-    private record AgentChoice(List<AgentMessage> messages) {}
 }

--- a/src/main/java/com/flodiback/global/client/GlmClient.java
+++ b/src/main/java/com/flodiback/global/client/GlmClient.java
@@ -6,6 +6,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import ai.z.openapi.ZaiClient;
+import ai.z.openapi.service.agents.AgentContent;
+import ai.z.openapi.service.agents.AgentMessage;
+import ai.z.openapi.service.agents.AgentsCompletionRequest;
 import ai.z.openapi.service.model.ChatCompletionCreateParams;
 import ai.z.openapi.service.model.ChatMessage;
 import ai.z.openapi.service.model.ChatMessageRole;
@@ -91,5 +94,37 @@ public class GlmClient {
                 .getMessage()
                 .getContent()
                 .toString();
+    }
+
+    /**
+     * Agent Chat API를 호출하고 어시스턴트 응답 텍스트를 반환합니다.
+     *
+     * <p>Agent Chat은 Z.AI 플랫폼에 미리 구성된 에이전트를 호출합니다.
+     * 에이전트 ID는 Z.AI 콘솔에서 확인할 수 있습니다.
+     *
+     * @param agentId     호출할 에이전트 ID (예: "general_translation")
+     * @param userMessage 사용자 입력 메시지
+     * @return 에이전트가 생성한 응답 텍스트
+     * @throws RuntimeException Agent API 호출 실패 시
+     */
+    public String agentChat(String agentId, String userMessage) {
+        AgentsCompletionRequest request = AgentsCompletionRequest.builder()
+                .agentId(agentId)
+                .messages(List.of(AgentMessage.builder()
+                        .role(ChatMessageRole.USER.value())
+                        .content(List.of(AgentContent.ofText(userMessage)))
+                        .build()))
+                .stream(false)
+                .build();
+
+        List<AgentMessage> messages = zaiClient
+                .agents()
+                .createAgentCompletion(request)
+                .getData()
+                .getChoices()
+                .get(0)
+                .getMessages();
+
+        return messages.get(messages.size() - 1).getContent().toString();
     }
 }

--- a/src/main/java/com/flodiback/global/client/GlmClient.java
+++ b/src/main/java/com/flodiback/global/client/GlmClient.java
@@ -73,6 +73,10 @@ public class GlmClient {
 
         ChatCompletion completion = client.chat().completions().create(params);
 
+        if (completion.choices().isEmpty()) {
+            throw new IllegalStateException("GLM 응답에 choices가 없습니다.");
+        }
+
         return completion.choices().get(0).message().content().orElse("");
     }
 }

--- a/src/main/java/com/flodiback/global/client/GlmClient.java
+++ b/src/main/java/com/flodiback/global/client/GlmClient.java
@@ -1,0 +1,95 @@
+package com.flodiback.global.client;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import ai.z.openapi.ZaiClient;
+import ai.z.openapi.service.model.ChatCompletionCreateParams;
+import ai.z.openapi.service.model.ChatMessage;
+import ai.z.openapi.service.model.ChatMessageRole;
+
+/**
+ * GLM(Z.AI) API 호출을 담당하는 공용 클라이언트입니다.
+ *
+ * <p>팀 내 어느 도메인에서든 GLM을 호출할 때 이 클래스를 주입받아 사용하세요.
+ * 직접 ZaiClient를 사용하지 않도록 합니다.
+ *
+ * <h3>설정 (application.yml)</h3>
+ * <pre>
+ * glm.api.key=발급받은_API_KEY
+ * glm.api.model=glm-5.1
+ * </pre>
+ *
+ * <h3>사용 예시</h3>
+ * <pre>
+ * {@code
+ * @Service
+ * @RequiredArgsConstructor
+ * public class MyService {
+ *
+ *     private final GlmClient glmClient;
+ *
+ *     public String doSomething() {
+ *         String systemPrompt = "당신은 ...";
+ *         String userPrompt   = "다음 내용을 분석해줘: ...";
+ *         return glmClient.chat(systemPrompt, userPrompt);
+ *     }
+ * }
+ * }
+ * </pre>
+ */
+@Component
+public class GlmClient {
+
+    private final ZaiClient zaiClient;
+    private final String model;
+
+    /**
+     * @param apiKey application.properties의 {@code glm.api.key} 값
+     * @param model  application.properties의 {@code glm.api.model} 값 (예: glm-5.1)
+     */
+    public GlmClient(@Value("${glm.api.key}") String apiKey, @Value("${glm.api.model}") String model) {
+        this.zaiClient = ZaiClient.builder().ofZAI().apiKey(apiKey).build();
+        this.model = model;
+    }
+
+    /**
+     * GLM에 system/user 메시지를 전송하고 응답 텍스트를 반환합니다.
+     *
+     * @param systemPrompt GLM의 역할과 응답 형식을 지정하는 시스템 메시지
+     * @param userPrompt   실제 분석/처리할 내용을 담은 사용자 메시지
+     * @return GLM이 생성한 응답 텍스트
+     * @throws RuntimeException GLM API 호출 실패 시
+     *
+     * <p><b>주의:</b> JSON 응답이 필요한 경우 systemPrompt에 반드시 JSON 형식을 명시하세요.
+     * GLM이 마크다운 코드블록(```json ... ```)으로 감싸서 응답할 수 있으므로,
+     * 파싱 전에 코드블록 제거 처리를 권장합니다.
+     */
+    public String chat(String systemPrompt, String userPrompt) {
+        ChatCompletionCreateParams request = ChatCompletionCreateParams.builder()
+                .model(model)
+                .messages(List.of(
+                        ChatMessage.builder()
+                                .role(ChatMessageRole.SYSTEM.value())
+                                .content(systemPrompt)
+                                .build(),
+                        ChatMessage.builder()
+                                .role(ChatMessageRole.USER.value())
+                                .content(userPrompt)
+                                .build()))
+                .stream(false)
+                .build();
+
+        return zaiClient
+                .chat()
+                .createChatCompletion(request)
+                .getData()
+                .getChoices()
+                .get(0)
+                .getMessage()
+                .getContent()
+                .toString();
+    }
+}

--- a/src/main/java/com/flodiback/global/client/GlmClient.java
+++ b/src/main/java/com/flodiback/global/client/GlmClient.java
@@ -3,26 +3,23 @@ package com.flodiback.global.client;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
 
-import ai.z.openapi.ZaiClient;
-import ai.z.openapi.service.agents.AgentContent;
-import ai.z.openapi.service.agents.AgentMessage;
-import ai.z.openapi.service.agents.AgentsCompletionRequest;
-import ai.z.openapi.service.model.ChatCompletionCreateParams;
-import ai.z.openapi.service.model.ChatMessage;
-import ai.z.openapi.service.model.ChatMessageRole;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * GLM(Z.AI) API 호출을 담당하는 공용 클라이언트입니다.
  *
  * <p>팀 내 어느 도메인에서든 GLM을 호출할 때 이 클래스를 주입받아 사용하세요.
- * 직접 ZaiClient를 사용하지 않도록 합니다.
  *
  * <h3>설정 (application.yml)</h3>
  * <pre>
  * glm.api.key=발급받은_API_KEY
  * glm.api.model=glm-5.1
+ * glm.api.url=https://api.z.ai/api  # 기본값, 변경 불필요
  * </pre>
  *
  * <h3>사용 예시</h3>
@@ -46,17 +43,22 @@ import ai.z.openapi.service.model.ChatMessageRole;
 @Component
 public class GlmClient {
 
-    private final ZaiClient zaiClient;
+    private final RestClient restClient;
     private final String model;
 
-    /**
-     * @param apiKey application.properties의 {@code glm.api.key} 값
-     * @param model  application.properties의 {@code glm.api.model} 값 (예: glm-5.1)
-     */
-    public GlmClient(@Value("${glm.api.key}") String apiKey, @Value("${glm.api.model}") String model) {
-        this.zaiClient = ZaiClient.builder().ofZAI().apiKey(apiKey).build();
+    public GlmClient(
+            @Value("${glm.api.key}") String apiKey,
+            @Value("${glm.api.model}") String model,
+            @Value("${glm.api.url}") String apiUrl) {
         this.model = model;
+        this.restClient = RestClient.builder()
+                .baseUrl(apiUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
     }
+
+    // ── Chat Completion ──────────────────────────────────────────────────────
 
     /**
      * GLM에 system/user 메시지를 전송하고 응답 텍스트를 반환합니다.
@@ -64,37 +66,26 @@ public class GlmClient {
      * @param systemPrompt GLM의 역할과 응답 형식을 지정하는 시스템 메시지
      * @param userPrompt   실제 분석/처리할 내용을 담은 사용자 메시지
      * @return GLM이 생성한 응답 텍스트
-     * @throws RuntimeException GLM API 호출 실패 시
      *
      * <p><b>주의:</b> JSON 응답이 필요한 경우 systemPrompt에 반드시 JSON 형식을 명시하세요.
      * GLM이 마크다운 코드블록(```json ... ```)으로 감싸서 응답할 수 있으므로,
      * 파싱 전에 코드블록 제거 처리를 권장합니다.
      */
     public String chat(String systemPrompt, String userPrompt) {
-        ChatCompletionCreateParams request = ChatCompletionCreateParams.builder()
-                .model(model)
-                .messages(List.of(
-                        ChatMessage.builder()
-                                .role(ChatMessageRole.SYSTEM.value())
-                                .content(systemPrompt)
-                                .build(),
-                        ChatMessage.builder()
-                                .role(ChatMessageRole.USER.value())
-                                .content(userPrompt)
-                                .build()))
-                .stream(false)
-                .build();
+        ChatRequest request = new ChatRequest(
+                model, List.of(new ChatMessage("system", systemPrompt), new ChatMessage("user", userPrompt)), false);
 
-        return zaiClient
-                .chat()
-                .createChatCompletion(request)
-                .getData()
-                .getChoices()
-                .get(0)
-                .getMessage()
-                .getContent()
-                .toString();
+        ChatResponse response = restClient
+                .post()
+                .uri("/paas/v4/chat/completions")
+                .body(request)
+                .retrieve()
+                .body(ChatResponse.class);
+
+        return response.choices().get(0).message().content();
     }
+
+    // ── Agent Chat ───────────────────────────────────────────────────────────
 
     /**
      * Agent Chat API를 호출하고 어시스턴트 응답 텍스트를 반환합니다.
@@ -105,26 +96,38 @@ public class GlmClient {
      * @param agentId     호출할 에이전트 ID (예: "general_translation")
      * @param userMessage 사용자 입력 메시지
      * @return 에이전트가 생성한 응답 텍스트
-     * @throws RuntimeException Agent API 호출 실패 시
      */
     public String agentChat(String agentId, String userMessage) {
-        AgentsCompletionRequest request = AgentsCompletionRequest.builder()
-                .agentId(agentId)
-                .messages(List.of(AgentMessage.builder()
-                        .role(ChatMessageRole.USER.value())
-                        .content(List.of(AgentContent.ofText(userMessage)))
-                        .build()))
-                .stream(false)
-                .build();
+        AgentRequest request = new AgentRequest(
+                agentId, List.of(new AgentMessage("user", List.of(new AgentContent("text", userMessage)))), false);
 
-        List<AgentMessage> messages = zaiClient
-                .agents()
-                .createAgentCompletion(request)
-                .getData()
-                .getChoices()
-                .get(0)
-                .getMessages();
+        AgentResponse response =
+                restClient.post().uri("/v1/agents").body(request).retrieve().body(AgentResponse.class);
 
-        return messages.get(messages.size() - 1).getContent().toString();
+        List<AgentMessage> messages = response.choices().get(0).messages();
+        return messages.get(messages.size() - 1).content().toString();
     }
+
+    // ── Chat Completion 요청/응답 ─────────────────────────────────────────────
+
+    private record ChatRequest(String model, List<ChatMessage> messages, boolean stream) {}
+
+    private record ChatMessage(String role, String content) {}
+
+    private record ChatResponse(List<ChatChoice> choices) {}
+
+    private record ChatChoice(ChatMessage message) {}
+
+    // ── Agent Chat 요청/응답 ──────────────────────────────────────────────────
+
+    private record AgentRequest(
+            @JsonProperty("agent_id") String agentId, List<AgentMessage> messages, boolean stream) {}
+
+    private record AgentMessage(String role, Object content) {}
+
+    private record AgentContent(String type, String text) {}
+
+    private record AgentResponse(List<AgentChoice> choices) {}
+
+    private record AgentChoice(List<AgentMessage> messages) {}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,7 @@ glm:
   api:
     key: ${GLM_API_KEY}
     model: ${GLM_MODEL:glm-5.1}
+    url: ${GLM_API_URL:https://api.z.ai/api}
 
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,11 @@ spring:
         highlight_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 100
+glm:
+  api:
+    key: ${GLM_API_KEY}
+    model: ${GLM_MODEL:glm-5.1}
+
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8
 logging:

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
@@ -1,0 +1,221 @@
+package com.flodiback.domain.meeting.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flodiback.domain.meeting.analysis.dto.AnalysisResult;
+import com.flodiback.domain.meeting.meeting.entity.ContextCache;
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.ContextCacheRepository;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.meeting.meetinglog.entity.MeetingSummary;
+import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
+import com.flodiback.domain.meeting.meetinglog.repository.MeetingSummaryRepository;
+import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
+import com.flodiback.global.client.GlmClient;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingAnalysisServiceTest {
+
+    @InjectMocks
+    private MeetingAnalysisService service;
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @Mock
+    private ContextCacheRepository contextCacheRepository;
+
+    @Mock
+    private UtteranceRepository utteranceRepository;
+
+    @Mock
+    private MeetingSummaryRepository meetingSummaryRepository;
+
+    @Mock
+    private GlmClient glmClient;
+
+    @Mock(name = "objectMapper")
+    private ObjectMapper objectMapper;
+
+    private final ObjectMapper realMapper = new ObjectMapper();
+
+    // ── analyze ───────────────────────────────────────────────────────────────
+
+    @Test
+    void analyze_회의없으면_예외발생() {
+        // given
+        given(meetingRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> service.analyze(999L))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 회의입니다.");
+    }
+
+    @Test
+    void analyze_캐시없고_발화있을때_summary저장() throws Exception {
+        // given
+        Meeting meeting = Meeting.builder().title("테스트 회의").build();
+        Utterance u1 = Utterance.builder()
+                .meeting(meeting)
+                .speakerName("홍길동")
+                .speakerDiscordId("user1")
+                .content("API 명세 확정했습니다.")
+                .build();
+        Utterance u2 = Utterance.builder()
+                .meeting(meeting)
+                .speakerName("김철수")
+                .speakerDiscordId("user2")
+                .content("다음 주 월요일까지 구현 완료 예정입니다.")
+                .build();
+
+        String glmResponse = """
+                {
+                  "summary": "API 명세 확정 및 구현 일정 논의",
+                  "unresolvedItems": null,
+                  "worklogs": [],
+                  "decisions": []
+                }
+                """;
+
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(contextCacheRepository.findByMeetingOrderByCreatedAtAsc(meeting)).willReturn(List.of());
+        given(utteranceRepository.findByMeetingOrderBySpokenAtAsc(meeting)).willReturn(List.of(u1, u2));
+        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponse);
+        given(objectMapper.readValue(anyString(), any(Class.class)))
+                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+
+        // when
+        service.analyze(1L);
+
+        // then
+        ArgumentCaptor<MeetingSummary> captor = ArgumentCaptor.forClass(MeetingSummary.class);
+        verify(meetingSummaryRepository).save(captor.capture());
+
+        MeetingSummary saved = captor.getValue();
+        System.out.println("=== 저장된 MeetingSummary ===");
+        System.out.println("summary        : " + saved.getSummary());
+        System.out.println("unresolvedItems: " + saved.getUnresolvedItems());
+
+        assertThat(saved.getSummary()).isEqualTo("API 명세 확정 및 구현 일정 논의");
+        assertThat(saved.getUnresolvedItems()).isNull();
+    }
+
+    @Test
+    void analyze_캐시있을때_context에_이전요약포함() throws Exception {
+        // given
+        Meeting meeting = Meeting.builder().title("테스트 회의").build();
+        ContextCache cache = ContextCache.builder()
+                .meeting(meeting)
+                .compressedText("지난 회의 요약 내용")
+                .tokenCount(100)
+                .turnRange("1-10")
+                .build();
+        Utterance utterance = Utterance.builder()
+                .meeting(meeting)
+                .speakerName("홍길동")
+                .speakerDiscordId("user1")
+                .content("오늘 안건입니다.")
+                .build();
+
+        String glmResponse = """
+                {
+                  "summary": "요약",
+                  "unresolvedItems": null,
+                  "worklogs": [],
+                  "decisions": []
+                }
+                """;
+
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(contextCacheRepository.findByMeetingOrderByCreatedAtAsc(meeting)).willReturn(List.of(cache));
+        given(utteranceRepository.findByMeetingOrderBySpokenAtAsc(meeting)).willReturn(List.of(utterance));
+        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponse);
+        given(objectMapper.readValue(anyString(), any(Class.class)))
+                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+
+        // when
+        service.analyze(1L);
+
+        // then
+        ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(glmClient).chat(anyString(), userPromptCaptor.capture());
+
+        String userPrompt = userPromptCaptor.getValue();
+        assertThat(userPrompt).contains("[이전 대화 요약]");
+        assertThat(userPrompt).contains("지난 회의 요약 내용");
+    }
+
+    @Test
+    void analyze_glm응답_마크다운코드블록_제거후_파싱() throws Exception {
+        // given
+        Meeting meeting = Meeting.builder().title("테스트 회의").build();
+
+        String glmResponseWithCodeBlock = """
+                ```json
+                {
+                  "summary": "마크다운 포함 응답",
+                  "unresolvedItems": "미결 사항 있음",
+                  "worklogs": [],
+                  "decisions": []
+                }
+                ```""";
+
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(contextCacheRepository.findByMeetingOrderByCreatedAtAsc(meeting)).willReturn(List.of());
+        given(utteranceRepository.findByMeetingOrderBySpokenAtAsc(meeting)).willReturn(List.of());
+        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponseWithCodeBlock);
+        given(objectMapper.readValue(anyString(), any(Class.class)))
+                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+
+        // when
+        service.analyze(1L);
+
+        // then
+        ArgumentCaptor<MeetingSummary> captor = ArgumentCaptor.forClass(MeetingSummary.class);
+        verify(meetingSummaryRepository).save(captor.capture());
+
+        MeetingSummary saved = captor.getValue();
+        System.out.println("=== 저장된 MeetingSummary (마크다운 제거 후) ===");
+        System.out.println("summary        : " + saved.getSummary());
+        System.out.println("unresolvedItems: " + saved.getUnresolvedItems());
+
+        assertThat(saved.getSummary()).isEqualTo("마크다운 포함 응답");
+        assertThat(saved.getUnresolvedItems()).isEqualTo("미결 사항 있음");
+    }
+
+    @Test
+    void analyze_glm응답_파싱실패시_예외발생() throws Exception {
+        // given
+        Meeting meeting = Meeting.builder().title("테스트 회의").build();
+
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(contextCacheRepository.findByMeetingOrderByCreatedAtAsc(meeting)).willReturn(List.of());
+        given(utteranceRepository.findByMeetingOrderBySpokenAtAsc(meeting)).willReturn(List.of());
+        given(glmClient.chat(anyString(), anyString())).willReturn("이건 JSON이 아닙니다");
+        given(objectMapper.readValue(anyString(), any(Class.class)))
+                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+
+        // when & then
+        assertThatThrownBy(() -> service.analyze(1L))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("GLM 응답 파싱 실패");
+    }
+}

--- a/src/test/java/com/flodiback/global/client/GlmClientManualTest.java
+++ b/src/test/java/com/flodiback/global/client/GlmClientManualTest.java
@@ -1,6 +1,5 @@
 package com.flodiback.global.client;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  *
  * <p>실행 전 로컬 .env 파일에 GLM_API_KEY가 설정되어 있어야 합니다.
  */
-@Disabled("수동 실행 전용 — 토큰 소모 주의. 실행 시 @Disabled 제거")
+// @Disabled("수동 실행 전용 — 토큰 소모 주의. 실행 시 @Disabled 제거")
 @SpringBootTest
 class GlmClientManualTest {
 
@@ -28,18 +27,6 @@ class GlmClientManualTest {
         String response = glmClient.chat(systemPrompt, userPrompt);
 
         System.out.println("=== chat() 응답 ===");
-        System.out.println(response);
-    }
-
-    @Test
-    void agentChat_응답확인() {
-        // agentId: Z.AI 콘솔에서 생성한 에이전트 ID로 교체하세요.
-        String agentId = "your_agent_id";
-        String userMessage = "안녕하세요, 테스트 메시지입니다.";
-
-        String response = glmClient.agentChat(agentId, userMessage);
-
-        System.out.println("=== agentChat() 응답 ===");
         System.out.println(response);
     }
 }

--- a/src/test/java/com/flodiback/global/client/GlmClientManualTest.java
+++ b/src/test/java/com/flodiback/global/client/GlmClientManualTest.java
@@ -1,5 +1,6 @@
 package com.flodiback.global.client;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,7 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  *
  * <p>실행 전 로컬 .env 파일에 GLM_API_KEY가 설정되어 있어야 합니다.
  */
-// @Disabled("수동 실행 전용 — 토큰 소모 주의. 실행 시 @Disabled 제거")
+@Disabled("수동 실행 전용 — 토큰 소모 주의. 실행 시 @Disabled 제거")
 @SpringBootTest
 class GlmClientManualTest {
 

--- a/src/test/java/com/flodiback/global/client/GlmClientManualTest.java
+++ b/src/test/java/com/flodiback/global/client/GlmClientManualTest.java
@@ -1,0 +1,45 @@
+package com.flodiback.global.client;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * GlmClient 수동 실행 테스트.
+ *
+ * <p>실제 Z.AI API를 호출하므로 토큰이 소모됩니다.
+ * 자동 빌드·CI에서는 실행되지 않으며, 검증이 필요할 때만 @Disabled를 제거하고 실행하세요.
+ *
+ * <p>실행 전 로컬 .env 파일에 GLM_API_KEY가 설정되어 있어야 합니다.
+ */
+@Disabled("수동 실행 전용 — 토큰 소모 주의. 실행 시 @Disabled 제거")
+@SpringBootTest
+class GlmClientManualTest {
+
+    @Autowired
+    private GlmClient glmClient;
+
+    @Test
+    void chat_응답확인() {
+        String systemPrompt = "당신은 친절한 어시스턴트입니다. 한국어로 답하세요.";
+        String userPrompt = "1 + 1은 뭐야?";
+
+        String response = glmClient.chat(systemPrompt, userPrompt);
+
+        System.out.println("=== chat() 응답 ===");
+        System.out.println(response);
+    }
+
+    @Test
+    void agentChat_응답확인() {
+        // agentId: Z.AI 콘솔에서 생성한 에이전트 ID로 교체하세요.
+        String agentId = "your_agent_id";
+        String userMessage = "안녕하세요, 테스트 메시지입니다.";
+
+        String response = glmClient.agentChat(agentId, userMessage);
+
+        System.out.println("=== agentChat() 응답 ===");
+        System.out.println(response);
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #23
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #23

---

**📝 작업 내용**

회의 종료 후 GLM을 호출해 회의 요약(MeetingSummary)을 자동 생성하는 분석 서비스를 구현했습니다.

GLM 연동은 OpenAI 호환 SDK(openai-java)를 사용하고, 시크릿 관리를 위한 환경변수 구조도 정비했습니다.

---

**✅ 주요 변경 사항**

1. MeetingAnalysisService: context_cache + utterance 기반으로 컨텍스트를 구성해 GLM 호출 후

MeetingSummary 저장 (WorkLog·Decision은 TODO 스켈레톤)

2. GlmClient: OpenAI 호환 SDK(openai-java:2.20.1) 기반으로 구현 — zai-sdk의 Jackson 2.15 비호환 문제

해결

3. 환경변수 구조 정비: GLM_API_KEY, GLM_MODEL, GLM_API_URL을 .env.example 및 CI Secrets에 추가

4. MeetingAnalysisServiceTest: Mockito 단위 테스트 5개 (예외, summary 저장, 캐시 포함 컨텍스트, 마크다운

제거 파싱, 파싱 실패)

5. GlmClientManualTest: 실제 API 호출 수동 테스트 (@Disabled로 자동 실행 방지)

---

**🧪 테스트 결과**

./gradlew test --tests "com.flodiback.domain.meeting.analysis.service.MeetingAnalysisServiceTest"

BUILD SUCCESSFUL — 5 tests passed

- 로컬 테스트 통과

- GlmClient chat() 실제 API 호출 확인 (grepp 게이트웨이)

---

**👀 리뷰 포인트 (선택)**

- GlmClient는 grepp 게이트웨이(OpenAI 호환)만 지원하며, agent chat 등 [Z.AI](http://z.ai/) 전용 기능은 사용 불가

- WorkLog·Decision 저장 로직 추후 구현 예정

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
