### PR TITLE
[feat] STT 발화 기반 AI 답변 파이프라인 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ DISCORD_TOKEN=your_discord_bot_token
 
 # Text command prefix
 DISCORD_BOT_PREFIX=!
+GLM_ENABLED=false
 
 # 기본 meetingId (현재 봇은 이 값으로 /internal/v1/speech를 전송)
 DISCORD_DEFAULT_MEETING_ID=1

--- a/docs/references/internal-api-contracts.md
+++ b/docs/references/internal-api-contracts.md
@@ -16,6 +16,22 @@ Discord 봇 파이프라인에서 STT 변환 결과를 수신합니다.
 }
 ```
 
+응답 본문:
+```json
+{
+  "resultCode": "200-1",
+  "msg": "발화가 저장되었습니다.",
+  "data": {
+    "utterance_id": 11,
+    "meeting_id": 1,
+    "ai_answer": "네, 기존 결정사항 기준으로 인증 방식은 JWT를 사용하기로 했습니다."
+  }
+}
+```
+
+- `ai_answer`는 호출어가 감지되어 AI 답변이 생성된 경우에만 문자열로 내려갑니다.
+- 호출어가 없거나 AI 답변 생성에 실패하면 `ai_answer`는 `null`입니다.
+
 ## `GET /internal/v1/projects/{id}/context`
 에이전트/봇 워크플로에서 사용할 프로젝트 컨텍스트를 조회합니다.
 

--- a/src/main/java/com/flodiback/domain/ai/service/AiChatService.java
+++ b/src/main/java/com/flodiback/domain/ai/service/AiChatService.java
@@ -1,0 +1,7 @@
+package com.flodiback.domain.ai.service;
+
+public interface AiChatService {
+
+    // 호출어/RAG 흐름이 실제 GLM SDK 구현체에 직접 의존하지 않도록 분리합니다.
+    String generateAnswer(String systemPrompt, String userQuestion);
+}

--- a/src/main/java/com/flodiback/domain/ai/service/DisabledAiChatService.java
+++ b/src/main/java/com/flodiback/domain/ai/service/DisabledAiChatService.java
@@ -1,0 +1,17 @@
+package com.flodiback.domain.ai.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import com.flodiback.global.exception.ServiceException;
+
+@Service
+@ConditionalOnProperty(prefix = "glm", name = "enabled", havingValue = "false", matchIfMissing = true)
+public class DisabledAiChatService implements AiChatService {
+
+    @Override
+    public String generateAnswer(String systemPrompt, String userQuestion) {
+        // 로컬/테스트 환경에서 GLM 키 없이 실행할 수 있도록 명확히 비활성 상태를 알립니다.
+        throw new ServiceException("503-1", "GLM 채팅 서비스가 비활성화되어 있습니다.");
+    }
+}

--- a/src/main/java/com/flodiback/domain/ai/service/GlmAiChatService.java
+++ b/src/main/java/com/flodiback/domain/ai/service/GlmAiChatService.java
@@ -1,0 +1,22 @@
+package com.flodiback.domain.ai.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import com.flodiback.global.client.GlmClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "glm", name = "enabled", havingValue = "true")
+public class GlmAiChatService implements AiChatService {
+
+    private final GlmClient glmClient;
+
+    @Override
+    public String generateAnswer(String systemPrompt, String userQuestion) {
+        // 실제 GLM 호출은 공용 GlmClient에 위임해 호출부가 SDK 세부 구현을 몰라도 되게 합니다.
+        return glmClient.chat(systemPrompt, userQuestion);
+    }
+}

--- a/src/main/java/com/flodiback/domain/speech/dto/InternalSpeechResponse.java
+++ b/src/main/java/com/flodiback/domain/speech/dto/InternalSpeechResponse.java
@@ -7,4 +7,7 @@ public record InternalSpeechResponse(
         @JsonProperty("utterance_id") Long utteranceId,
 
         // 발화가 저장된 회의 ID입니다.
-        @JsonProperty("meeting_id") Long meetingId) {}
+        @JsonProperty("meeting_id") Long meetingId,
+
+        // 호출어가 감지되어 생성된 AI 답변입니다. 답변이 없으면 null입니다.
+        @JsonProperty("ai_answer") String aiAnswer) {}

--- a/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
@@ -19,6 +19,7 @@ public class InternalSpeechService {
 
     private final MeetingRepository meetingRepository;
     private final UtteranceRepository utteranceRepository;
+    private final SpeechAiAnswerService speechAiAnswerService;
 
     @Transactional
     public InternalSpeechResponse saveSpeech(InternalSpeechRequest request) {
@@ -43,9 +44,9 @@ public class InternalSpeechService {
 
         Utterance savedUtterance = utteranceRepository.save(utterance);
 
-        // TODO: 호출어("AI야", "봇아", "클로드야") 감지 후 GLM AI Gateway 스트리밍 응답 흐름을 연결한다.
-        // 현재 1차 범위에서는 STT 발화 저장까지만 처리한다.
+        // 호출어가 있는 발화라면 회의 컨텍스트와 GLM을 사용해 봇이 출력할 답변을 만든다.
+        String aiAnswer = speechAiAnswerService.generateAnswerIfCalled(meeting.getId(), request.text());
 
-        return new InternalSpeechResponse(savedUtterance.getId(), meeting.getId());
+        return new InternalSpeechResponse(savedUtterance.getId(), meeting.getId(), aiAnswer);
     }
 }

--- a/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
@@ -1,0 +1,161 @@
+package com.flodiback.domain.speech.service;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.flodiback.domain.ai.service.AiChatService;
+import com.flodiback.domain.meeting.meetinglog.dto.ContextResponse;
+import com.flodiback.domain.meeting.meetinglog.dto.DecisionSummary;
+import com.flodiback.domain.meeting.meetinglog.dto.PastSummary;
+import com.flodiback.domain.meeting.meetinglog.dto.UtteranceSummary;
+import com.flodiback.domain.meeting.meetinglog.service.ContextService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SpeechAiAnswerService {
+
+    private static final List<String> WAKE_WORDS = List.of("AI야", "ai야", "봇아", "클로드야");
+    private static final Pattern LEADING_PUNCTUATION = Pattern.compile("^[\\s,，.。?？!！:：;；-]+");
+    private static final String SYSTEM_PROMPT = """
+            너는 Discord 회의에 참여하는 AI 회의 보조자야.
+            회의 맥락을 바탕으로 한국어로 2~3문장만 답해줘.
+            컨텍스트에 없는 내용은 추측하지 말고 모른다고 말해줘.
+            """;
+
+    private final ContextService contextService;
+    private final AiChatService aiChatService;
+
+    public String generateAnswerIfCalled(Long meetingId, String speechText) {
+        String question = extractQuestion(speechText);
+        if (!StringUtils.hasText(question)) {
+            return null;
+        }
+
+        try {
+            ContextResponse context = contextService.assemble(meetingId, question);
+            String answer = aiChatService.generateAnswer(SYSTEM_PROMPT, buildUserPrompt(context, question));
+            return StringUtils.hasText(answer) ? answer.strip() : null;
+        } catch (RuntimeException e) {
+            // STT 원문 저장이 더 중요하므로 AI 답변 실패는 응답만 비우고 회의록 흐름은 유지합니다.
+            log.warn("AI 답변 생성에 실패했습니다. meetingId={}, reason={}", meetingId, e.getMessage());
+            return null;
+        }
+    }
+
+    private String extractQuestion(String speechText) {
+        // 빈 STT 문장은 AI가 답할 질문으로 볼 수 없으므로 바로 종료합니다.
+        if (!StringUtils.hasText(speechText)) {
+            return null;
+        }
+
+        int wakeWordIndex = Integer.MAX_VALUE;
+        String matchedWakeWord = null;
+
+        // 한 문장에 호출어가 여러 개 있어도 가장 앞에 나온 호출어를 기준으로 질문을 자릅니다.
+        for (String wakeWord : WAKE_WORDS) {
+            int index = speechText.indexOf(wakeWord);
+            if (index >= 0 && index < wakeWordIndex) {
+                wakeWordIndex = index;
+                matchedWakeWord = wakeWord;
+            }
+        }
+
+        if (matchedWakeWord == null) {
+            return null;
+        }
+
+        // 호출어 뒤에 붙은 쉼표, 물음표, 공백을 제거해 실제 질문만 남깁니다.
+        String rawQuestion = speechText.substring(wakeWordIndex + matchedWakeWord.length());
+        String question =
+                LEADING_PUNCTUATION.matcher(rawQuestion).replaceFirst("").strip();
+
+        return StringUtils.hasText(question) ? question : null;
+    }
+
+    private String buildUserPrompt(ContextResponse context, String question) {
+        // GLM이 회의 맥락을 함께 읽을 수 있도록 컨텍스트를 섹션별 텍스트로 정리합니다.
+        StringBuilder prompt = new StringBuilder();
+
+        prompt.append("[프로젝트 정보]\n");
+        prompt.append("프로젝트명: ")
+                .append(valueOrNone(context.longTerm().projectName()))
+                .append("\n");
+        prompt.append("기술 스택: ")
+                .append(valueOrNone(context.longTerm().techStack()))
+                .append("\n");
+        prompt.append("메타데이터: ")
+                .append(valueOrNone(context.longTerm().metadata()))
+                .append("\n\n");
+
+        prompt.append("[기존 결정사항]\n");
+        appendDecisions(prompt, context.longTerm().decisions());
+
+        prompt.append("\n[과거 회의 요약]\n");
+        appendPastSummaries(prompt, context.longTerm().pastSummaries());
+
+        prompt.append("\n[최근 회의 대화]\n");
+        appendRecentUtterances(prompt, context.shortTerm().recentUtterances());
+
+        // 마지막에 실제 질문을 붙여 GLM이 위 맥락을 근거로 답하도록 합니다.
+        prompt.append("\n[질문]\n").append(question);
+
+        return prompt.toString();
+    }
+
+    private void appendDecisions(StringBuilder prompt, List<DecisionSummary> decisions) {
+        // 기존 결정사항은 프로젝트의 장기 기억으로, 회의 중 재확인 질문에 쓰입니다.
+        if (decisions == null || decisions.isEmpty()) {
+            // 섹션을 비워두지 않고 "없음"을 넣어 GLM이 누락으로 오해하지 않게 합니다.
+            prompt.append("- 없음\n");
+            return;
+        }
+
+        decisions.forEach(decision -> prompt.append("- ")
+                .append(decision.content())
+                .append(" (")
+                .append(decision.decidedAt())
+                .append(")\n"));
+    }
+
+    private void appendPastSummaries(StringBuilder prompt, List<PastSummary> pastSummaries) {
+        // 과거 회의 요약은 현재 회의 이전에 정해진 맥락을 보충합니다.
+        if (pastSummaries == null || pastSummaries.isEmpty()) {
+            // 과거 요약이 없는 경우에도 프롬프트 구조를 일정하게 유지합니다.
+            prompt.append("- 없음\n");
+            return;
+        }
+
+        pastSummaries.forEach(summary -> prompt.append("- ")
+                .append(summary.summary())
+                .append(" (")
+                .append(summary.createdAt())
+                .append(")\n"));
+    }
+
+    private void appendRecentUtterances(StringBuilder prompt, List<UtteranceSummary> recentUtterances) {
+        // 최근 발화는 방금 진행 중인 회의의 단기 맥락으로 사용합니다.
+        if (recentUtterances == null || recentUtterances.isEmpty()) {
+            // 최근 대화가 없어도 섹션 의미가 드러나도록 "없음"을 명시합니다.
+            prompt.append("- 없음\n");
+            return;
+        }
+
+        recentUtterances.forEach(utterance -> prompt.append("- [")
+                .append(utterance.speakerName())
+                .append("] ")
+                .append(utterance.content())
+                .append("\n"));
+    }
+
+    private String valueOrNone(String value) {
+        // 값이 비어 있으면 프롬프트에 null 대신 "없음"을 넣어 읽기 쉽게 만듭니다.
+        return StringUtils.hasText(value) ? value : "없음";
+    }
+}

--- a/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SpeechAiAnswerService {
 
-    private static final List<String> WAKE_WORDS = List.of("AI야", "ai야", "봇아", "클로드야");
+    private static final List<String> WAKE_WORDS = List.of("AI야", "ai야", "봇아", "클로드야", "플로디야", "flodiya", "plodiya");
     private static final Pattern LEADING_PUNCTUATION = Pattern.compile("^[\\s,，.。?？!！:：;；-]+");
     private static final String SYSTEM_PROMPT = """
             너는 Discord 회의에 참여하는 AI 회의 보조자야.

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,3 +14,10 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
+
+glm:
+  # 실제 GLM SDK 구현체가 붙기 전까지는 기본 비활성 상태로 둡니다.
+  enabled: ${GLM_ENABLED:false}
+  api:
+    key: ${GLM_API_KEY:}
+    model: ${GLM_API_MODEL:glm-5}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,8 +16,5 @@ spring:
         default_batch_fetch_size: 100
 
 glm:
-  # 실제 GLM SDK 구현체가 붙기 전까지는 기본 비활성 상태로 둡니다.
+  # 실제 GLM 호출은 .env에서 GLM_ENABLED=true로 켰을 때만 사용합니다.
   enabled: ${GLM_ENABLED:false}
-  api:
-    key: ${GLM_API_KEY:}
-    model: ${GLM_API_MODEL:glm-5}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,3 +1,7 @@
+glm:
+  # 테스트에서는 외부 GLM 키 없이 컨텍스트가 뜨도록 채팅 기능을 끕니다.
+  enabled: false
+
 spring:
   jpa:
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,8 +30,9 @@ spring:
         use_sql_comments: true
         default_batch_fetch_size: 100
 glm:
+  enabled: ${GLM_ENABLED:false}
   api:
-    key: ${GLM_API_KEY}
+    key: ${GLM_API_KEY:}
     model: ${GLM_MODEL:glm-5.1}
     url: ${GLM_API_URL:https://api.z.ai/api}
 

--- a/src/test/java/com/flodiback/api/speech/InternalSpeechControllerTest.java
+++ b/src/test/java/com/flodiback/api/speech/InternalSpeechControllerTest.java
@@ -1,6 +1,11 @@
 package com.flodiback.api.speech;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -14,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +27,7 @@ import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
 import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
 import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.speech.service.SpeechAiAnswerService;
 import com.flodiback.global.enums.MeetingStatus;
 import com.flodiback.support.AbstractPostgresIntegrationTest;
 
@@ -39,6 +46,9 @@ class InternalSpeechControllerTest extends AbstractPostgresIntegrationTest {
 
     @Autowired
     private UtteranceRepository utteranceRepository;
+
+    @MockitoBean
+    private SpeechAiAnswerService speechAiAnswerService;
 
     private Meeting meeting;
 
@@ -78,7 +88,8 @@ class InternalSpeechControllerTest extends AbstractPostgresIntegrationTest {
                         .content(requestBody))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
-                .andExpect(jsonPath("$.data.meeting_id").value(meeting.getId()));
+                .andExpect(jsonPath("$.data.meeting_id").value(meeting.getId()))
+                .andExpect(jsonPath("$.data.ai_answer").value(nullValue()));
 
         List<Utterance> utterances = utteranceRepository.findAll();
         assertThat(utterances).hasSize(1);
@@ -130,7 +141,10 @@ class InternalSpeechControllerTest extends AbstractPostgresIntegrationTest {
     }
 
     @Test
-    void receiveSpeech_savesOnly_whenWakeWordIsIncludedForNow() throws Exception {
+    void receiveSpeech_returnsAiAnswer_whenWakeWordIsIncluded() throws Exception {
+        given(speechAiAnswerService.generateAnswerIfCalled(anyLong(), anyString()))
+                .willReturn("인증 방식은 JWT로 결정했습니다.");
+
         String requestBody = """
                 {
                   "meeting_id": %d,
@@ -145,10 +159,61 @@ class InternalSpeechControllerTest extends AbstractPostgresIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value("200-1"));
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data.ai_answer").value("인증 방식은 JWT로 결정했습니다."));
 
         List<Utterance> utterances = utteranceRepository.findAll();
         assertThat(utterances).hasSize(1);
         assertThat(utterances.get(0).getContent()).isEqualTo("AI야, 인증 방식 뭐로 하기로 했지?");
+        verify(speechAiAnswerService).generateAnswerIfCalled(meeting.getId(), "AI야, 인증 방식 뭐로 하기로 했지?");
+    }
+
+    @Test
+    void receiveSpeech_savesOnly_whenWakeWordHasNoQuestion() throws Exception {
+        String requestBody = """
+                {
+                  "meeting_id": %d,
+                  "speaker_discord_id": "123456789",
+                  "speaker_name": "김철수",
+                  "text": "AI야",
+                  "timestamp": "2026-04-23T10:30:00"
+                }
+                """.formatted(meeting.getId());
+
+        mockMvc.perform(post("/internal/v1/speech")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data.ai_answer").value(nullValue()));
+
+        List<Utterance> utterances = utteranceRepository.findAll();
+        assertThat(utterances).hasSize(1);
+        assertThat(utterances.get(0).getContent()).isEqualTo("AI야");
+    }
+
+    @Test
+    void receiveSpeech_savesSpeech_whenAiAnswerIsNull() throws Exception {
+        String requestBody = """
+                {
+                  "meeting_id": %d,
+                  "speaker_discord_id": "123456789",
+                  "speaker_name": "김철수",
+                  "text": "봇아, 토큰 만료 시간 정했어?",
+                  "timestamp": "2026-04-23T10:30:00"
+                }
+                """.formatted(meeting.getId());
+
+        mockMvc.perform(post("/internal/v1/speech")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data.ai_answer").value(nullValue()));
+
+        List<Utterance> utterances = utteranceRepository.findAll();
+        assertThat(utterances).hasSize(1);
+        assertThat(utterances.get(0).getContent()).isEqualTo("봇아, 토큰 만료 시간 정했어?");
+        verify(speechAiAnswerService).generateAnswerIfCalled(meeting.getId(), "봇아, 토큰 만료 시간 정했어?");
     }
 }

--- a/src/test/java/com/flodiback/domain/ai/service/DisabledAiChatServiceTest.java
+++ b/src/test/java/com/flodiback/domain/ai/service/DisabledAiChatServiceTest.java
@@ -1,0 +1,20 @@
+package com.flodiback.domain.ai.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.flodiback.global.exception.ServiceException;
+
+class DisabledAiChatServiceTest {
+
+    private final AiChatService aiChatService = new DisabledAiChatService();
+
+    @Test
+    void generateAnswer_throwsServiceException_whenAiChatIsDisabled() {
+        assertThatThrownBy(() -> aiChatService.generateAnswer("system prompt", "user question"))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("503-1")
+                .hasMessageContaining("GLM 채팅 서비스가 비활성화되어 있습니다.");
+    }
+}

--- a/src/test/java/com/flodiback/domain/ai/service/GlmAiChatServiceTest.java
+++ b/src/test/java/com/flodiback/domain/ai/service/GlmAiChatServiceTest.java
@@ -1,0 +1,33 @@
+package com.flodiback.domain.ai.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flodiback.global.client.GlmClient;
+
+@ExtendWith(MockitoExtension.class)
+class GlmAiChatServiceTest {
+
+    @Mock
+    private GlmClient glmClient;
+
+    @InjectMocks
+    private GlmAiChatService glmAiChatService;
+
+    @Test
+    void generateAnswer_delegatesToGlmClient() {
+        given(glmClient.chat("system", "user")).willReturn("answer");
+
+        String result = glmAiChatService.generateAnswer("system", "user");
+
+        assertThat(result).isEqualTo("answer");
+        verify(glmClient).chat("system", "user");
+    }
+}

--- a/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
@@ -1,0 +1,98 @@
+package com.flodiback.domain.speech.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flodiback.domain.ai.service.AiChatService;
+import com.flodiback.domain.meeting.meetinglog.dto.ContextResponse;
+import com.flodiback.domain.meeting.meetinglog.dto.DecisionSummary;
+import com.flodiback.domain.meeting.meetinglog.dto.LongTermContext;
+import com.flodiback.domain.meeting.meetinglog.dto.PastSummary;
+import com.flodiback.domain.meeting.meetinglog.dto.ShortTermContext;
+import com.flodiback.domain.meeting.meetinglog.dto.UtteranceSummary;
+import com.flodiback.domain.meeting.meetinglog.service.ContextService;
+
+@ExtendWith(MockitoExtension.class)
+class SpeechAiAnswerServiceTest {
+
+    @Mock
+    private ContextService contextService;
+
+    @Mock
+    private AiChatService aiChatService;
+
+    @InjectMocks
+    private SpeechAiAnswerService speechAiAnswerService;
+
+    @Test
+    void generateAnswerIfCalled_returnsNull_whenWakeWordDoesNotExist() {
+        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "이번 스프린트 목표를 정해봅시다.");
+
+        assertThat(result).isNull();
+        verify(contextService, never()).assemble(1L, "이번 스프린트 목표를 정해봅시다.");
+        verify(aiChatService, never()).generateAnswer(anyString(), anyString());
+    }
+
+    @Test
+    void generateAnswerIfCalled_usesContextAndAiChat_whenWakeWordExists() {
+        ContextResponse context = new ContextResponse(
+                new ShortTermContext(List.of(new UtteranceSummary("김철수", "인증은 JWT로 하죠.", null))),
+                new LongTermContext(
+                        "Flodi",
+                        "Spring Boot",
+                        null,
+                        List.of(new DecisionSummary("인증 방식은 JWT로 한다.", null)),
+                        List.of(new PastSummary("로그인 기능 담당자를 정했다.", null))));
+
+        given(contextService.assemble(1L, "인증 방식 뭐로 하기로 했지?")).willReturn(context);
+        given(aiChatService.generateAnswer(anyString(), anyString())).willReturn("인증 방식은 JWT로 결정했습니다.");
+
+        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "AI야, 인증 방식 뭐로 하기로 했지?");
+
+        assertThat(result).isEqualTo("인증 방식은 JWT로 결정했습니다.");
+        verify(contextService).assemble(1L, "인증 방식 뭐로 하기로 했지?");
+
+        ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(aiChatService).generateAnswer(anyString(), userPromptCaptor.capture());
+        assertThat(userPromptCaptor.getValue())
+                .contains("Flodi")
+                .contains("인증 방식은 JWT로 한다.")
+                .contains("로그인 기능 담당자를 정했다.")
+                .contains("[질문]")
+                .contains("인증 방식 뭐로 하기로 했지?");
+    }
+
+    @Test
+    void generateAnswerIfCalled_returnsNull_whenQuestionIsBlank() {
+        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "봇아!");
+
+        assertThat(result).isNull();
+        verify(contextService, never()).assemble(1L, "");
+        verify(aiChatService, never()).generateAnswer(anyString(), anyString());
+    }
+
+    @Test
+    void generateAnswerIfCalled_returnsNull_whenAiChatFails() {
+        ContextResponse context = ContextResponse.noProject(List.of());
+        given(contextService.assemble(1L, "토큰 만료 시간 정했어?")).willReturn(context);
+        given(aiChatService.generateAnswer(anyString(), anyString())).willThrow(new RuntimeException("GLM error"));
+
+        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "클로드야 토큰 만료 시간 정했어?");
+
+        assertThat(result).isNull();
+        verify(contextService).assemble(1L, "토큰 만료 시간 정했어?");
+        verify(aiChatService).generateAnswer(anyString(), anyString());
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #22 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #22 

---

<html>
<body>
<!--StartFragment-->
<h1>STT 호출어 기반 GLM 답변 흐름 연결</h1>

<h3>개념</h3>
<pre><code class="language-java">Discord Bot / Python STT 파이프라인
       ↓
POST /internal/v1/speech
       ↓
InternalSpeechService
  1. 발화를 Utterance로 저장
  2. 호출어 포함 여부 확인
       ↓
호출어 없음
  → ai_answer = null
       ↓
호출어 있음
  → 질문 추출
  → ContextService로 회의/프로젝트 컨텍스트 조회
  → AiChatService로 GLM 답변 생성
  → ai_answer에 답변 포함

발화 저장은 항상 우선 처리하고,
AI 답변 생성 실패는 발화 저장 흐름을 막지 않음
</code></pre>

<h3>이번 브랜치 변경 요약</h3>
<ul>
  <li>STT 발화 수신 API 응답에 <code>ai_answer</code>를 추가했다.</li>
  <li>발화 내용에 호출어가 포함된 경우에만 AI 답변 생성을 시도한다.</li>
  <li>호출어 뒤의 문장을 실제 질문으로 추출해 GLM에 전달한다.</li>
  <li>회의 컨텍스트, 프로젝트 정보, 기존 결정사항, 과거 요약, 최근 발화를 모아 GLM 프롬프트를 구성한다.</li>
  <li>GLM 호출부를 <code>AiChatService</code> 인터페이스로 분리해 실제 GLM 구현과 비활성 구현을 교체 가능하게 했다.</li>
  <li><code>glm.enabled</code> 설정으로 GLM 호출 활성/비활성을 제어한다.</li>
  <li>GLM 비활성 상태나 호출 실패 시에도 STT 발화 저장은 정상 완료되고 <code>ai_answer</code>만 null로 내려간다.</li>
  <li>internal API 계약 문서에 <code>ai_answer</code> 응답 필드를 반영했다.</li>
</ul>

<h3>커밋</h3>
<ul>
  <li><code>d38eec8 refactor: GLM SDK 연동 대비 AI 서비스 구조 정리</code></li>
  <li><code>50dc40a feat: STT 호출어 기반 GLM 답변 흐름 연결</code></li>
</ul>

<h3>변경 파일</h3>
<ul>
  <li><code>AiChatService.java</code> - GLM 답변 생성용 추상 인터페이스 추가</li>
  <li><code>DisabledAiChatService.java</code> - GLM 비활성 상태 기본 구현 추가</li>
  <li><code>GlmAiChatService.java</code> - 실제 <code>GlmClient</code> 위임 구현 추가</li>
  <li><code>SpeechAiAnswerService.java</code> - 호출어 감지, 질문 추출, 컨텍스트 조립, AI 답변 생성 흐름 추가</li>
  <li><code>InternalSpeechService.java</code> - 발화 저장 후 AI 답변 생성 흐름 연결</li>
  <li><code>InternalSpeechResponse.java</code> - 응답에 <code>ai_answer</code> 필드 추가</li>
  <li><code>application.yml</code> - <code>glm.enabled</code> 설정과 API key 기본값 추가</li>
  <li><code>application-dev.yml</code> - dev 환경에서 <code>GLM_ENABLED</code> env 기반 활성화 설정</li>
  <li><code>application-test.yml</code> - 테스트 환경에서 GLM 호출 비활성화</li>
  <li><code>.env.example</code> - <code>GLM_ENABLED=false</code> 예시 추가</li>
  <li><code>internal-api-contracts.md</code> - STT 수신 API 응답 계약 갱신</li>
  <li><code>InternalSpeechControllerTest.java</code> - <code>ai_answer</code> 응답 케이스 추가</li>
  <li><code>SpeechAiAnswerServiceTest.java</code> - 호출어/질문 추출/컨텍스트 프롬프트/실패 처리 단위 테스트 추가</li>
  <li><code>DisabledAiChatServiceTest.java</code> - GLM 비활성 구현 테스트 추가</li>
  <li><code>GlmAiChatServiceTest.java</code> - <code>GlmClient</code> 위임 테스트 추가</li>
</ul>

<h3>API 응답 변경</h3>
<pre><code class="language-json">POST /internal/v1/speech

Request:
{
  "meeting_id": 1,
  "speaker_discord_id": "123456789",
  "speaker_name": "김철수",
  "text": "AI야, 인증 방식 뭐로 하기로 했지?",
  "timestamp": "2026-04-23T10:30:00"
}

Response:
{
  "resultCode": "200-1",
  "msg": "발화가 저장되었습니다.",
  "data": {
    "utterance_id": 11,
    "meeting_id": 1,
    "ai_answer": "네, 기존 결정사항 기준으로 인증 방식은 JWT를 사용하기로 했습니다."
  }
}
</code></pre>

<h3>STT 처리 흐름</h3>
<pre><code class="language-java">[STT 결과 수신]
POST /internal/v1/speech
          ↓
[InternalSpeechService.saveSpeech()]
  meetingId로 Meeting 조회
  Utterance 저장
  sequenceNo 자동 배정
          ↓
[SpeechAiAnswerService.generateAnswerIfCalled()]
  호출어가 없으면 null 반환
  호출어만 있고 질문이 없으면 null 반환
  호출어 뒤 문장을 질문으로 추출
          ↓
[ContextService.assemble()]
  프로젝트 정보
  기존 결정사항
  과거 회의 요약
  최근 발화
  질문 기준 컨텍스트 조립
          ↓
[AiChatService.generateAnswer()]
  GLM 활성화 시 GlmClient.chat() 호출
  GLM 비활성/실패 시 null 처리
          ↓
[응답]
  utterance_id
  meeting_id
  ai_answer
</code></pre>

<h3>호출어 처리 규칙</h3>
<ul>
  <li>발화에 호출어가 없으면 AI 답변을 생성하지 않는다.</li>
  <li>호출어가 있어도 뒤에 질문 내용이 없으면 AI 답변을 생성하지 않는다.</li>
  <li>호출어 뒤의 쉼표, 물음표, 느낌표, 공백 등 앞쪽 문장부호를 제거하고 질문만 추출한다.</li>
  <li>여러 호출어가 들어간 경우 가장 앞에 나온 호출어를 기준으로 질문을 추출한다.</li>
</ul>

<h3>GLM 연동 구조</h3>
<pre><code class="language-java">AiChatService
  ├─ DisabledAiChatService
  │   └─ glm.enabled=false 또는 미설정일 때 사용
  │
  └─ GlmAiChatService
      └─ glm.enabled=true일 때 사용
          GlmClient.chat(systemPrompt, userQuestion) 호출
</code></pre>

<h3>설정</h3>
<pre><code class="language-yaml">glm:
  enabled: ${GLM_ENABLED:false}
  api:
    key: ${GLM_API_KEY:}
    model: ${GLM_MODEL:glm-5.1}
    url: ${GLM_API_URL:https://api.z.ai/api}
</code></pre>

<ul>
  <li>기본값은 <code>GLM_ENABLED=false</code>다.</li>
  <li>테스트 환경에서는 외부 GLM 키 없이 동작하도록 GLM을 비활성화한다.</li>
  <li>dev 환경에서는 <code>.env</code>의 <code>GLM_ENABLED</code> 값으로 실제 호출 여부를 제어한다.</li>
</ul>

<h3>프롬프트 구성</h3>
<ul>
  <li>시스템 프롬프트는 Discord 회의 보조자로서 짧고 명확하게 답하도록 구성했다.</li>
  <li>사용자 프롬프트에는 프로젝트명, 기술 스택, 메타데이터를 포함한다.</li>
  <li>기존 결정사항을 포함해 회의 중 질문에 장기 기억을 반영할 수 있게 했다.</li>
  <li>과거 회의 요약과 최근 발화를 함께 넣어 현재 회의 맥락을 반영한다.</li>
  <li>마지막에 실제 질문을 붙여 GLM이 컨텍스트 기반으로 답하도록 구성했다.</li>
</ul>

<h3>실패 처리</h3>
<ul>
  <li>AI 답변 생성 중 예외가 발생해도 발화 저장은 롤백하지 않는다.</li>
  <li>GLM 비활성 상태, GLM 호출 실패, 빈 응답은 모두 <code>ai_answer = null</code>로 처리한다.</li>
  <li>실패 원인은 warn 로그로 남기고 STT 저장 파이프라인은 유지한다.</li>
</ul>

<h3>문서 갱신</h3>
<ul>
  <li><code>docs/references/internal-api-contracts.md</code>에 <code>POST /internal/v1/speech</code> 응답 본문 예시를 추가했다.</li>
  <li><code>ai_answer</code>는 호출어가 감지되어 AI 답변이 생성된 경우에만 문자열로 내려간다고 명시했다.</li>
  <li>호출어가 없거나 AI 답변 생성에 실패하면 <code>ai_answer</code>는 null이라고 명시했다.</li>
</ul>

<h3>테스트에서 검증한 것</h3>
<ul>
  <li>호출어가 없으면 컨텍스트 조립과 AI 호출을 하지 않고 null을 반환하는지 검증했다.</li>
  <li>호출어가 있으면 질문을 추출하고 컨텍스트를 포함한 프롬프트로 AI 서비스를 호출하는지 검증했다.</li>
  <li>호출어만 있고 질문이 없으면 AI 답변을 생성하지 않는지 검증했다.</li>
  <li>AI 호출 실패 시 null을 반환하고 STT 흐름을 유지하는지 검증했다.</li>
  <li>STT API 응답에 <code>ai_answer</code>가 포함되는지 검증했다.</li>
  <li>AI 답변이 생성된 경우 응답의 <code>data.ai_answer</code>로 내려가는지 검증했다.</li>
  <li>AI 답변이 없는 경우 응답의 <code>data.ai_answer</code>가 null인지 검증했다.</li>
  <li><code>DisabledAiChatService</code>가 비활성 상태를 명확히 알리는 예외를 던지는지 검증했다.</li>
  <li><code>GlmAiChatService</code>가 실제 호출을 <code>GlmClient.chat()</code>으로 위임하는지 검증했다.</li>
</ul>

<h3>현재 범위</h3>
<ul>
  <li>이번 PR은 STT 발화 저장 흐름에 호출어 기반 AI 답변 생성 흐름을 연결하는 것까지 다룬다.</li>
  <li>실시간 음성 송출, Discord 채널로 AI 답변을 다시 보내는 기능은 이 PR 범위에 포함하지 않는다.</li>
  <li>GLM 호출은 설정으로 끄고 켤 수 있으며, 기본값은 안전하게 비활성 상태다.</li>
</ul>
<!--EndFragment-->
</body>
</html>
