### PR TITLE
[Feat] meeting종료 후 decision 추출 로직 구현

### DIFF
--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/AnalysisResult.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/AnalysisResult.java
@@ -3,4 +3,10 @@ package com.flodiback.domain.meeting.analysis.dto;
 import java.util.List;
 
 public record AnalysisResult(
-        String summary, String unresolvedItems, List<WorkLogItem> worklogs, List<DecisionItem> decisions) {}
+        String summary, String unresolvedItems, List<WorkLogItem> worklogs, List<DecisionItem> decisions) {
+
+    public AnalysisResult {
+        worklogs = worklogs != null ? worklogs : List.of();
+        decisions = decisions != null ? decisions : List.of();
+    }
+}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flodiback.domain.decision.decision.entity.Decision;
+import com.flodiback.domain.decision.decision.repository.DecisionRepository;
 import com.flodiback.domain.meeting.analysis.dto.AnalysisResult;
 import com.flodiback.domain.meeting.meeting.entity.ContextCache;
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
@@ -45,6 +47,7 @@ public class MeetingAnalysisService {
     private final ContextCacheRepository contextCacheRepository;
     private final UtteranceRepository utteranceRepository;
     private final MeetingSummaryRepository meetingSummaryRepository;
+    private final DecisionRepository decisionRepository;
     private final GlmClient glmClient;
     private final ObjectMapper objectMapper;
 
@@ -71,9 +74,17 @@ public class MeetingAnalysisService {
         // TODO: WorkLogService 구현 후 연동
         // result.worklogs().forEach(item -> ...);
 
-        // 6. Decision 저장 (스켈레톤)
-        // TODO: DecisionService 구현 후 연동 (embedding 포함)
-        // result.decisions().forEach(item -> ...);
+        // 6. Decision 저장
+        if (meeting.getProject() != null) {
+            result.decisions().forEach(item -> {
+                Decision decision = Decision.builder()
+                        .project(meeting.getProject())
+                        .meeting(meeting)
+                        .content(item.content())
+                        .build();
+                decisionRepository.save(decision);
+            });
+        }
     }
 
     private String buildContext(Meeting meeting) {

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
@@ -332,4 +332,31 @@ class MeetingAnalysisServiceTest {
         // then
         verify(decisionRepository, never()).save(any(Decision.class));
     }
+
+    @Test
+    void analyze_decisions_null일때_저장_스킵() throws Exception {
+        // given
+        Project project = Project.builder().name("테스트 프로젝트").build();
+        Meeting meeting = Meeting.builder().project(project).title("테스트 회의").build();
+
+        String glmResponse = """
+                {
+                  "summary": "요약",
+                  "unresolvedItems": null,
+                  "worklogs": [],
+                  "decisions": null
+                }
+                """;
+
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(contextCacheRepository.findByMeetingOrderByCreatedAtAsc(meeting)).willReturn(List.of());
+        given(utteranceRepository.findByMeetingOrderBySpokenAtAsc(meeting)).willReturn(List.of());
+        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponse);
+        given(objectMapper.readValue(anyString(), any(Class.class)))
+                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+
+        // when & then (NPE 없이 정상 종료)
+        service.analyze(1L);
+        verify(decisionRepository, never()).save(any(Decision.class));
+    }
 }

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
@@ -19,6 +21,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flodiback.domain.decision.decision.entity.Decision;
+import com.flodiback.domain.decision.decision.repository.DecisionRepository;
 import com.flodiback.domain.meeting.analysis.dto.AnalysisResult;
 import com.flodiback.domain.meeting.meeting.entity.ContextCache;
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
@@ -28,6 +32,7 @@ import com.flodiback.domain.meeting.meetinglog.entity.MeetingSummary;
 import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
 import com.flodiback.domain.meeting.meetinglog.repository.MeetingSummaryRepository;
 import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
