### PR TITLE
fix: Discord STT 파이프라인 안정화 (VAD/PCM/자막)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,8 @@ OPENAI_TRANSCRIBE_PROMPT=한국어 회의 대화입니다. 번역하지 말고 �
 GLM_API_KEY=your_glm_api_key
 GLM_MODEL=glm-5.1
 GLM_API_URL=grepp_url
+
+# STT debug dump (기본 off)
+STT_DEBUG_DUMP_WAV=false
+STT_DEBUG_DUMP_DIR=debug/stt-pcm
+STT_DEBUG_DUMP_SECONDS=5

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,8 @@ INTERNAL_API_KEY=
 OPENAI_API_KEY=your_openai_api_key
 OPENAI_REALTIME_WS_URL=wss://api.openai.com/v1/realtime?intent=transcription
 OPENAI_TRANSCRIBE_MODEL=gpt-4o-transcribe
+OPENAI_TRANSCRIBE_LANGUAGE=ko
+OPENAI_TRANSCRIBE_PROMPT=한국어 회의 대화입니다. 번역하지 말고 들리는 한국어를 그대로 전사하세요.
 GLM_API_KEY=your_glm_api_key
 GLM_MODEL=glm-5.1
 GLM_API_URL=grepp_url

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,6 @@ OPENAI_API_KEY=your_openai_api_key
 OPENAI_REALTIME_WS_URL=wss://api.openai.com/v1/realtime?intent=transcription
 OPENAI_TRANSCRIBE_MODEL=gpt-4o-transcribe
 OPENAI_TRANSCRIBE_LANGUAGE=ko
-OPENAI_TRANSCRIBE_PROMPT=한국어 회의 대화입니다. 번역하지 말고 들리는 한국어를 그대로 전사하세요.
 GLM_API_KEY=your_glm_api_key
 GLM_MODEL=glm-5.1
 GLM_API_URL=grepp_url

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,6 +105,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testAnnotationProcessor("org.projectlombok:lombok")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("com.orctom:vad4j:1.0")
 
     // Discord bot (JDA + DAVE)
     // JDA: Discord Gateway/REST 클라이언트 기본 SDK

--- a/docker-compose.bot.yml
+++ b/docker-compose.bot.yml
@@ -1,7 +1,7 @@
 services:
   discord-bot:
     image: eclipse-temurin:21-jdk
-    platform: linux/arm64/v8
+    platform: linux/amd64
     working_dir: /workspace
     volumes:
       - ./:/workspace

--- a/docker-compose.bot.yml
+++ b/docker-compose.bot.yml
@@ -10,9 +10,7 @@ services:
       - .env
     environment:
       ORG_GRADLE_JAVA_INSTALLATIONS_AUTO_DOWNLOAD: "true"
-    command: ["/bin/bash", "-lc", "./gradlew --no-daemon runDiscordBot"]
-    stdin_open: true
-    tty: true
+    command: ["/bin/bash", "-lc", "./gradlew --no-daemon --console=plain runDiscordBot"]
     restart: "no"
 
 volumes:

--- a/docs/references/discord-bot-jda-dave.md
+++ b/docs/references/discord-bot-jda-dave.md
@@ -18,7 +18,6 @@ export OPENAI_API_KEY=...
 export OPENAI_REALTIME_WS_URL='wss://api.openai.com/v1/realtime?intent=transcription'
 export OPENAI_TRANSCRIBE_MODEL=gpt-4o-transcribe
 export OPENAI_TRANSCRIBE_LANGUAGE=ko
-export OPENAI_TRANSCRIBE_PROMPT='한국어 회의 대화입니다. 번역하지 말고 들리는 한국어를 그대로 전사하세요.'
 ```
 
 Docker에서 봇을 실행하고 Spring 서버를 호스트 Mac에서 실행한다면 `INTERNAL_API_BASE_URL`은

--- a/docs/references/discord-bot-jda-dave.md
+++ b/docs/references/discord-bot-jda-dave.md
@@ -17,6 +17,8 @@ export INTERNAL_API_BASE_URL=http://localhost:8080
 export OPENAI_API_KEY=...
 export OPENAI_REALTIME_WS_URL='wss://api.openai.com/v1/realtime?intent=transcription'
 export OPENAI_TRANSCRIBE_MODEL=gpt-4o-transcribe
+export OPENAI_TRANSCRIBE_LANGUAGE=ko
+export OPENAI_TRANSCRIBE_PROMPT='한국어 회의 대화입니다. 번역하지 말고 들리는 한국어를 그대로 전사하세요.'
 ```
 
 Docker에서 봇을 실행하고 Spring 서버를 호스트 Mac에서 실행한다면 `INTERNAL_API_BASE_URL`은

