### PR TITLE
[fea] ERD 기준으로 엔티티 컬럼 동기화

### DIFF
--- a/src/main/java/com/flodiback/domain/meeting/meeting/entity/ContextCache.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/entity/ContextCache.java
@@ -24,24 +24,38 @@ public class ContextCache {
     @JoinColumn(name = "meeting_id", nullable = false)
     private Meeting meeting;
 
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
     @Column(name = "compressed_text", nullable = false, columnDefinition = "TEXT")
     private String compressedText;
 
     @Column(name = "token_count", nullable = false)
     private Integer tokenCount;
 
-    @Column(name = "turn_range", nullable = false, length = 50)
-    private String turnRange;
+    @Column(name = "start_sequence_no", nullable = false)
+    private Long startSequenceNo;
+
+    @Column(name = "end_sequence_no", nullable = false)
+    private Long endSequenceNo;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Builder
-    public ContextCache(Meeting meeting, String compressedText, Integer tokenCount, String turnRange) {
+    public ContextCache(
+            Meeting meeting,
+            Integer version,
+            String compressedText,
+            Integer tokenCount,
+            Long startSequenceNo,
+            Long endSequenceNo) {
         this.meeting = meeting;
+        this.version = version;
         this.compressedText = compressedText;
         this.tokenCount = tokenCount;
-        this.turnRange = turnRange;
+        this.startSequenceNo = startSequenceNo;
+        this.endSequenceNo = endSequenceNo;
     }
 }

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/entity/Utterance.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/entity/Utterance.java
@@ -30,19 +30,38 @@ public class Utterance {
     @Column(name = "speaker_discord_id", nullable = false, length = 50)
     private String speakerDiscordId;
 
+    @Column(name = "speaker_type", nullable = false, length = 20)
+    private String speakerType;
+
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(name = "spoken_at", nullable = false)
     private LocalDateTime spokenAt;
 
+    @Column(name = "sequence_no", nullable = false)
+    private Long sequenceNo;
+
+    @Column(name = "token_count")
+    private Integer tokenCount;
+
     @Builder
     public Utterance(
-            Meeting meeting, String speakerName, String speakerDiscordId, String content, LocalDateTime spokenAt) {
+            Meeting meeting,
+            String speakerName,
+            String speakerDiscordId,
+            String speakerType,
+            String content,
+            LocalDateTime spokenAt,
+            Long sequenceNo,
+            Integer tokenCount) {
         this.meeting = meeting;
         this.speakerName = speakerName;
         this.speakerDiscordId = speakerDiscordId;
+        this.speakerType = speakerType != null ? speakerType : "HUMAN";
         this.content = content;
         this.spokenAt = spokenAt != null ? spokenAt : LocalDateTime.now();
+        this.sequenceNo = sequenceNo;
+        this.tokenCount = tokenCount;
     }
 }

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
@@ -12,4 +12,6 @@ public interface UtteranceRepository extends JpaRepository<Utterance, Long> {
     List<Utterance> findTop20ByMeetingIdOrderBySpokenAtDesc(Long meetingId);
 
     List<Utterance> findByMeetingOrderBySpokenAtAsc(Meeting meeting);
+
+    long countByMeeting(Meeting meeting);
 }

--- a/src/main/java/com/flodiback/domain/project/worklog/entity/WorkLog.java
+++ b/src/main/java/com/flodiback/domain/project/worklog/entity/WorkLog.java
@@ -41,6 +41,9 @@ public class WorkLog {
     @Column(name = "due_date")
     private LocalDate dueDate;
 
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -52,5 +55,6 @@ public class WorkLog {
         this.assigneeName = assigneeName;
         this.task = task;
         this.dueDate = dueDate;
+        this.status = "TODO";
     }
 }

--- a/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
@@ -27,6 +27,10 @@ public class InternalSpeechService {
                 .findById(request.meetingId())
                 .orElseThrow(() -> new ServiceException("404-1", "회의를 찾을 수 없습니다."));
 
+        // 동시 요청이 들어오면 같은 sequenceNo가 배정될 수 있다.
+        // 현재는 단일 봇 환경이므로 허용하지만, 멀티 봇/고부하 환경에서는 DB 시퀀스나 낙관적 락으로 교체해야 한다.
+        long sequenceNo = utteranceRepository.countByMeeting(meeting) + 1;
+
         // Discord 봇이 넘긴 발화 시각을 spoken_at으로 저장한다.
         Utterance utterance = Utterance.builder()
                 .meeting(meeting)
@@ -34,6 +38,7 @@ public class InternalSpeechService {
                 .speakerName(request.speakerName())
                 .content(request.text())
                 .spokenAt(request.timestamp())
+                .sequenceNo(sequenceNo)
                 .build();
 
         Utterance savedUtterance = utteranceRepository.save(utterance);

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
@@ -78,12 +78,14 @@ class MeetingAnalysisServiceTest {
                 .speakerName("홍길동")
                 .speakerDiscordId("user1")
                 .content("API 명세 확정했습니다.")
+                .sequenceNo(1L)
                 .build();
         Utterance u2 = Utterance.builder()
                 .meeting(meeting)
                 .speakerName("김철수")
                 .speakerDiscordId("user2")
                 .content("다음 주 월요일까지 구현 완료 예정입니다.")
+                .sequenceNo(2L)
                 .build();
 
         String glmResponse = """
@@ -124,15 +126,18 @@ class MeetingAnalysisServiceTest {
         Meeting meeting = Meeting.builder().title("테스트 회의").build();
         ContextCache cache = ContextCache.builder()
                 .meeting(meeting)
+                .version(1)
                 .compressedText("지난 회의 요약 내용")
                 .tokenCount(100)
-                .turnRange("1-10")
+                .startSequenceNo(1L)
+                .endSequenceNo(10L)
                 .build();
         Utterance utterance = Utterance.builder()
                 .meeting(meeting)
                 .speakerName("홍길동")
                 .speakerDiscordId("user1")
                 .content("오늘 안건입니다.")
+                .sequenceNo(1L)
                 .build();
 
         String glmResponse = """

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepositoryTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepositoryTest.java
@@ -66,6 +66,7 @@ class UtteranceRepositoryTest extends AbstractPostgresIntegrationTest {
                 .speakerName(name)
                 .speakerDiscordId(discordId)
                 .content(content)
+                .sequenceNo((long) (Math.random() * 100000))
                 .build();
     }
 }


### PR DESCRIPTION
  ContextCache: turn_range 제거 → version, start_sequence_no, end_sequence_no 추가
  Utterance: speaker_type, sequence_no, token_count 추가
  WorkLog: status 추가 (기본값 TODO), 문법 오류 수정

## 🔗 연관된 이슈
refs #25
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #25

---

**📝 작업 내용**

ERD와 엔티티 클래스 간 불일치 컬럼을 동기화했습니다.

ContextCache의 turn_range를 ERD 기준 필드로 교체하고, Utterance와 WorkLog에 누락된 컬럼을 추가했습니다.

---

**✅ 주요 변경 사항**

1. ContextCache: turn_range 제거 → version, start_sequence_no, end_sequence_no 추가

2. Utterance: speaker_type, sequence_no, token_count 추가

3. WorkLog: status 추가 (기본값 TODO), 문법 오류(private 단독 선언) 수정

4. 관련 테스트(MeetingAnalysisServiceTest, UtteranceRepositoryTest) 빌더 호출 수정

---

**🧪 테스트 결과**

./gradlew compileJava compileTestJava

BUILD SUCCESSFUL

- 로컬 컴파일 통과

- 관련 시나리오 수동 확인

---

**👀 리뷰 포인트 (선택)**

- InternalSpeechService에서 Utterance 생성 시 sequenceNo가 누락되어 있습니다. 해당 담당자 확인이

필요합니다.

- UtteranceRepositoryTest의 sequenceNo는 임의값(Math.random())으로 처리했습니다. 테스트 목적상 값 자체는 중요하지 않아 이렇게 처리했으나 의견 있으시면 말씀해주세요.
---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