+import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.global.client.GlmClient;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,6 +52,9 @@ class MeetingAnalysisServiceTest {
 
     @Mock
     private MeetingSummaryRepository meetingSummaryRepository;
+
+    @Mock
+    private DecisionRepository decisionRepository;
 
     @Mock
     private GlmClient glmClient;
@@ -222,5 +230,106 @@ class MeetingAnalysisServiceTest {
         assertThatThrownBy(() -> service.analyze(1L))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("GLM 응답 파싱 실패");
+    }
+
+    // ── Decision 저장 ─────────────────────────────────────────────────────────
+
+    @Test
+    void analyze_project있을때_decision_저장됨() throws Exception {
+        // given
+        Project project = Project.builder().name("테스트 프로젝트").build();
+        Meeting meeting = Meeting.builder().project(project).title("테스트 회의").build();
+
+        String glmResponse = """
+                {
+                  "summary": "요약",
+                  "unresolvedItems": null,
+                  "worklogs": [],
+                  "decisions": [
+                    { "content": "Next.js로 프론트엔드 기술 스택 확정" }
+                  ]
+                }
+                """;
+
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(contextCacheRepository.findByMeetingOrderByCreatedAtAsc(meeting)).willReturn(List.of());
+        given(utteranceRepository.findByMeetingOrderBySpokenAtAsc(meeting)).willReturn(List.of());
+        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponse);
+        given(objectMapper.readValue(anyString(), any(Class.class)))
+                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+
+        // when
+        service.analyze(1L);
+
+        // then
+        ArgumentCaptor<Decision> captor = ArgumentCaptor.forClass(Decision.class);
+        verify(decisionRepository).save(captor.capture());
+
+        Decision saved = captor.getValue();
+        assertThat(saved.getContent()).isEqualTo("Next.js로 프론트엔드 기술 스택 확정");
+        assertThat(saved.getMeeting()).isEqualTo(meeting);
+        assertThat(saved.getProject()).isEqualTo(project);
+    }
+
+    @Test
+    void analyze_decisions_여러개일때_모두저장() throws Exception {
+        // given
+        Project project = Project.builder().name("테스트 프로젝트").build();
+        Meeting meeting = Meeting.builder().project(project).title("테스트 회의").build();
+
+        String glmResponse = """
+                {
+                  "summary": "요약",
+                  "unresolvedItems": null,
+                  "worklogs": [],
+                  "decisions": [
+                    { "content": "결정 사항 1" },
+                    { "content": "결정 사항 2" }
+                  ]
+                }
+                """;
+
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(contextCacheRepository.findByMeetingOrderByCreatedAtAsc(meeting)).willReturn(List.of());
+        given(utteranceRepository.findByMeetingOrderBySpokenAtAsc(meeting)).willReturn(List.of());
+        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponse);
+        given(objectMapper.readValue(anyString(), any(Class.class)))
+                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+
+        // when
+        service.analyze(1L);
+
+        // then
+        verify(decisionRepository, times(2)).save(any(Decision.class));
+    }
+
+    @Test
+    void analyze_project없을때_decision_저장_스킵() throws Exception {
+        // given
+        Meeting meeting = Meeting.builder().title("프로젝트 없는 회의").build(); // project = null
+
+        String glmResponse = """
+                {
+                  "summary": "요약",
+                  "unresolvedItems": null,
+                  "worklogs": [],
+                  "decisions": [
+                    { "content": "저장되면 안 되는 결정 사항" }
+                  ]
+                }
+                """;
+
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(contextCacheRepository.findByMeetingOrderByCreatedAtAsc(meeting)).willReturn(List.of());
+        given(utteranceRepository.findByMeetingOrderBySpokenAtAsc(meeting)).willReturn(List.of());
+        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponse);
+        given(objectMapper.readValue(anyString(), any(Class.class)))
+                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+
+        // when
+        service.analyze(1L);
+
+        // then
+        verify(decisionRepository, never()).save(any(Decision.class));
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #32 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #32

---

## 📝 작업 내용

회의 분석(MeetingAnalysisService) 완료 시 GLM이 추출한 결정사항을 `decisions` 테이블에 자동 저장하는 로직을 구현했습니다.

프로젝트가 없는 회의(project=null)는 `Decision.project NOT NULL` 제약 때문에 저장을 스킵합니다.

---

## ✅ 주요 변경 사항

1) `MeetingAnalysisService` — `analyze()` 6번 스켈레톤을 실제 저장 로직으로 교체, `DecisionRepository` 주입

2) project null 방어 처리 — `meeting.getProject() != null` 조건으로 저장 스킵

3) `MeetingAnalysisServiceTest` — Decision 저장 관련 테스트 3개 추가 (단건 저장 / 다건 저장 / project null 스킵)

4) 'AnalysisResult'에서 decision, worklog가 null이 들어오는 경우 빈 리스트로 변환하도록 수정(NPE 방어)

---

## 🧪 테스트 결과

```bash

./gradlew test --tests "com.flodiback.domain.meeting.analysis.service.MeetingAnalysisServiceTest"
```

- 로컬 테스트 통과 (8개 전체)

- 기존 5개 테스트 영향 없음 확인

---

**👀 리뷰 포인트 (선택)**

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