--- a/src/main/java/com/flodiback/bot/DiscordBotMain.java
+++ b/src/main/java/com/flodiback/bot/DiscordBotMain.java
@@ -38,7 +38,7 @@ public final class DiscordBotMain {
         // canReceiveUser/Opus decode 경로는 native 준비 여부에 영향받는다.
         boolean opusReady = AudioNatives.ensureOpus();
         log.info(
-                "Audio natives status. supported={}, initialized={}, opusReady={}",
+                "[봇/오디오준비] supported={}, initialized={}, opusReady={}",
                 AudioNatives.isAudioSupported(),
                 AudioNatives.isInitialized(),
                 opusReady);
@@ -65,7 +65,7 @@ public final class DiscordBotMain {
                 .awaitReady();
 
         log.info(
-                "Discord bot ready. userId={}, username={}, prefix={}, defaultMeetingId={}",
+                "[봇/준비완료] userId={}, username={}, prefix={}, defaultMeetingId={}",
                 jda.getSelfUser().getId(),
                 jda.getSelfUser().getName(),
                 prefix,

--- a/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
+++ b/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
@@ -21,6 +21,9 @@ import com.flodiback.domain.speech.stt.SttProvider;
 import net.dv8tion.jda.api.audio.AudioReceiveHandler;
 import net.dv8tion.jda.api.audio.OpusPacket;
 import net.dv8tion.jda.api.audio.UserAudio;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 
 /**
  * 길드 단위 음성 수신 핸들러.
@@ -44,6 +47,8 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
     private final long meetingId;
     private final SttProvider sttProvider;
     private final ScheduledExecutorService silenceWatcher;
+    private final Guild guild;
+    private volatile MessageChannel captionChannel;
 
     // 사용자 ID별 누적 통계
     private final Map<Long, SpeakerStats> statsByUserId = new ConcurrentHashMap<>();
@@ -67,8 +72,9 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
     private final AtomicBoolean firstEncodedLogged = new AtomicBoolean(false);
     private final AtomicBoolean firstUserLogged = new AtomicBoolean(false);
 
-    public PerUserAudioReceiveHandler(long guildId, SttProvider sttProvider, long meetingId) {
+    public PerUserAudioReceiveHandler(long guildId, Guild guild, SttProvider sttProvider, long meetingId) {
         this.guildId = guildId;
+        this.guild = Objects.requireNonNull(guild);
         this.sttProvider = Objects.requireNonNull(sttProvider);
         this.meetingId = meetingId;
         this.silenceWatcher = Executors.newSingleThreadScheduledExecutor(new SilenceWatcherThreadFactory(guildId));
@@ -77,6 +83,10 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                 STT_SILENCE_WATCH_INTERVAL_MS,
                 STT_SILENCE_WATCH_INTERVAL_MS,
                 TimeUnit.MILLISECONDS);
+    }
+
+    public void updateCaptionChannel(MessageChannel captionChannel) {
+        this.captionChannel = captionChannel;
     }
 
     @Override
@@ -342,7 +352,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         }
 
         String speakerId = Long.toString(userId);
-        String normalizedSpeakerName = (speakerName == null || speakerName.isBlank()) ? "user-" + userId : speakerName;
+        String normalizedSpeakerName = resolveSpeakerName(userId, speakerName);
         String sessionId = guildId + ":" + speakerId + ":" + now;
 
         ActiveSttSession created = new ActiveSttSession(sessionId, speakerId, now);
@@ -353,7 +363,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
 
         try {
             // 세션 시작 시점에 결과 소비자(BotSttListener)를 함께 바인딩한다.
-            BotSttListener listener = new BotSttListener(meetingId, speakerId, normalizedSpeakerName);
+            BotSttListener listener = new BotSttListener(meetingId, speakerId, normalizedSpeakerName, captionChannel);
             sttProvider.startSession(sessionId, speakerId, listener);
             log.info(
                     "[STT/세션시작] guildId={}, meetingId={}, userId={}, sessionId={}, speakerName={}",
@@ -374,6 +384,25 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                     startException);
             return null;
         }
+    }
+
+    private String resolveSpeakerName(long userId, String fallbackSpeakerName) {
+        Member member = guild.getMemberById(userId);
+        if (member != null) {
+            String effectiveName = member.getEffectiveName();
+            if (effectiveName != null && !effectiveName.isBlank()) {
+                return effectiveName;
+            }
+            String userName = member.getUser().getName();
+            if (userName != null && !userName.isBlank()) {
+                return userName;
+            }
+        }
+
+        if (fallbackSpeakerName != null && !fallbackSpeakerName.isBlank()) {
+            return fallbackSpeakerName;
+        }
+        return "user-" + userId;
     }
 
     /**

--- a/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
+++ b/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
@@ -1,10 +1,10 @@
 package com.flodiback.bot.audio;
 
-import java.util.Comparator;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Deque;
-import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -309,15 +309,15 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                     + decodedPcmPackets
                     + ", decodedFromEncodedBytes="
                     + decodedPcmBytes
-                + ", activeSttSessions="
-                + activeSttSessionsByUserId.size()
-                + ", vadStartThreshold="
-                + vadStartThreshold.get()
-                + ", vadEndThreshold="
-                + vadEndThreshold.get()
-                + ", firstDecodeFailureReason="
-                + (decodeFailureReason == null ? "-" : decodeFailureReason)
-                + ")";
+                    + ", activeSttSessions="
+                    + activeSttSessionsByUserId.size()
+                    + ", vadStartThreshold="
+                    + vadStartThreshold.get()
+                    + ", vadEndThreshold="
+                    + vadEndThreshold.get()
+                    + ", firstDecodeFailureReason="
+                    + (decodeFailureReason == null ? "-" : decodeFailureReason)
+                    + ")";
         }
 
         StringBuilder builder = new StringBuilder("화자별 수신 통계 (encodedPackets="
@@ -451,7 +451,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         if (fallbackSpeakerName != null && !fallbackSpeakerName.isBlank()) {
             return fallbackSpeakerName;
         }
-            return "user-" + userId;
+        return "user-" + userId;
     }
 
     private void sendToActiveSession(ActiveSttSession session, long userId, byte[] pcm, long now) {
@@ -538,14 +538,12 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         ActiveSttSession activeSession = activeSttSessionsByUserId.get(userId);
         long startThreshold = vadStartThreshold.get();
         long endThreshold = vadEndThreshold.get();
-        boolean startSpeech =
-                speechEvidence.webRtcAvailable
-                        ? speechEvidence.webRtcScore >= VAD_START_PROB_THRESHOLD
-                        : speechEvidence.rms >= startThreshold;
-        boolean continueSpeech =
-                speechEvidence.webRtcAvailable
-                        ? speechEvidence.webRtcScore >= VAD_END_PROB_THRESHOLD
-                        : speechEvidence.rms >= endThreshold;
+        boolean startSpeech = speechEvidence.webRtcAvailable
+                ? speechEvidence.webRtcScore >= VAD_START_PROB_THRESHOLD
+                : speechEvidence.rms >= startThreshold;
+        boolean continueSpeech = speechEvidence.webRtcAvailable
+                ? speechEvidence.webRtcScore >= VAD_END_PROB_THRESHOLD
+                : speechEvidence.rms >= endThreshold;
 
         if (activeSession != null) {
             if (continueSpeech) {

--- a/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
+++ b/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
@@ -133,10 +133,11 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                 // 실시간 수신 루프에서 매 프레임 warn을 찍으면 로그가 폭증하므로 샘플링한다.
                 if (failures <= 3 || failures % 200 == 0) {
                     log.warn(
-                            "Failed to decode opus packet. guildId={}, userId={}, decodeFailures={}",
+                            "[음성/디코드실패] guildId={}, userId={}, decodeFailures={}, firstReason={}",
                             guildId,
                             userId,
                             failures,
+                            firstDecodeFailureReason.get() == null ? "-" : firstDecodeFailureReason.get(),
                             decodeException);
                 }
             }
@@ -146,20 +147,19 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         endInactiveSttSessions(now, userId);
 
         if (firstEncodedLogged.compareAndSet(false, true)) {
-            log.info(
-                    "[FIRST_ENCODED_AUDIO] guildId={}, firstUserId={}, encodedPackets={}",
-                    guildId,
-                    userId,
-                    encodedCount);
+            log.info("[음성/인코드첫수신] guildId={}, firstUserId={}, encodedPackets={}", guildId, userId, encodedCount);
         }
         if (encodedCount == 1 || encodedCount % LOG_INTERVAL_PACKETS == 0) {
             log.info(
-                    "Encoded audio received. guildId={}, encodedPackets={}, userId={}, userEncodedPackets={}, canDecode={}",
+                    "[음성/인코드수신] guildId={}, encodedPackets={}, userId={}, userEncodedPackets={}, canDecode={}, decodeFailures={}, userPackets={}, activeSttSessions={}",
                     guildId,
                     encodedCount,
                     userId,
                     userEncodedPackets,
-                    canDecode);
+                    canDecode,
+                    decodeFailureCount.get(),
+                    userPacketCount.get(),
+                    activeSttSessionsByUserId.size());
         }
     }
 
@@ -178,7 +178,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
 
         if (firstUserLogged.compareAndSet(false, true)) {
             log.info(
-                    "[FIRST_USER_AUDIO] guildId={}, userId={}, userName={}, frameBytes={}",
+                    "[음성/유저PCM첫수신] guildId={}, userId={}, userName={}, frameBytes={}",
                     guildId,
                     userId,
                     userName,
@@ -195,13 +195,15 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
 
         if (packetCount == 1 || packetCount % LOG_INTERVAL_PACKETS == 0) {
             log.info(
-                    "Audio receive stats. guildId={}, userId={}, userName={}, userPackets={}, bytes={}, totalUserPackets={}",
+                    "[음성/유저PCM수신] guildId={}, userId={}, userName={}, userPackets={}, bytes={}, totalUserPackets={}, encodedPackets={}, decodeFailures={}",
                     guildId,
                     userId,
                     userName,
                     packetCount,
                     stats.byteCount.get(),
-                    totalUserPackets);
+                    totalUserPackets,
+                    encodedPacketCount.get(),
+                    decodeFailureCount.get());
         }
     }
 
@@ -311,7 +313,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
             sttProvider.sendPcm(session.sessionId, decodedPcm, now);
         } catch (Exception sendException) {
             log.warn(
-                    "Failed to send PCM to STT. guildId={}, sessionId={}, userId={}",
+                    "[STT/PCM전달실패] guildId={}, sessionId={}, userId={}",
                     guildId,
                     session.sessionId,
                     userId,
@@ -343,7 +345,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
             BotSttListener listener = new BotSttListener(meetingId, speakerId, normalizedSpeakerName);
             sttProvider.startSession(sessionId, speakerId, listener);
             log.info(
-                    "STT session started. guildId={}, meetingId={}, userId={}, sessionId={}, speakerName={}",
+                    "[STT/세션시작] guildId={}, meetingId={}, userId={}, sessionId={}, speakerName={}",
                     guildId,
                     meetingId,
                     userId,
@@ -353,7 +355,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         } catch (Exception startException) {
             activeSttSessionsByUserId.remove(userId, created);
             log.warn(
-                    "Failed to start STT session. guildId={}, meetingId={}, userId={}, sessionId={}",
+                    "[STT/세션시작실패] guildId={}, meetingId={}, userId={}, sessionId={}",
                     guildId,
                     meetingId,
                     userId,
@@ -397,7 +399,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         try {
             sttProvider.endSession(session.sessionId);
             log.info(
-                    "STT session ended. guildId={}, meetingId={}, sessionId={}, speakerId={}, reason={}",
+                    "[STT/세션종료] guildId={}, meetingId={}, sessionId={}, speakerId={}, reason={}",
                     guildId,
                     meetingId,
                     session.sessionId,
@@ -405,7 +407,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                     reason);
         } catch (Exception endException) {
             log.warn(
-                    "Failed to end STT session. guildId={}, meetingId={}, sessionId={}, reason={}",
+                    "[STT/세션종료실패] guildId={}, meetingId={}, sessionId={}, reason={}",
                     guildId,
                     meetingId,
                     session.sessionId,
@@ -430,11 +432,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                 firstDecodeFailureReason.compareAndSet(null, "decodedShort is null/empty");
                 long failures = decodeFailureCount.incrementAndGet();
                 if (failures <= 3 || failures % 200 == 0) {
-                    log.warn(
-                            "Decoded short PCM is empty. guildId={}, userId={}, decodeFailures={}",
-                            guildId,
-                            userId,
-                            failures);
+                    log.warn("[음성/빈PCM] guildId={}, userId={}, decodeFailures={}", guildId, userId, failures);
                 }
                 return null;
             }

--- a/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
+++ b/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
@@ -4,6 +4,10 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,10 +37,13 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
     private static final long LOG_INTERVAL_PACKETS = 50;
     // 이 시간(ms) 동안 화자 오디오가 없으면 해당 STT 세션을 종료한다.
     private static final long STT_SILENCE_END_MS = 1500L;
+    // 무음 종료 감시 주기(ms)
+    private static final long STT_SILENCE_WATCH_INTERVAL_MS = 250L;
 
     private final long guildId;
     private final long meetingId;
     private final SttProvider sttProvider;
+    private final ScheduledExecutorService silenceWatcher;
 
     // 사용자 ID별 누적 통계
     private final Map<Long, SpeakerStats> statsByUserId = new ConcurrentHashMap<>();
@@ -64,6 +71,12 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         this.guildId = guildId;
         this.sttProvider = Objects.requireNonNull(sttProvider);
         this.meetingId = meetingId;
+        this.silenceWatcher = Executors.newSingleThreadScheduledExecutor(new SilenceWatcherThreadFactory(guildId));
+        this.silenceWatcher.scheduleAtFixedRate(
+                this::endInactiveSttSessionsOnSchedule,
+                STT_SILENCE_WATCH_INTERVAL_MS,
+                STT_SILENCE_WATCH_INTERVAL_MS,
+                TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -143,9 +156,6 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
             }
         }
 
-        // 현재 화자 외 세션 중 무음 초과 세션을 정리한다.
-        endInactiveSttSessions(now, userId);
-
         if (firstEncodedLogged.compareAndSet(false, true)) {
             log.info("[음성/인코드첫수신] guildId={}, firstUserId={}, encodedPackets={}", guildId, userId, encodedCount);
         }
@@ -211,6 +221,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
      * 길드 음성 세션을 명시적으로 종료할 때(예: !leave) 모든 STT 세션을 end(commit)한다.
      */
     public void closeAllSttSessions() {
+        silenceWatcher.shutdownNow();
         for (Map.Entry<Long, ActiveSttSession> entry : activeSttSessionsByUserId.entrySet()) {
             Long userId = entry.getKey();
             ActiveSttSession activeSession = entry.getValue();
@@ -368,18 +379,12 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
     /**
      * 무음 세션을 종료한다.
      *
-     * @param now 현재 시각(ms)
-     * @param speakingUserId 지금 오디오가 들어온 사용자 ID(해당 사용자는 종료 제외)
-     * @implNote 현재 구현은 "오디오 패킷이 들어올 때" 무음 체크를 수행한다.
-     *     따라서 완전 무음 상태에서는 다음 패킷 또는 !leave 시점에 종료가 반영된다.
+     * @implNote 스케줄러가 주기적으로 검사하므로, 다른 사용자의 패킷 도착 여부와 무관하게 종료된다.
      */
-    private void endInactiveSttSessions(long now, long speakingUserId) {
+    private void endInactiveSttSessionsOnSchedule() {
+        long now = System.currentTimeMillis();
         for (Map.Entry<Long, ActiveSttSession> entry : activeSttSessionsByUserId.entrySet()) {
             Long userId = entry.getKey();
-            if (userId == speakingUserId) {
-                continue;
-            }
-
             ActiveSttSession session = entry.getValue();
             long silenceMs = now - session.lastAudioAtMs.get();
             if (silenceMs < STT_SILENCE_END_MS) {
@@ -456,6 +461,21 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
             this.sessionId = sessionId;
             this.speakerId = speakerId;
             this.lastAudioAtMs.set(startedAtMs);
+        }
+    }
+
+    private static final class SilenceWatcherThreadFactory implements ThreadFactory {
+        private final long guildId;
+
+        private SilenceWatcherThreadFactory(long guildId) {
+            this.guildId = guildId;
+        }
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = new Thread(runnable, "stt-silence-watcher-guild-" + guildId);
+            thread.setDaemon(true);
+            return thread;
         }
     }
 

--- a/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
+++ b/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
@@ -1,6 +1,11 @@
 package com.flodiback.bot.audio;
 
 import java.util.Comparator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.ArrayDeque;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -17,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import com.flodiback.bot.stt.BotSttListener;
 import com.flodiback.domain.speech.stt.SttProvider;
+import com.orctom.vad4j.VAD;
 
 import net.dv8tion.jda.api.audio.AudioReceiveHandler;
 import net.dv8tion.jda.api.audio.OpusPacket;
@@ -39,9 +45,16 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
     // 로그 과다 방지를 위한 주기
     private static final long LOG_INTERVAL_PACKETS = 50;
     // 이 시간(ms) 동안 화자 오디오가 없으면 해당 STT 세션을 종료한다.
-    private static final long STT_SILENCE_END_MS = 1500L;
+    private static final long STT_SILENCE_END_MS = 1800L;
     // 무음 종료 감시 주기(ms)
     private static final long STT_SILENCE_WATCH_INTERVAL_MS = 250L;
+    private static final int VAD_START_RMS_THRESHOLD = 600;
+    private static final int VAD_END_RMS_THRESHOLD = 500;
+    private static final float VAD_START_PROB_THRESHOLD = 0.62f;
+    private static final float VAD_END_PROB_THRESHOLD = 0.45f;
+    private static final int VAD_MIN_CONSECUTIVE_SPEECH_FRAMES = 3;
+    private static final int VAD_PREROLL_MS = 400;
+    private static final long VAD_CALIBRATION_WINDOW_MS = 180_000L;
 
     private final long guildId;
     private final long meetingId;
@@ -52,6 +65,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
 
     // 사용자 ID별 누적 통계
     private final Map<Long, SpeakerStats> statsByUserId = new ConcurrentHashMap<>();
+    private final Map<Long, VAD> webRtcVadByUserId = new ConcurrentHashMap<>();
     // 사용자 ID별 활성 STT 세션
     private final Map<Long, ActiveSttSession> activeSttSessionsByUserId = new ConcurrentHashMap<>();
 
@@ -71,6 +85,13 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
     // 첫 수신 순간 강조 로그 플래그
     private final AtomicBoolean firstEncodedLogged = new AtomicBoolean(false);
     private final AtomicBoolean firstUserLogged = new AtomicBoolean(false);
+    private final AtomicBoolean webRtcVadUnavailableLogged = new AtomicBoolean(false);
+    private final AtomicLong vadStartThreshold = new AtomicLong(VAD_START_RMS_THRESHOLD);
+    private final AtomicLong vadEndThreshold = new AtomicLong(VAD_END_RMS_THRESHOLD);
+    private final AtomicLong calibrationStartedAtMs = new AtomicLong(System.currentTimeMillis());
+    private final AtomicBoolean calibrationDone = new AtomicBoolean(false);
+    private final List<Integer> calibrationNoiseRms = new ArrayList<>();
+    private final List<Integer> calibrationSpeechRms = new ArrayList<>();
 
     public PerUserAudioReceiveHandler(long guildId, Guild guild, SttProvider sttProvider, long meetingId) {
         this.guildId = guildId;
@@ -147,8 +168,26 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                 stats.decodedPcmPacketCount.incrementAndGet();
                 stats.decodedPcmByteCount.addAndGet(decodedPcm.length);
 
-                // 디코딩 성공 시점에만 STT로 실제 PCM을 전달한다.
-                forwardPcmToStt(userId, stats.userName, decodedPcm, now);
+                int rms = calculateRms(decodedPcm);
+                maybeCalibrateVad(now, rms);
+                SpeechEvidence speechEvidence = detectSpeechEvidence(userId, decodedPcm, rms);
+
+                ForwardDecision decision = evaluateVad(userId, stats, decodedPcm, speechEvidence, now);
+                if (decision == ForwardDecision.DROP) {
+                    // no-op
+                } else if (decision == ForwardDecision.START_WITH_PREROLL) {
+                    ActiveSttSession session = getOrCreateSttSession(userId, stats.userName, now);
+                    if (session == null) {
+                        // no-op
+                    } else {
+                        session.lastAudioAtMs.set(now);
+                        for (byte[] preRollFrame : stats.preRollBuffer.drain()) {
+                            sendToActiveSession(session, userId, preRollFrame, now);
+                        }
+                    }
+                } else {
+                    forwardPcmToStt(userId, stats.userName, decodedPcm, now);
+                }
             } catch (Exception decodeException) {
                 nonDecodableEncodedPackets.incrementAndGet();
                 firstDecodeFailureReason.compareAndSet(null, decodeException.getMessage());
@@ -239,6 +278,10 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                 safelyEndSession(activeSession, "manual_close_all");
             }
         }
+        for (VAD vad : webRtcVadByUserId.values()) {
+            closeVadQuietly(vad);
+        }
+        webRtcVadByUserId.clear();
     }
 
     /**
@@ -266,11 +309,15 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                     + decodedPcmPackets
                     + ", decodedFromEncodedBytes="
                     + decodedPcmBytes
-                    + ", activeSttSessions="
-                    + activeSttSessionsByUserId.size()
-                    + ", firstDecodeFailureReason="
-                    + (decodeFailureReason == null ? "-" : decodeFailureReason)
-                    + ")";
+                + ", activeSttSessions="
+                + activeSttSessionsByUserId.size()
+                + ", vadStartThreshold="
+                + vadStartThreshold.get()
+                + ", vadEndThreshold="
+                + vadEndThreshold.get()
+                + ", firstDecodeFailureReason="
+                + (decodeFailureReason == null ? "-" : decodeFailureReason)
+                + ")";
         }
 
         StringBuilder builder = new StringBuilder("화자별 수신 통계 (encodedPackets="
@@ -311,7 +358,9 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                             .append(", userPackets=")
                             .append(stats.packetCount.get())
                             .append(", userBytes=")
-                            .append(stats.byteCount.get());
+                            .append(stats.byteCount.get())
+                            .append(", vadState=")
+                            .append(stats.vadState);
                 });
         return builder.toString();
     }
@@ -331,7 +380,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         session.lastAudioAtMs.set(now);
 
         try {
-            sttProvider.sendPcm(session.sessionId, decodedPcm, now);
+            sendToActiveSession(session, userId, decodedPcm, now);
         } catch (Exception sendException) {
             log.warn(
                     "[STT/PCM전달실패] guildId={}, sessionId={}, userId={}",
@@ -402,7 +451,12 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         if (fallbackSpeakerName != null && !fallbackSpeakerName.isBlank()) {
             return fallbackSpeakerName;
         }
-        return "user-" + userId;
+            return "user-" + userId;
+    }
+
+    private void sendToActiveSession(ActiveSttSession session, long userId, byte[] pcm, long now) {
+        session.lastAudioAtMs.set(now);
+        sttProvider.sendPcm(session.sessionId, pcm, now);
     }
 
     /**
@@ -478,6 +532,220 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         }
     }
 
+    private ForwardDecision evaluateVad(
+            long userId, SpeakerStats stats, byte[] decodedPcm, SpeechEvidence speechEvidence, long now) {
+        stats.preRollBuffer.add(decodedPcm);
+        ActiveSttSession activeSession = activeSttSessionsByUserId.get(userId);
+        long startThreshold = vadStartThreshold.get();
+        long endThreshold = vadEndThreshold.get();
+        boolean startSpeech =
+                speechEvidence.webRtcAvailable
+                        ? speechEvidence.webRtcScore >= VAD_START_PROB_THRESHOLD
+                        : speechEvidence.rms >= startThreshold;
+        boolean continueSpeech =
+                speechEvidence.webRtcAvailable
+                        ? speechEvidence.webRtcScore >= VAD_END_PROB_THRESHOLD
+                        : speechEvidence.rms >= endThreshold;
+
+        if (activeSession != null) {
+            if (continueSpeech) {
+                stats.vadState = VadState.IN_SPEECH;
+                stats.trailingSilenceStartedAtMs.set(0L);
+                return ForwardDecision.FORWARD;
+            }
+            if (stats.trailingSilenceStartedAtMs.get() == 0L) {
+                stats.trailingSilenceStartedAtMs.set(now);
+            }
+            stats.vadState = VadState.TRAILING_SILENCE;
+            return ForwardDecision.DROP;
+        }
+
+        if (startSpeech) {
+            long consecutive = stats.consecutiveSpeechFrames.incrementAndGet();
+            stats.vadState = VadState.SPEECH_CANDIDATE;
+            if (consecutive >= VAD_MIN_CONSECUTIVE_SPEECH_FRAMES) {
+                stats.consecutiveSpeechFrames.set(0L);
+                stats.trailingSilenceStartedAtMs.set(0L);
+                stats.vadState = VadState.IN_SPEECH;
+                return ForwardDecision.START_WITH_PREROLL;
+            }
+            return ForwardDecision.DROP;
+        }
+
+        if (continueSpeech && stats.vadState == VadState.SPEECH_CANDIDATE) {
+            return ForwardDecision.DROP;
+        }
+
+        stats.consecutiveSpeechFrames.set(0L);
+        stats.trailingSilenceStartedAtMs.set(0L);
+        stats.vadState = VadState.IDLE;
+        return ForwardDecision.DROP;
+    }
+
+    private int calculateRms(byte[] decodedPcm) {
+        if (decodedPcm == null || decodedPcm.length < 2) {
+            return 0;
+        }
+
+        long sumSquare = 0L;
+        int sampleCount = 0;
+        // JDA 출력은 16-bit signed big-endian PCM
+        for (int index = 0; index + 1 < decodedPcm.length; index += 2) {
+            int high = decodedPcm[index] & 0xFF;
+            int low = decodedPcm[index + 1] & 0xFF;
+            short sample = (short) ((high << 8) | low);
+            int value = sample;
+            sumSquare += (long) value * value;
+            sampleCount++;
+        }
+
+        if (sampleCount == 0) {
+            return 0;
+        }
+        return (int) Math.sqrt(sumSquare / (double) sampleCount);
+    }
+
+    private SpeechEvidence detectSpeechEvidence(long userId, byte[] decodedPcm, int rms) {
+        VAD vad = getOrCreateWebRtcVad(userId);
+        if (vad == null) {
+            return SpeechEvidence.rmsOnly(rms);
+        }
+
+        byte[] mono48kLe = toMono48kLe(decodedPcm);
+        try {
+            float score = vad.speechProbability(mono48kLe);
+            return SpeechEvidence.webRtc(score, rms);
+        } catch (Exception exception) {
+            if (webRtcVadUnavailableLogged.compareAndSet(false, true)) {
+                log.warn("[VAD/WEBRTC폴백] guildId={}, reason={}", guildId, exception.toString());
+            }
+            webRtcVadByUserId.remove(userId, vad);
+            closeVadQuietly(vad);
+            return SpeechEvidence.rmsOnly(rms);
+        }
+    }
+
+    private VAD getOrCreateWebRtcVad(long userId) {
+        VAD existing = webRtcVadByUserId.get(userId);
+        if (existing != null) {
+            return existing;
+        }
+
+        try {
+            VAD created = new VAD();
+            VAD previous = webRtcVadByUserId.putIfAbsent(userId, created);
+            if (previous != null) {
+                closeVadQuietly(created);
+                return previous;
+            }
+            return created;
+        } catch (Throwable throwable) {
+            if (webRtcVadUnavailableLogged.compareAndSet(false, true)) {
+                log.warn("[VAD/WEBRTC사용불가] guildId={}, fallback=RMS, reason={}", guildId, throwable.toString());
+            }
+            return null;
+        }
+    }
+
+    private void closeVadQuietly(VAD vad) {
+        try {
+            vad.close();
+        } catch (Exception ignored) {
+            // no-op
+        }
+    }
+
+    private byte[] toMono48kLe(byte[] stereoBe) {
+        if (stereoBe == null || stereoBe.length < 4) {
+            return new byte[0];
+        }
+
+        int stereoFrameSize = 4;
+        int frameCount = stereoBe.length / stereoFrameSize;
+        byte[] monoLe = new byte[frameCount * 2];
+        int out = 0;
+        for (int frame = 0; frame < frameCount; frame++) {
+            int index = frame * stereoFrameSize;
+            short left = (short) (((stereoBe[index] & 0xFF) << 8) | (stereoBe[index + 1] & 0xFF));
+            short right = (short) (((stereoBe[index + 2] & 0xFF) << 8) | (stereoBe[index + 3] & 0xFF));
+            short mono = (short) ((left + right) / 2);
+            monoLe[out++] = (byte) (mono & 0xFF);
+            monoLe[out++] = (byte) ((mono >>> 8) & 0xFF);
+        }
+        return monoLe;
+    }
+
+    private void maybeCalibrateVad(long now, int rms) {
+        if (calibrationDone.get()) {
+            return;
+        }
+
+        long startedAt = calibrationStartedAtMs.get();
+        if (now - startedAt <= VAD_CALIBRATION_WINDOW_MS) {
+            synchronized (calibrationNoiseRms) {
+                if (rms >= vadStartThreshold.get()) {
+                    calibrationSpeechRms.add(rms);
+                } else {
+                    calibrationNoiseRms.add(rms);
+                }
+            }
+            return;
+        }
+
+        if (!calibrationDone.compareAndSet(false, true)) {
+            return;
+        }
+
+        int[] noise;
+        int[] speech;
+        synchronized (calibrationNoiseRms) {
+            noise = calibrationNoiseRms.stream().mapToInt(Integer::intValue).toArray();
+            speech = calibrationSpeechRms.stream().mapToInt(Integer::intValue).toArray();
+        }
+
+        if (noise.length == 0) {
+            log.info(
+                    "[VAD/캘리브레이션] guildId={}, noise 샘플 부족으로 기본 임계값 유지(start={}, end={})",
+                    guildId,
+                    vadStartThreshold.get(),
+                    vadEndThreshold.get());
+            return;
+        }
+
+        Arrays.sort(noise);
+        Arrays.sort(speech);
+        int noiseP95 = percentile(noise, 95);
+        int speechP50 = speech.length == 0 ? 0 : percentile(speech, 50);
+        int speechP95 = speech.length == 0 ? 0 : percentile(speech, 95);
+
+        long suggestedStart = Math.max(VAD_START_RMS_THRESHOLD, Math.round(noiseP95 * 1.8));
+        long suggestedEnd = Math.max(VAD_END_RMS_THRESHOLD, Math.round(noiseP95 * 1.2));
+        if (suggestedEnd >= suggestedStart) {
+            suggestedEnd = Math.max(VAD_END_RMS_THRESHOLD, suggestedStart - 100);
+        }
+
+        vadStartThreshold.set(suggestedStart);
+        vadEndThreshold.set(suggestedEnd);
+
+        log.info(
+                "[VAD/캘리브레이션완료] guildId={}, noiseP95={}, speechP50={}, speechP95={}, appliedStart={}, appliedEnd={}",
+                guildId,
+                noiseP95,
+                speechP50,
+                speechP95,
+                suggestedStart,
+                suggestedEnd);
+    }
+
+    private int percentile(int[] sortedValues, int percentile) {
+        if (sortedValues.length == 0) {
+            return 0;
+        }
+        int index = (int) Math.ceil((percentile / 100.0) * sortedValues.length) - 1;
+        index = Math.max(0, Math.min(index, sortedValues.length - 1));
+        return sortedValues[index];
+    }
+
     /**
      * 화자별 활성 STT 세션 상태.
      */
@@ -517,9 +785,13 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
         private final AtomicLong encodedByteCount = new AtomicLong();
         private final AtomicLong decodedPcmPacketCount = new AtomicLong();
         private final AtomicLong decodedPcmByteCount = new AtomicLong();
+        private final AtomicLong consecutiveSpeechFrames = new AtomicLong();
+        private final AtomicLong trailingSilenceStartedAtMs = new AtomicLong();
         private final AtomicLong packetCount = new AtomicLong();
         private final AtomicLong byteCount = new AtomicLong();
         private final AtomicLong lastSeenAtMs = new AtomicLong();
+        private final PreRollBuffer preRollBuffer = new PreRollBuffer(VAD_PREROLL_MS);
+        private volatile VadState vadState = VadState.IDLE;
 
         private SpeakerStats(String userName) {
             this.userName = userName;
@@ -532,6 +804,71 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
             if (this.userName != null && this.userName.startsWith("user-")) {
                 this.userName = candidateName;
             }
+        }
+    }
+
+    private enum VadState {
+        IDLE,
+        SPEECH_CANDIDATE,
+        IN_SPEECH,
+        TRAILING_SILENCE
+    }
+
+    private enum ForwardDecision {
+        DROP,
+        FORWARD,
+        START_WITH_PREROLL
+    }
+
+    private static final class SpeechEvidence {
+        private final boolean webRtcAvailable;
+        private final float webRtcScore;
+        private final int rms;
+
+        private SpeechEvidence(boolean webRtcAvailable, float webRtcScore, int rms) {
+            this.webRtcAvailable = webRtcAvailable;
+            this.webRtcScore = webRtcScore;
+            this.rms = rms;
+        }
+
+        private static SpeechEvidence webRtc(float webRtcScore, int rms) {
+            return new SpeechEvidence(true, webRtcScore, rms);
+        }
+
+        private static SpeechEvidence rmsOnly(int rms) {
+            return new SpeechEvidence(false, 0f, rms);
+        }
+    }
+
+    private static final class PreRollBuffer {
+        private static final int SAMPLE_RATE = 48_000;
+        private static final int CHANNELS = 2;
+        private static final int BYTES_PER_SAMPLE = 2;
+
+        private final int maxBytes;
+        private final Deque<byte[]> frames = new ArrayDeque<>();
+        private int totalBytes = 0;
+
+        private PreRollBuffer(int preRollMs) {
+            this.maxBytes = (int) ((long) SAMPLE_RATE * CHANNELS * BYTES_PER_SAMPLE * preRollMs / 1000L);
+        }
+
+        private void add(byte[] frame) {
+            byte[] copy = Arrays.copyOf(frame, frame.length);
+            frames.addLast(copy);
+            totalBytes += copy.length;
+
+            while (totalBytes > maxBytes && !frames.isEmpty()) {
+                byte[] removed = frames.removeFirst();
+                totalBytes -= removed.length;
+            }
+        }
+
+        private List<byte[]> drain() {
+            List<byte[]> drained = new ArrayList<>(frames);
+            frames.clear();
+            totalBytes = 0;
+            return drained;
         }
     }
 }

--- a/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
+++ b/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
@@ -93,9 +93,20 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
     private final List<Integer> calibrationNoiseRms = new ArrayList<>();
     private final List<Integer> calibrationSpeechRms = new ArrayList<>();
 
+    /**
+     * 하위 호환 생성자.
+     *
+     * @deprecated Guild 기반 화자명 조회를 쓰려면
+     *     {@link #PerUserAudioReceiveHandler(long, Guild, SttProvider, long)} 생성자를 사용하세요.
+     */
+    @Deprecated(forRemoval = false)
+    public PerUserAudioReceiveHandler(long guildId, SttProvider sttProvider, long meetingId) {
+        this(guildId, null, sttProvider, meetingId);
+    }
+
     public PerUserAudioReceiveHandler(long guildId, Guild guild, SttProvider sttProvider, long meetingId) {
         this.guildId = guildId;
-        this.guild = Objects.requireNonNull(guild);
+        this.guild = guild;
         this.sttProvider = Objects.requireNonNull(sttProvider);
         this.meetingId = meetingId;
         this.silenceWatcher = Executors.newSingleThreadScheduledExecutor(new SilenceWatcherThreadFactory(guildId));
@@ -436,15 +447,17 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
     }
 
     private String resolveSpeakerName(long userId, String fallbackSpeakerName) {
-        Member member = guild.getMemberById(userId);
-        if (member != null) {
-            String effectiveName = member.getEffectiveName();
-            if (effectiveName != null && !effectiveName.isBlank()) {
-                return effectiveName;
-            }
-            String userName = member.getUser().getName();
-            if (userName != null && !userName.isBlank()) {
-                return userName;
+        if (guild != null) {
+            Member member = guild.getMemberById(userId);
+            if (member != null) {
+                String effectiveName = member.getEffectiveName();
+                if (effectiveName != null && !effectiveName.isBlank()) {
+                    return effectiveName;
+                }
+                String userName = member.getUser().getName();
+                if (userName != null && !userName.isBlank()) {
+                    return userName;
+                }
             }
         }
 

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -109,7 +109,7 @@ public class DiscordCommandListener extends ListenerAdapter {
                 .queue();
 
         log.info(
-                "Joined voice channel. guildId={}, channelId={}, channelName={}, meetingId={}",
+                "[디스코드/입장] guildId={}, channelId={}, channelName={}, meetingId={}",
                 event.getGuild().getId(),
                 targetChannel.getId(),
                 targetChannel.getName(),
@@ -131,7 +131,7 @@ public class DiscordCommandListener extends ListenerAdapter {
         audioManager.setReceivingHandler(null);
 
         event.getChannel().sendMessage("퇴장 완료").queue();
-        log.info("Left voice channel. guildId={}", event.getGuild().getId());
+        log.info("[디스코드/퇴장] guildId={}", event.getGuild().getId());
     }
 
     private void handleStats(MessageReceivedEvent event) {

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -91,7 +91,8 @@ public class DiscordCommandListener extends ListenerAdapter {
         // (디스코드 특성상 봇 1개는 길드 내 음성 채널 1개 연결만 가능)
         PerUserAudioReceiveHandler handler = receiveHandlers.computeIfAbsent(
                 event.getGuild().getIdLong(),
-                guildId -> new PerUserAudioReceiveHandler(guildId, sttProvider, defaultMeetingId));
+                guildId -> new PerUserAudioReceiveHandler(guildId, event.getGuild(), sttProvider, defaultMeetingId));
+        handler.updateCaptionChannel(event.getChannel());
 
         // 오디오 수신 핸들러 연결 + 음성 연결
         audioManager.setReceivingHandler(handler);
@@ -103,10 +104,13 @@ public class DiscordCommandListener extends ListenerAdapter {
         audioManager.openAudioConnection(targetChannel);
 
         event.getChannel()
-                .sendMessage("입장 완료: "
+                .sendMessage("입장 요청 완료: "
                         + targetChannel.getName()
-                        + " | status="
+                        + " | 현재상태="
                         + audioManager.getConnectionStatus()
+                        + " (오디오 연결은 비동기로 진행됨)"
+                        + ", connected="
+                        + audioManager.isConnected()
                         + ", selfMuted="
                         + audioManager.isSelfMuted()
                         + ", selfDeafened="

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -11,7 +11,10 @@ import com.flodiback.bot.audio.PerUserAudioReceiveHandler;
 import com.flodiback.domain.speech.stt.SttProvider;
 import com.flodiback.domain.speech.stt.provider.openai.OpenAiSttProvider;
 
+import net.dv8tion.jda.api.audio.hooks.ConnectionListener;
+import net.dv8tion.jda.api.audio.hooks.ConnectionStatus;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -92,6 +95,8 @@ public class DiscordCommandListener extends ListenerAdapter {
 
         // 오디오 수신 핸들러 연결 + 음성 연결
         audioManager.setReceivingHandler(handler);
+        audioManager.setConnectionListener(
+                new LoggingConnectionListener(event.getGuild().getIdLong(), targetChannel));
         audioManager.setAutoReconnect(true);
         audioManager.setSelfMuted(false);
         audioManager.setSelfDeafened(false);
@@ -109,11 +114,13 @@ public class DiscordCommandListener extends ListenerAdapter {
                 .queue();
 
         log.info(
-                "[디스코드/입장] guildId={}, channelId={}, channelName={}, meetingId={}",
+                "[디스코드/입장] guildId={}, channelId={}, channelName={}, meetingId={}, voiceMemberCount={}, voiceMembers={}",
                 event.getGuild().getId(),
                 targetChannel.getId(),
                 targetChannel.getName(),
-                defaultMeetingId);
+                defaultMeetingId,
+                targetChannel.getMembers().size(),
+                summarizeVoiceMembers(targetChannel));
     }
 
     private void handleLeave(MessageReceivedEvent event) {
@@ -129,6 +136,7 @@ public class DiscordCommandListener extends ListenerAdapter {
         // 디스코드 음성 연결 종료 + 핸들러 해제
         audioManager.closeAudioConnection();
         audioManager.setReceivingHandler(null);
+        audioManager.setConnectionListener(null);
 
         event.getChannel().sendMessage("퇴장 완료").queue();
         log.info("[디스코드/퇴장] guildId={}", event.getGuild().getId());
@@ -155,5 +163,50 @@ public class DiscordCommandListener extends ListenerAdapter {
         event.getChannel()
                 .sendMessage(connectionSummary + "\n" + handler.getStatsSummary())
                 .queue();
+    }
+
+    private String summarizeVoiceMembers(AudioChannel channel) {
+        if (channel.getMembers().isEmpty()) {
+            return "-";
+        }
+        return channel.getMembers().stream()
+                .map(member -> member.getId() + ":" + member.getUser().getName())
+                .limit(10)
+                .reduce((left, right) -> left + ", " + right)
+                .orElse("-");
+    }
+
+    private final class LoggingConnectionListener implements ConnectionListener {
+        private final long guildId;
+        private final String channelId;
+        private final String channelName;
+
+        private LoggingConnectionListener(long guildId, AudioChannel channel) {
+            this.guildId = guildId;
+            this.channelId = channel.getId();
+            this.channelName = channel.getName();
+        }
+
+        @Override
+        public void onStatusChange(ConnectionStatus status) {
+            log.info(
+                    "[디스코드/오디오상태] guildId={}, channelId={}, channelName={}, status={}",
+                    guildId,
+                    channelId,
+                    channelName,
+                    status);
+        }
+
+        @Override
+        public void onUserSpeakingModeUpdate(
+                User user, java.util.EnumSet<net.dv8tion.jda.api.audio.SpeakingMode> modes) {
+            log.debug(
+                    "[디스코드/말하기상태] guildId={}, channelId={}, userId={}, userName={}, modes={}",
+                    guildId,
+                    channelId,
+                    user.getId(),
+                    user.getName(),
+                    modes);
+        }
     }
 }

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -5,7 +5,13 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDateTime;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
@@ -28,6 +34,10 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
  */
 public class BotSttListener implements SttListener {
     private static final Logger log = LoggerFactory.getLogger(BotSttListener.class);
+    private static final long CAPTION_DEBOUNCE_MS = 300L;
+    private static final int CAPTION_MIN_CHARS = 2;
+    private static final ScheduledExecutorService CAPTION_DEBOUNCE_EXECUTOR =
+            Executors.newSingleThreadScheduledExecutor(new CaptionDebounceThreadFactory());
 
     private final HttpClient httpClient = HttpClient.newHttpClient();
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -44,6 +54,9 @@ public class BotSttListener implements SttListener {
     private final AtomicBoolean desiredCaptionFinal = new AtomicBoolean(false);
     private final AtomicBoolean captionMessageCreating = new AtomicBoolean(false);
     private final AtomicBoolean captionEditInFlight = new AtomicBoolean(false);
+    private final AtomicReference<ScheduledFuture<?>> pendingPartialTask = new AtomicReference<>();
+    private final AtomicReference<String> pendingPartialText = new AtomicReference<>("");
+    private final AtomicLong pendingPartialVersion = new AtomicLong();
 
     public BotSttListener(long meetingId, String speakerDiscordId, String speakerName) {
         this(meetingId, speakerDiscordId, speakerName, null);
@@ -64,7 +77,10 @@ public class BotSttListener implements SttListener {
         if (!result.isFinal()) {
             String partialText = result.text();
             if (partialText != null && !partialText.isBlank()) {
-                upsertLiveCaption(partialText, false);
+                int charCount = partialText.codePointCount(0, partialText.length());
+                if (charCount >= CAPTION_MIN_CHARS) {
+                    schedulePartialCaptionUpdate(partialText);
+                }
                 log.info(
                         "[STT/중간텍스트] sessionId={}, speakerId={}, meetingId={}, text={}",
                         result.sessionId(),
@@ -81,6 +97,7 @@ public class BotSttListener implements SttListener {
             return;
         }
 
+        cancelPendingPartialTask();
         upsertLiveCaption(text, true);
 
         try {
@@ -162,6 +179,8 @@ public class BotSttListener implements SttListener {
 
     @Override
     public void onError(String sessionId, Throwable throwable) {
+        cancelPendingPartialTask();
+        clearLiveCaptionMessage();
         log.warn(
                 "[STT/오류] sessionId={}, speakerId={}, meetingId={}", sessionId, speakerDiscordId, meetingId, throwable);
     }
@@ -189,6 +208,34 @@ public class BotSttListener implements SttListener {
         desiredCaptionContent.set(formatCaption(text, isFinal));
         desiredCaptionFinal.set(isFinal);
         syncLiveCaption();
+    }
+
+    private void schedulePartialCaptionUpdate(String partialText) {
+        long version = pendingPartialVersion.incrementAndGet();
+        pendingPartialText.set(partialText);
+        ScheduledFuture<?> previous = pendingPartialTask.getAndSet(CAPTION_DEBOUNCE_EXECUTOR.schedule(() -> {
+            if (version != pendingPartialVersion.get()) {
+                return;
+            }
+            String latest = pendingPartialText.getAndSet("");
+            if (latest != null && !latest.isBlank()) {
+                upsertLiveCaption(latest, false);
+            }
+            pendingPartialTask.set(null);
+        }, CAPTION_DEBOUNCE_MS, TimeUnit.MILLISECONDS));
+
+        if (previous != null) {
+            previous.cancel(false);
+        }
+    }
+
+    private void cancelPendingPartialTask() {
+        ScheduledFuture<?> pending = pendingPartialTask.getAndSet(null);
+        if (pending != null) {
+            pending.cancel(false);
+        }
+        pendingPartialText.set("");
+        pendingPartialVersion.incrementAndGet();
     }
 
     private void syncLiveCaption() {
@@ -269,5 +316,29 @@ public class BotSttListener implements SttListener {
         desiredCaptionFinal.set(false);
         captionMessageCreating.set(false);
         captionEditInFlight.set(false);
+    }
+
+    private void clearLiveCaptionMessage() {
+        String messageId = liveCaptionMessageId.get();
+        if (captionChannel != null && messageId != null) {
+            captionChannel.deleteMessageById(messageId).queue(
+                    ignored -> {},
+                    throwable -> log.debug(
+                            "[STT/자막메시지삭제실패] speakerId={}, meetingId={}, messageId={}",
+                            speakerDiscordId,
+                            meetingId,
+                            messageId,
+                            throwable));
+        }
+        clearLiveCaptionState();
+    }
+
+    private static final class CaptionDebounceThreadFactory implements ThreadFactory {
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = new Thread(runnable, "stt-caption-debounce");
+            thread.setDaemon(true);
+            return thread;
+        }
     }
 }

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -73,6 +73,12 @@ public class BotSttListener implements SttListener {
                     speakerDiscordId,
                     meetingId,
                     text.length());
+            log.info(
+                    "Final STT text. sessionId={}, speakerId={}, meetingId={}, text={}",
+                    result.sessionId(),
+                    speakerDiscordId,
+                    meetingId,
+                    text);
 
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(internalBaseUrl + "/internal/v1/speech"))

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -5,6 +5,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +16,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.flodiback.bot.BotEnv;
 import com.flodiback.domain.speech.stt.SttListener;
 import com.flodiback.domain.speech.stt.SttResult;
+
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 
 /**
  * STT 결과 소비자.
@@ -33,13 +37,25 @@ public class BotSttListener implements SttListener {
     private final String speakerName;
     private final String internalBaseUrl;
     private final String internalApiKey;
+    private final MessageChannel captionChannel;
+    private final AtomicReference<String> liveCaptionMessageId = new AtomicReference<>();
+    private final AtomicReference<String> desiredCaptionContent = new AtomicReference<>("");
+    private final AtomicReference<String> renderedCaptionContent = new AtomicReference<>("");
+    private final AtomicBoolean desiredCaptionFinal = new AtomicBoolean(false);
+    private final AtomicBoolean captionMessageCreating = new AtomicBoolean(false);
+    private final AtomicBoolean captionEditInFlight = new AtomicBoolean(false);
 
     public BotSttListener(long meetingId, String speakerDiscordId, String speakerName) {
+        this(meetingId, speakerDiscordId, speakerName, null);
+    }
+
+    public BotSttListener(long meetingId, String speakerDiscordId, String speakerName, MessageChannel captionChannel) {
         this.meetingId = meetingId;
         this.speakerDiscordId = speakerDiscordId;
         this.speakerName = normalizeSpeakerName(speakerName, speakerDiscordId);
         this.internalBaseUrl = normalizeBaseUrl(BotEnv.getOrDefault("INTERNAL_API_BASE_URL", "http://localhost:8080"));
         this.internalApiKey = BotEnv.get("INTERNAL_API_KEY");
+        this.captionChannel = captionChannel;
     }
 
     @Override
@@ -48,6 +64,7 @@ public class BotSttListener implements SttListener {
         if (!result.isFinal()) {
             String partialText = result.text();
             if (partialText != null && !partialText.isBlank()) {
+                upsertLiveCaption(partialText, false);
                 log.info(
                         "[STT/중간텍스트] sessionId={}, speakerId={}, meetingId={}, text={}",
                         result.sessionId(),
@@ -63,6 +80,8 @@ public class BotSttListener implements SttListener {
         if (text == null || text.isBlank()) {
             return;
         }
+
+        upsertLiveCaption(text, true);
 
         try {
             // Spring이 관리하는 ObjectMapper가 아니므로 LocalDateTime 직렬화 설정이 없다.
@@ -160,5 +179,95 @@ public class BotSttListener implements SttListener {
             return "user-" + speakerId;
         }
         return rawSpeakerName.trim();
+    }
+
+    private void upsertLiveCaption(String text, boolean isFinal) {
+        if (captionChannel == null || text == null || text.isBlank()) {
+            return;
+        }
+
+        desiredCaptionContent.set(formatCaption(text, isFinal));
+        desiredCaptionFinal.set(isFinal);
+        syncLiveCaption();
+    }
+
+    private void syncLiveCaption() {
+        String messageId = liveCaptionMessageId.get();
+        if (messageId == null) {
+            if (!captionMessageCreating.compareAndSet(false, true)) {
+                return;
+            }
+            String messageContent = desiredCaptionContent.get();
+            captionChannel
+                    .sendMessage(messageContent)
+                    .queue(
+                            message -> {
+                                liveCaptionMessageId.set(message.getId());
+                                renderedCaptionContent.set(messageContent);
+                                captionMessageCreating.set(false);
+                                if (!messageContent.equals(desiredCaptionContent.get())) {
+                                    syncLiveCaption();
+                                    return;
+                                }
+                                if (desiredCaptionFinal.get()) {
+                                    clearLiveCaptionState();
+                                }
+                            },
+                            throwable -> {
+                                captionMessageCreating.set(false);
+                                log.warn(
+                                        "[STT/자막메시지생성실패] speakerId={}, meetingId={}",
+                                        speakerDiscordId,
+                                        meetingId,
+                                        throwable);
+                            });
+            return;
+        }
+
+        String desiredContent = desiredCaptionContent.get();
+        String renderedContent = renderedCaptionContent.get();
+        if (desiredContent.equals(renderedContent)) {
+            return;
+        }
+        if (!captionEditInFlight.compareAndSet(false, true)) {
+            return;
+        }
+
+        captionChannel
+                .editMessageById(messageId, desiredContent)
+                .queue(
+                        message -> {
+                            renderedCaptionContent.set(desiredContent);
+                            captionEditInFlight.set(false);
+                            if (!desiredContent.equals(desiredCaptionContent.get())) {
+                                syncLiveCaption();
+                                return;
+                            }
+                            if (desiredCaptionFinal.get()) {
+                                clearLiveCaptionState();
+                            }
+                        },
+                        throwable -> {
+                            captionEditInFlight.set(false);
+                            log.warn(
+                                    "[STT/자막메시지수정실패] speakerId={}, meetingId={}, messageId={}",
+                                    speakerDiscordId,
+                                    meetingId,
+                                    messageId,
+                                    throwable);
+                        });
+    }
+
+    private String formatCaption(String text, boolean isFinal) {
+        return "[" + speakerName + "] " + text + (isFinal ? " [final]" : "");
+    }
+
+    private void clearLiveCaptionState() {
+        liveCaptionMessageId.set(null);
+        desiredCaptionContent.set("");
+        renderedCaptionContent.set("");
+        desiredCaptionFinal.set(false);
+        captionMessageCreating.set(false);
+        captionEditInFlight.set(false);
     }
 }

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -68,13 +68,13 @@ public class BotSttListener implements SttListener {
 
             // 보안상 원문(text)은 로그에 남기지 않고 길이만 남긴다.
             log.info(
-                    "Final STT result received. sessionId={}, speakerId={}, meetingId={}, textLength={}",
+                    "[STT/최종결과] sessionId={}, speakerId={}, meetingId={}, textLength={}",
                     result.sessionId(),
                     speakerDiscordId,
                     meetingId,
                     text.length());
             log.info(
-                    "Final STT text. sessionId={}, speakerId={}, meetingId={}, text={}",
+                    "[STT/최종텍스트] sessionId={}, speakerId={}, meetingId={}, text={}",
                     result.sessionId(),
                     speakerDiscordId,
                     meetingId,
@@ -95,7 +95,7 @@ public class BotSttListener implements SttListener {
                     .whenComplete((response, throwable) -> {
                         if (throwable != null) {
                             log.warn(
-                                    "Failed to POST speech. sessionId={}, speakerId={}, meetingId={}",
+                                    "[전송/실패] sessionId={}, speakerId={}, meetingId={}",
                                     result.sessionId(),
                                     speakerDiscordId,
                                     meetingId,
@@ -105,7 +105,7 @@ public class BotSttListener implements SttListener {
 
                         if (response.statusCode() / 100 != 2) {
                             log.warn(
-                                    "Speech POST non-2xx. sessionId={}, speakerId={}, meetingId={}, status={}, body={}",
+                                    "[전송/비정상응답] sessionId={}, speakerId={}, meetingId={}, status={}, body={}",
                                     result.sessionId(),
                                     speakerDiscordId,
                                     meetingId,
@@ -116,7 +116,7 @@ public class BotSttListener implements SttListener {
 
                         // 보안상 원문(text)은 로그에 남기지 않는다.
                         log.info(
-                                "Speech POST success. sessionId={}, speakerId={}, meetingId={}, textLength={}",
+                                "[전송/성공] sessionId={}, speakerId={}, meetingId={}, textLength={}",
                                 result.sessionId(),
                                 speakerDiscordId,
                                 meetingId,
@@ -124,7 +124,7 @@ public class BotSttListener implements SttListener {
                     });
         } catch (Exception exception) {
             log.warn(
-                    "Failed to serialize/send speech. sessionId={}, speakerId={}, meetingId={}",
+                    "[전송/직렬화실패] sessionId={}, speakerId={}, meetingId={}",
                     result.sessionId(),
                     speakerDiscordId,
                     meetingId,
@@ -135,11 +135,7 @@ public class BotSttListener implements SttListener {
     @Override
     public void onError(String sessionId, Throwable throwable) {
         log.warn(
-                "STT error. sessionId={}, speakerId={}, meetingId={}",
-                sessionId,
-                speakerDiscordId,
-                meetingId,
-                throwable);
+                "[STT/오류] sessionId={}, speakerId={}, meetingId={}", sessionId, speakerDiscordId, meetingId, throwable);
     }
 
     private String normalizeBaseUrl(String baseUrl) {

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -46,6 +46,15 @@ public class BotSttListener implements SttListener {
     public void onResult(SttResult result) {
         // 중간 결과(delta)는 저장 API로 보내지 않는다.
         if (!result.isFinal()) {
+            String partialText = result.text();
+            if (partialText != null && !partialText.isBlank()) {
+                log.info(
+                        "[STT/중간텍스트] sessionId={}, speakerId={}, meetingId={}, text={}",
+                        result.sessionId(),
+                        speakerDiscordId,
+                        meetingId,
+                        partialText);
+            }
             return;
         }
 

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -213,16 +213,19 @@ public class BotSttListener implements SttListener {
     private void schedulePartialCaptionUpdate(String partialText) {
         long version = pendingPartialVersion.incrementAndGet();
         pendingPartialText.set(partialText);
-        ScheduledFuture<?> previous = pendingPartialTask.getAndSet(CAPTION_DEBOUNCE_EXECUTOR.schedule(() -> {
-            if (version != pendingPartialVersion.get()) {
-                return;
-            }
-            String latest = pendingPartialText.getAndSet("");
-            if (latest != null && !latest.isBlank()) {
-                upsertLiveCaption(latest, false);
-            }
-            pendingPartialTask.set(null);
-        }, CAPTION_DEBOUNCE_MS, TimeUnit.MILLISECONDS));
+        ScheduledFuture<?> previous = pendingPartialTask.getAndSet(CAPTION_DEBOUNCE_EXECUTOR.schedule(
+                () -> {
+                    if (version != pendingPartialVersion.get()) {
+                        return;
+                    }
+                    String latest = pendingPartialText.getAndSet("");
+                    if (latest != null && !latest.isBlank()) {
+                        upsertLiveCaption(latest, false);
+                    }
+                    pendingPartialTask.set(null);
+                },
+                CAPTION_DEBOUNCE_MS,
+                TimeUnit.MILLISECONDS));
 
         if (previous != null) {
             previous.cancel(false);
@@ -321,14 +324,16 @@ public class BotSttListener implements SttListener {
     private void clearLiveCaptionMessage() {
         String messageId = liveCaptionMessageId.get();
         if (captionChannel != null && messageId != null) {
-            captionChannel.deleteMessageById(messageId).queue(
-                    ignored -> {},
-                    throwable -> log.debug(
-                            "[STT/자막메시지삭제실패] speakerId={}, meetingId={}, messageId={}",
-                            speakerDiscordId,
-                            meetingId,
-                            messageId,
-                            throwable));
+            captionChannel
+                    .deleteMessageById(messageId)
+                    .queue(
+                            ignored -> {},
+                            throwable -> log.debug(
+                                    "[STT/자막메시지삭제실패] speakerId={}, meetingId={}, messageId={}",
+                                    speakerDiscordId,
+                                    meetingId,
+                                    messageId,
+                                    throwable));
         }
         clearLiveCaptionState();
     }

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverter.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverter.java
@@ -7,15 +7,74 @@ import org.slf4j.LoggerFactory;
 final class OpenAiPcmConverter {
     private static final Logger log = LoggerFactory.getLogger(OpenAiPcmConverter.class);
 
+    private static final int PCM_16BIT_BYTES = 2;
+    private static final int INPUT_CHANNELS = 2;
+    private static final int INPUT_FRAME_BYTES = PCM_16BIT_BYTES * INPUT_CHANNELS;
+    private static final int DOWNSAMPLE_FACTOR = 2;
     private static final AtomicOnce WARN_ONCE = new AtomicOnce();
 
     byte[] toRealtimePcm16(byte[] jdaPcm) {
-        // TODO: 현재 JDA PCM이 48kHz 16-bit stereo 라고 가정 하고 그냥 통과,
-        //  OpenAI Realtime이 24kHz 16-bit mono 를 요구하므로 이후 endian 정규화 구현 필요
-        WARN_ONCE.run(() -> log.warn(
-                "OpenAiPcmConverter is pass-through mode. Implement 24k mono conversion before production use."));
+        if (jdaPcm == null || jdaPcm.length == 0) {
+            return new byte[0];
+        }
 
-        return jdaPcm;
+        // JDA 디코딩 PCM은 48kHz stereo 16-bit little-endian 으로 가정한다.
+        // OpenAI Realtime transcription은 24kHz mono PCM을 요구하므로:
+        // 1) stereo -> mono 다운믹스
+        // 2) 48k -> 24k 다운샘플
+        int completeInputFrames = jdaPcm.length / INPUT_FRAME_BYTES;
+        int outputFrames = completeInputFrames / DOWNSAMPLE_FACTOR;
+        if (outputFrames == 0) {
+            return new byte[0];
+        }
+
+        int truncatedBytes = jdaPcm.length - (completeInputFrames * INPUT_FRAME_BYTES);
+        WARN_ONCE.run(() -> log.info(
+                "OpenAiPcmConverter enabled. inputAssumption=48k_stereo_pcm16le, outputFormat=24k_mono_pcm16le"));
+        if (truncatedBytes > 0) {
+            log.debug("Ignoring trailing PCM bytes that do not fill a frame. bytes={}", truncatedBytes);
+        }
+
+        byte[] output = new byte[outputFrames * PCM_16BIT_BYTES];
+        for (int outputFrameIndex = 0; outputFrameIndex < outputFrames; outputFrameIndex++) {
+            int inputFrameIndex = outputFrameIndex * DOWNSAMPLE_FACTOR;
+
+            int monoSampleA = mixStereoFrameToMono(jdaPcm, inputFrameIndex);
+            int monoSampleB = mixStereoFrameToMono(jdaPcm, inputFrameIndex + 1);
+            short downsampledMono = clampToShort((monoSampleA + monoSampleB) / 2);
+
+            writeLittleEndianShort(output, outputFrameIndex * PCM_16BIT_BYTES, downsampledMono);
+        }
+
+        return output;
+    }
+
+    private int mixStereoFrameToMono(byte[] pcm, int frameIndex) {
+        int offset = frameIndex * INPUT_FRAME_BYTES;
+        short left = readLittleEndianShort(pcm, offset);
+        short right = readLittleEndianShort(pcm, offset + PCM_16BIT_BYTES);
+        return (left + right) / 2;
+    }
+
+    private short readLittleEndianShort(byte[] pcm, int offset) {
+        int low = pcm[offset] & 0xFF;
+        int high = pcm[offset + 1];
+        return (short) ((high << 8) | low);
+    }
+
+    private void writeLittleEndianShort(byte[] target, int offset, short value) {
+        target[offset] = (byte) (value & 0xFF);
+        target[offset + 1] = (byte) ((value >>> 8) & 0xFF);
+    }
+
+    private short clampToShort(int value) {
+        if (value > Short.MAX_VALUE) {
+            return Short.MAX_VALUE;
+        }
+        if (value < Short.MIN_VALUE) {
+            return Short.MIN_VALUE;
+        }
+        return (short) value;
     }
 
     /**

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverter.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverter.java
@@ -18,7 +18,7 @@ final class OpenAiPcmConverter {
             return new byte[0];
         }
 
-        // JDA 디코딩 PCM은 48kHz stereo 16-bit little-endian 으로 가정한다.
+        // JDA 디코딩 PCM은 48kHz stereo 16-bit big-endian 으로 가정한다.
         // OpenAI Realtime transcription은 24kHz mono PCM을 요구하므로:
         // 1) stereo -> mono 다운믹스
         // 2) 48k -> 24k 다운샘플
@@ -30,7 +30,7 @@ final class OpenAiPcmConverter {
 
         int truncatedBytes = jdaPcm.length - (completeInputFrames * INPUT_FRAME_BYTES);
         WARN_ONCE.run(() -> log.info(
-                "OpenAiPcmConverter enabled. inputAssumption=48k_stereo_pcm16le, outputFormat=24k_mono_pcm16le"));
+                "OpenAiPcmConverter enabled. inputAssumption=48k_stereo_pcm16be, outputFormat=24k_mono_pcm16le"));
         if (truncatedBytes > 0) {
             log.debug("Ignoring trailing PCM bytes that do not fill a frame. bytes={}", truncatedBytes);
         }
@@ -51,14 +51,14 @@ final class OpenAiPcmConverter {
 
     private int mixStereoFrameToMono(byte[] pcm, int frameIndex) {
         int offset = frameIndex * INPUT_FRAME_BYTES;
-        short left = readLittleEndianShort(pcm, offset);
-        short right = readLittleEndianShort(pcm, offset + PCM_16BIT_BYTES);
+        short left = readBigEndianShort(pcm, offset);
+        short right = readBigEndianShort(pcm, offset + PCM_16BIT_BYTES);
         return (left + right) / 2;
     }
 
-    private short readLittleEndianShort(byte[] pcm, int offset) {
-        int low = pcm[offset] & 0xFF;
-        int high = pcm[offset + 1];
+    private short readBigEndianShort(byte[] pcm, int offset) {
+        int high = pcm[offset];
+        int low = pcm[offset + 1] & 0xFF;
         return (short) ((high << 8) | low);
     }
 

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverter.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverter.java
@@ -11,6 +11,11 @@ final class OpenAiPcmConverter {
     private static final int INPUT_CHANNELS = 2;
     private static final int INPUT_FRAME_BYTES = PCM_16BIT_BYTES * INPUT_CHANNELS;
     private static final int DOWNSAMPLE_FACTOR = 2;
+    // 48k -> 24k decimation 전에 적용할 저역통과 FIR(정규화 합=64)
+    // binomial 계열 계수로 구현이 단순하고 alias 억제에 유리하다.
+    private static final int[] FIR_TAPS = {1, 6, 15, 20, 15, 6, 1};
+    private static final int FIR_NORMALIZATION = 64;
+    private static final int FIR_HALF = FIR_TAPS.length / 2;
     private static final AtomicOnce WARN_ONCE = new AtomicOnce();
 
     byte[] toRealtimePcm16(byte[] jdaPcm) {
@@ -35,18 +40,38 @@ final class OpenAiPcmConverter {
             log.debug("Ignoring trailing PCM bytes that do not fill a frame. bytes={}", truncatedBytes);
         }
 
+        short[] mono48k = extractMono48k(jdaPcm, completeInputFrames);
         byte[] output = new byte[outputFrames * PCM_16BIT_BYTES];
         for (int outputFrameIndex = 0; outputFrameIndex < outputFrames; outputFrameIndex++) {
-            int inputFrameIndex = outputFrameIndex * DOWNSAMPLE_FACTOR;
-
-            int monoSampleA = mixStereoFrameToMono(jdaPcm, inputFrameIndex);
-            int monoSampleB = mixStereoFrameToMono(jdaPcm, inputFrameIndex + 1);
-            short downsampledMono = clampToShort((monoSampleA + monoSampleB) / 2);
-
-            writeLittleEndianShort(output, outputFrameIndex * PCM_16BIT_BYTES, downsampledMono);
+            int sourceIndex = outputFrameIndex * DOWNSAMPLE_FACTOR;
+            short filtered = lowPassAt(mono48k, sourceIndex);
+            writeLittleEndianShort(output, outputFrameIndex * PCM_16BIT_BYTES, filtered);
         }
 
         return output;
+    }
+
+    private short[] extractMono48k(byte[] pcm, int frameCount) {
+        short[] mono = new short[frameCount];
+        for (int frame = 0; frame < frameCount; frame++) {
+            mono[frame] = (short) mixStereoFrameToMono(pcm, frame);
+        }
+        return mono;
+    }
+
+    private short lowPassAt(short[] mono, int center) {
+        long accumulator = 0L;
+        for (int tap = 0; tap < FIR_TAPS.length; tap++) {
+            int index = center + tap - FIR_HALF;
+            if (index < 0) {
+                index = 0;
+            } else if (index >= mono.length) {
+                index = mono.length - 1;
+            }
+            accumulator += (long) FIR_TAPS[tap] * mono[index];
+        }
+        int filtered = (int) Math.round(accumulator / (double) FIR_NORMALIZATION);
+        return clampToShort(filtered);
     }
 
     private int mixStereoFrameToMono(byte[] pcm, int frameIndex) {

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmDebugDumper.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmDebugDumper.java
@@ -1,0 +1,141 @@
+package com.flodiback.domain.speech.stt.provider.openai;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.sound.sampled.AudioFileFormat;
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.flodiback.bot.BotEnv;
+
+final class OpenAiPcmDebugDumper {
+    private static final Logger log = LoggerFactory.getLogger(OpenAiPcmDebugDumper.class);
+
+    private static final AudioFormat RAW_FORMAT = new AudioFormat(48_000f, 16, 2, true, true);
+    private static final AudioFormat REALTIME_FORMAT = new AudioFormat(24_000f, 16, 1, true, false);
+
+    private final boolean enabled;
+    private final Path outputDir;
+    private final int maxRawBytes;
+    private final int maxRealtimeBytes;
+    private final Map<String, SessionBuffers> buffersBySessionId = new ConcurrentHashMap<>();
+
+    OpenAiPcmDebugDumper() {
+        this.enabled = Boolean.parseBoolean(BotEnv.getOrDefault("STT_DEBUG_DUMP_WAV", "false"));
+        this.outputDir = Path.of(BotEnv.getOrDefault("STT_DEBUG_DUMP_DIR", "debug/stt-pcm"));
+        int dumpSeconds = parsePositiveInt(BotEnv.getOrDefault("STT_DEBUG_DUMP_SECONDS", "5"), 5);
+        this.maxRawBytes = (int) (RAW_FORMAT.getFrameRate() * RAW_FORMAT.getFrameSize() * dumpSeconds);
+        this.maxRealtimeBytes = (int) (REALTIME_FORMAT.getFrameRate() * REALTIME_FORMAT.getFrameSize() * dumpSeconds);
+
+        if (enabled) {
+            log.info(
+                    "[PCM덤프/활성화] outputDir={}, dumpSeconds={}, rawFormat=48k_stereo_pcm16be, realtimeFormat=24k_mono_pcm16le",
+                    outputDir,
+                    dumpSeconds);
+        }
+    }
+
+    void capture(String sessionId, byte[] rawPcm, byte[] realtimePcm) {
+        if (!enabled) {
+            return;
+        }
+        SessionBuffers buffers = buffersBySessionId.computeIfAbsent(
+                sessionId, ignored -> new SessionBuffers(maxRawBytes, maxRealtimeBytes));
+        buffers.appendRaw(rawPcm);
+        buffers.appendRealtime(realtimePcm);
+    }
+
+    void flushSession(String sessionId) {
+        if (!enabled) {
+            return;
+        }
+        SessionBuffers buffers = buffersBySessionId.remove(sessionId);
+        if (buffers == null) {
+            return;
+        }
+
+        try {
+            Files.createDirectories(outputDir);
+            Path rawPath = outputDir.resolve(sanitize(sessionId) + "-raw.wav");
+            Path realtimePath = outputDir.resolve(sanitize(sessionId) + "-openai.wav");
+            writeWav(buffers.rawBytes(), RAW_FORMAT, rawPath);
+            writeWav(buffers.realtimeBytes(), REALTIME_FORMAT, realtimePath);
+            log.info(
+                    "[PCM덤프/저장완료] sessionId={}, rawPath={}, rawBytes={}, realtimePath={}, realtimeBytes={}",
+                    sessionId,
+                    rawPath,
+                    buffers.rawBytes().length,
+                    realtimePath,
+                    buffers.realtimeBytes().length);
+        } catch (Exception exception) {
+            log.warn("[PCM덤프/저장실패] sessionId={}, outputDir={}", sessionId, outputDir, exception);
+        }
+    }
+
+    private void writeWav(byte[] pcmBytes, AudioFormat format, Path outputPath) throws IOException {
+        try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(pcmBytes);
+                AudioInputStream audioInputStream =
+                        new AudioInputStream(byteArrayInputStream, format, pcmBytes.length / format.getFrameSize())) {
+            AudioSystem.write(audioInputStream, AudioFileFormat.Type.WAVE, outputPath.toFile());
+        }
+    }
+
+    private int parsePositiveInt(String raw, int defaultValue) {
+        try {
+            int parsed = Integer.parseInt(raw.trim());
+            return parsed > 0 ? parsed : defaultValue;
+        } catch (Exception ignored) {
+            return defaultValue;
+        }
+    }
+
+    private String sanitize(String sessionId) {
+        return sessionId.replaceAll("[^a-zA-Z0-9._-]", "_");
+    }
+
+    private static final class SessionBuffers {
+        private final ByteArrayOutputStream raw = new ByteArrayOutputStream();
+        private final ByteArrayOutputStream realtime = new ByteArrayOutputStream();
+        private final int maxRawBytes;
+        private final int maxRealtimeBytes;
+
+        private SessionBuffers(int maxRawBytes, int maxRealtimeBytes) {
+            this.maxRawBytes = maxRawBytes;
+            this.maxRealtimeBytes = maxRealtimeBytes;
+        }
+
+        synchronized void appendRaw(byte[] bytes) {
+            appendWithLimit(raw, bytes, maxRawBytes);
+        }
+
+        synchronized void appendRealtime(byte[] bytes) {
+            appendWithLimit(realtime, bytes, maxRealtimeBytes);
+        }
+
+        synchronized byte[] rawBytes() {
+            return raw.toByteArray();
+        }
+
+        synchronized byte[] realtimeBytes() {
+            return realtime.toByteArray();
+        }
+
+        private void appendWithLimit(ByteArrayOutputStream target, byte[] bytes, int maxBytes) {
+            if (bytes == null || bytes.length == 0 || target.size() >= maxBytes) {
+                return;
+            }
+            int writable = Math.min(bytes.length, maxBytes - target.size());
+            target.write(bytes, 0, writable);
+        }
+    }
+}

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeClient.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeClient.java
@@ -29,11 +29,9 @@ final class OpenAiRealtimeClient {
     private static final String ENV_OPENAI_REALTIME_WS_URL = "OPENAI_REALTIME_WS_URL";
     private static final String ENV_OPENAI_TRANSCRIBE_MODEL = "OPENAI_TRANSCRIBE_MODEL";
     private static final String ENV_OPENAI_TRANSCRIBE_LANGUAGE = "OPENAI_TRANSCRIBE_LANGUAGE";
-    private static final String ENV_OPENAI_TRANSCRIBE_PROMPT = "OPENAI_TRANSCRIBE_PROMPT";
 
     private static final String DEFAULT_TRANSCRIBE_MODEL = "gpt-4o-mini-transcribe";
     private static final String DEFAULT_TRANSCRIBE_LANGUAGE = "ko";
-    private static final String DEFAULT_TRANSCRIBE_PROMPT = "한국어 회의 대화입니다. 번역하지 말고 들리는 한국어를 그대로 전사하세요.";
     private static final Duration COMMIT_WAIT_TIMEOUT = Duration.ofSeconds(8);
 
     private final HttpClient httpClient =
@@ -72,7 +70,6 @@ final class OpenAiRealtimeClient {
         ObjectNode transcriptionNode = inputNode.putObject("transcription");
         transcriptionNode.put("model", envOrDefault(ENV_OPENAI_TRANSCRIBE_MODEL, DEFAULT_TRANSCRIBE_MODEL));
         transcriptionNode.put("language", envOrDefault(ENV_OPENAI_TRANSCRIBE_LANGUAGE, DEFAULT_TRANSCRIBE_LANGUAGE));
-        transcriptionNode.put("prompt", envOrDefault(ENV_OPENAI_TRANSCRIBE_PROMPT, DEFAULT_TRANSCRIBE_PROMPT));
         inputNode.putNull("turn_detection");
 
         sendJson(webSocket, root);

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeClient.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeClient.java
@@ -77,7 +77,7 @@ final class OpenAiRealtimeClient {
 
         sendJson(webSocket, root);
 
-        log.info("OpenAI STT session opened. sessionId={}, speakerId={}", session.sessionId(), session.speakerId());
+        log.info("[OPENAI/세션열림] sessionId={}, speakerId={}", session.sessionId(), session.speakerId());
     }
 
     /**
@@ -92,8 +92,7 @@ final class OpenAiRealtimeClient {
 
         sendJson(webSocket, event);
 
-        log.debug(
-                "OpenAI append sent. sessionId={}, bytes={}, ts={}", session.sessionId(), pcm16le.length, timestampMs);
+        log.debug("[OPENAI/오디오전송] sessionId={}, bytes={}, ts={}", session.sessionId(), pcm16le.length, timestampMs);
     }
 
     /**
@@ -106,14 +105,14 @@ final class OpenAiRealtimeClient {
         commit.put("type", "input_audio_buffer.commit");
         sendJson(webSocket, commit);
 
-        log.info("OpenAI commit sent. sessionId={}, sentBytes={}", session.sessionId(), session.sentPcmBytes());
+        log.info("[OPENAI/커밋전송] sessionId={}, sentBytes={}", session.sessionId(), session.sentPcmBytes());
 
         // completed 이벤트를 기다렸다가 닫는다.
         // 네트워크 상태에 따라 못 받을 수도 있으므로 timeout을 둔다.
         try {
             session.completedFuture().get(COMMIT_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (Exception timeoutOrError) {
-            log.warn("OpenAI completed wait timeout/error. sessionId={}", session.sessionId(), timeoutOrError);
+            log.warn("[OPENAI/커밋대기실패] sessionId={}", session.sessionId(), timeoutOrError);
         }
 
         webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "done").join();

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeClient.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeClient.java
@@ -28,8 +28,12 @@ final class OpenAiRealtimeClient {
     private static final String ENV_OPENAI_API_KEY = "OPENAI_API_KEY";
     private static final String ENV_OPENAI_REALTIME_WS_URL = "OPENAI_REALTIME_WS_URL";
     private static final String ENV_OPENAI_TRANSCRIBE_MODEL = "OPENAI_TRANSCRIBE_MODEL";
+    private static final String ENV_OPENAI_TRANSCRIBE_LANGUAGE = "OPENAI_TRANSCRIBE_LANGUAGE";
+    private static final String ENV_OPENAI_TRANSCRIBE_PROMPT = "OPENAI_TRANSCRIBE_PROMPT";
 
     private static final String DEFAULT_TRANSCRIBE_MODEL = "gpt-4o-mini-transcribe";
+    private static final String DEFAULT_TRANSCRIBE_LANGUAGE = "ko";
+    private static final String DEFAULT_TRANSCRIBE_PROMPT = "한국어 회의 대화입니다. 번역하지 말고 들리는 한국어를 그대로 전사하세요.";
     private static final Duration COMMIT_WAIT_TIMEOUT = Duration.ofSeconds(8);
 
     private final HttpClient httpClient =
@@ -65,9 +69,10 @@ final class OpenAiRealtimeClient {
 
         ObjectNode inputNode = sessionNode.putObject("audio").putObject("input");
         inputNode.putObject("format").put("type", "audio/pcm").put("rate", 24000);
-        inputNode
-                .putObject("transcription")
-                .put("model", envOrDefault(ENV_OPENAI_TRANSCRIBE_MODEL, DEFAULT_TRANSCRIBE_MODEL));
+        ObjectNode transcriptionNode = inputNode.putObject("transcription");
+        transcriptionNode.put("model", envOrDefault(ENV_OPENAI_TRANSCRIBE_MODEL, DEFAULT_TRANSCRIBE_MODEL));
+        transcriptionNode.put("language", envOrDefault(ENV_OPENAI_TRANSCRIBE_LANGUAGE, DEFAULT_TRANSCRIBE_LANGUAGE));
+        transcriptionNode.put("prompt", envOrDefault(ENV_OPENAI_TRANSCRIBE_PROMPT, DEFAULT_TRANSCRIBE_PROMPT));
         inputNode.putNull("turn_detection");
 
         sendJson(webSocket, root);

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeClient.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeClient.java
@@ -30,7 +30,7 @@ final class OpenAiRealtimeClient {
     private static final String ENV_OPENAI_TRANSCRIBE_MODEL = "OPENAI_TRANSCRIBE_MODEL";
     private static final String ENV_OPENAI_TRANSCRIBE_LANGUAGE = "OPENAI_TRANSCRIBE_LANGUAGE";
 
-    private static final String DEFAULT_TRANSCRIBE_MODEL = "gpt-4o-mini-transcribe";
+    private static final String DEFAULT_TRANSCRIBE_MODEL = "gpt-4o-transcribe";
     private static final String DEFAULT_TRANSCRIBE_LANGUAGE = "ko";
     private static final Duration COMMIT_WAIT_TIMEOUT = Duration.ofSeconds(8);
 

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandler.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandler.java
@@ -1,11 +1,15 @@
 package com.flodiback.domain.speech.stt.provider.openai;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.flodiback.domain.speech.stt.SttResult;
 
 /**
  * OpenAI Realtime 이벤트를 STT 도메인 이벤트(SttResult)로 변환한다.
  */
 final class OpenAiRealtimeEventHandler {
+    private static final Logger log = LoggerFactory.getLogger(OpenAiRealtimeEventHandler.class);
 
     /**
      * 중간 결과(delta) 이벤트 처리.
@@ -18,6 +22,12 @@ final class OpenAiRealtimeEventHandler {
         }
 
         String cumulative = session.appendDelta(itemId, delta);
+        log.debug(
+                "[OPENAI/중간전사] sessionId={}, itemId={}, deltaLength={}, cumulativeLength={}",
+                session.sessionId(),
+                itemId,
+                delta.length(),
+                cumulative.length());
 
         session.sttListener()
                 .onResult(new SttResult(session.sessionId(), session.speakerId(), cumulative, false, 0L, 0L, null));
@@ -31,6 +41,11 @@ final class OpenAiRealtimeEventHandler {
      */
     void onCompleted(OpenAiSttSessionState session, String itemId, String transcript) {
         String finalText = session.takeCompletedText(itemId, transcript);
+        log.info(
+                "[OPENAI/최종전사] sessionId={}, itemId={}, textLength={}",
+                session.sessionId(),
+                itemId,
+                finalText.length());
 
         session.sttListener()
                 .onResult(new SttResult(session.sessionId(), session.speakerId(), finalText, true, 0L, 0L, null));
@@ -44,6 +59,7 @@ final class OpenAiRealtimeEventHandler {
      * - commit 대기 future를 실패로 종료
      */
     void onError(OpenAiSttSessionState session, Throwable throwable) {
+        log.warn("[OPENAI/이벤트오류] sessionId={}", session.sessionId(), throwable);
         session.sttListener().onError(session.sessionId(), throwable);
         session.markFailed(throwable);
     }

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeWsListener.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeWsListener.java
@@ -66,7 +66,7 @@ final class OpenAiRealtimeWsListener implements WebSocket.Listener {
 
     @Override
     public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
-        log.info("OpenAI ws closed. sessionId={}, statusCode={}, reason={}", session.sessionId(), statusCode, reason);
+        log.info("[OPENAI/소켓종료] sessionId={}, statusCode={}, reason={}", session.sessionId(), statusCode, reason);
         return CompletableFuture.completedFuture(null);
     }
 

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
@@ -63,6 +63,7 @@ public class OpenAiSttProvider implements SttProvider {
         } catch (Exception exception) {
             sessions.remove(sessionId, newSession);
             nonNullListener.onError(sessionId, exception);
+            throw new IllegalStateException("Failed to open OpenAI STT session. sessionId=" + sessionId, exception);
         }
     }
 

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
@@ -20,20 +20,27 @@ public class OpenAiSttProvider implements SttProvider {
     private final OpenAiRealtimeClient realtimeClient;
     private final OpenAiPcmConverter pcmConverter;
     private final OpenAiRealtimeEventHandler eventHandler;
+    private final OpenAiPcmDebugDumper pcmDebugDumper;
 
     // 내부에서 필요한 기본 객체들을 직접 만듦
     public OpenAiSttProvider() {
-        this(new OpenAiRealtimeClient(), new OpenAiPcmConverter(), new OpenAiRealtimeEventHandler());
+        this(
+                new OpenAiRealtimeClient(),
+                new OpenAiPcmConverter(),
+                new OpenAiRealtimeEventHandler(),
+                new OpenAiPcmDebugDumper());
     }
 
     // 외부에서 객체를 주입할 수 있는 생성자 (테스트 용이성 향상)
     OpenAiSttProvider(
             OpenAiRealtimeClient realtimeClient,
             OpenAiPcmConverter pcmConverter,
-            OpenAiRealtimeEventHandler eventHandler) {
+            OpenAiRealtimeEventHandler eventHandler,
+            OpenAiPcmDebugDumper pcmDebugDumper) {
         this.realtimeClient = Objects.requireNonNull(realtimeClient);
         this.pcmConverter = Objects.requireNonNull(pcmConverter);
         this.eventHandler = Objects.requireNonNull(eventHandler);
+        this.pcmDebugDumper = Objects.requireNonNull(pcmDebugDumper);
     }
 
     @Override
@@ -67,6 +74,7 @@ public class OpenAiSttProvider implements SttProvider {
         }
         try {
             byte[] realtimePcm = pcmConverter.toRealtimePcm16(pcm16le);
+            pcmDebugDumper.capture(sessionId, pcm16le, realtimePcm);
             session.addSentPcmBytes(realtimePcm.length);
             realtimeClient.appendAudio(session, realtimePcm, timestampMs);
         } catch (Exception exception) {
@@ -86,6 +94,8 @@ public class OpenAiSttProvider implements SttProvider {
         } catch (Exception exception) {
             session.sttListener().onError(sessionId, exception);
             realtimeClient.closeSessionQuietly(session);
+        } finally {
+            pcmDebugDumper.flushSession(sessionId);
         }
     }
 }

--- a/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverterTest.java
+++ b/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverterTest.java
@@ -1,0 +1,52 @@
+package com.flodiback.domain.speech.stt.provider.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class OpenAiPcmConverterTest {
+
+    private final OpenAiPcmConverter converter = new OpenAiPcmConverter();
+
+    @Test
+    void converts48kStereoPcmTo24kMonoPcm() {
+        byte[] input = stereoFrames(
+                new short[] {1000, 3000}, new short[] {2000, 4000}, new short[] {-1000, 1000}, new short[] {2000, 2000
+                });
+
+        byte[] output = converter.toRealtimePcm16(input);
+
+        assertThat(output).containsExactly(littleEndianShorts((short) 2500, (short) 1000));
+    }
+
+    @Test
+    void returnsEmptyWhenInputHasFewerThanTwoStereoFrames() {
+        byte[] input = stereoFrames(new short[] {1000, 2000});
+
+        byte[] output = converter.toRealtimePcm16(input);
+
+        assertThat(output).isEmpty();
+    }
+
+    private byte[] stereoFrames(short[]... frames) {
+        byte[] pcm = new byte[frames.length * 4];
+        for (int i = 0; i < frames.length; i++) {
+            writeShort(pcm, i * 4, frames[i][0]);
+            writeShort(pcm, i * 4 + 2, frames[i][1]);
+        }
+        return pcm;
+    }
+
+    private byte[] littleEndianShorts(short... values) {
+        byte[] pcm = new byte[values.length * 2];
+        for (int i = 0; i < values.length; i++) {
+            writeShort(pcm, i * 2, values[i]);
+        }
+        return pcm;
+    }
+
+    private void writeShort(byte[] target, int offset, short value) {
+        target[offset] = (byte) (value & 0xFF);
+        target[offset + 1] = (byte) ((value >>> 8) & 0xFF);
+    }
+}

--- a/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverterTest.java
+++ b/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverterTest.java
@@ -16,7 +16,7 @@ class OpenAiPcmConverterTest {
 
         byte[] output = converter.toRealtimePcm16(input);
 
-        assertThat(output).containsExactly(littleEndianShorts((short) 2500, (short) 1000));
+        assertThat(output).containsExactly(littleEndianShorts((short) 2047, (short) 1609));
     }
 
     @Test

--- a/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverterTest.java
+++ b/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiPcmConverterTest.java
@@ -10,7 +10,7 @@ class OpenAiPcmConverterTest {
 
     @Test
     void converts48kStereoPcmTo24kMonoPcm() {
-        byte[] input = stereoFrames(
+        byte[] input = stereoFramesBigEndian(
                 new short[] {1000, 3000}, new short[] {2000, 4000}, new short[] {-1000, 1000}, new short[] {2000, 2000
                 });
 
@@ -21,18 +21,18 @@ class OpenAiPcmConverterTest {
 
     @Test
     void returnsEmptyWhenInputHasFewerThanTwoStereoFrames() {
-        byte[] input = stereoFrames(new short[] {1000, 2000});
+        byte[] input = stereoFramesBigEndian(new short[] {1000, 2000});
 
         byte[] output = converter.toRealtimePcm16(input);
 
         assertThat(output).isEmpty();
     }
 
-    private byte[] stereoFrames(short[]... frames) {
+    private byte[] stereoFramesBigEndian(short[]... frames) {
         byte[] pcm = new byte[frames.length * 4];
         for (int i = 0; i < frames.length; i++) {
-            writeShort(pcm, i * 4, frames[i][0]);
-            writeShort(pcm, i * 4 + 2, frames[i][1]);
+            writeBigEndianShort(pcm, i * 4, frames[i][0]);
+            writeBigEndianShort(pcm, i * 4 + 2, frames[i][1]);
         }
         return pcm;
     }
@@ -40,13 +40,18 @@ class OpenAiPcmConverterTest {
     private byte[] littleEndianShorts(short... values) {
         byte[] pcm = new byte[values.length * 2];
         for (int i = 0; i < values.length; i++) {
-            writeShort(pcm, i * 2, values[i]);
+            writeLittleEndianShort(pcm, i * 2, values[i]);
         }
         return pcm;
     }
 
-    private void writeShort(byte[] target, int offset, short value) {
+    private void writeLittleEndianShort(byte[] target, int offset, short value) {
         target[offset] = (byte) (value & 0xFF);
         target[offset + 1] = (byte) ((value >>> 8) & 0xFF);
+    }
+
+    private void writeBigEndianShort(byte[] target, int offset, short value) {
+        target[offset] = (byte) ((value >>> 8) & 0xFF);
+        target[offset + 1] = (byte) (value & 0xFF);
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #30
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #30

---

## 📝 작업 내용
Discord 음성 STT에서 발생하던 `문장 초반 씹힘`, `무발화 세션 반복`, `중간 자막 노이즈`, `원인 추적 어려움` 문제를 해결하기 위해 수신-판정-VAD-전송-자막-로그 흐름을 단계별로 정리/안정화했습니다.  
핵심은 **WebRTC VAD 우선 판정 + RMS fallback**, **pre-roll 포함 세션 제어**, **PCM 변환 품질 개선(48k stereo -> 24k mono)** 입니다.

```java
// 예) PerUserAudioReceiveHandler 내부 개념 흐름
// 1) Opus decode -> PCM
// 2) VAD(WebRTC 우선, 실패 시 RMS)
// 3) START_WITH_PREROLL / FORWARD / DROP
// 4) silence watcher로 commit/end
```

---

## ✅ 주요 변경 사항
1) STT 세션 안정화
- VAD 상태 머신(`IDLE/SPEECH_CANDIDATE/IN_SPEECH/TRAILING_SILENCE`) 적용
- pre-roll(400ms) 버퍼 추가
- 무음 종료 스케줄러 기반 commit/end 정리

2) WebRTC VAD 도입 + fallback
- `vad4j` 의존성 추가
- WebRTC 사용 불가 시 RMS 자동 fallback
- 캘리브레이션 로그 및 임계값 자동 보정 추가

3) PCM 처리 및 Realtime 전송 정리
- PCM 변환기 개선(저역통과 FIR + decimation)
- Realtime 세션 설정 정리(`session.update`, `turn_detection=null`, model/language)
- delta/completed 이벤트 처리 경로 명확화

4) 자막/운영 로그 개선
- 중간 자막: 300ms debounce + 최소 2글자
- 최종 자막 `[final]` 반영 안정화
- 화자명 표시 개선(Discord 표시명 우선)
- STT/OpenAI/Discord 단계별 한글 로그 정리

5) 운영 환경 설정 보강
- `.env.example`에 STT 관련 설정/설명 보강
- `docker-compose.bot.yml`에서 bot platform을 `linux/amd64`로 지정(WebRTC 네이티브 이슈 대응)

---

## 🧪 테스트 결과
```bash
# 수동 검증 위주
# 1) docker compose -f docker-compose.bot.yml up --force-recreate -d discord-bot
# 2) Discord !join 후 단문/복문 발화 테스트
# 3) 로그에서 세션 시작/커밋/최종텍스트/세션종료 확인
# 4) STT_DEBUG_DUMP_WAV=true 로 raw/openai wav 덤프 비교 확인
```

- [ ] 로컬 테스트 통과
- [x] 관련 시나리오 수동 확인
- [ ] 구현 기록이 필요한 변경인지 확인
- [ ] 필요한 경우 `docs/impl/{author}/`에 구현 기록 추가
- [ ] 구현 기록을 AI가 생성한 경우, 사실관계/대안 비교/수치 근거 검토 완료

---

## 👀 리뷰 포인트 (선택)
- `PerUserAudioReceiveHandler`의 VAD 상태 전이와 세션 종료 타이밍이 의도대로 동작하는지
- `OpenAiPcmConverter` FIR 다운샘플링이 실제 인식 품질에 개선 효과가 있는지
- `BotSttListener` 자막 upsert/debounce 로직의 경합(동시 수정) 가능성

---

## 📎 참고 사항 (선택)
- 주요 로그 키워드
  - `[STT/세션시작]`, `[OPENAI/커밋전송]`, `[STT/최종텍스트]`, `[STT/세션종료]`
  - `[PCM덤프/저장완료]` (덤프 ON일 때)
- `meetingId=1` 관련 404는 STT 인식 이슈가 아니라 내부 API 데이터 상태 이슈입니다.
