### PR TITLE
feat: Discord join/leave 회의 연동 및 STT 응답 디버그 로그 보강

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,6 @@ DISCORD_TOKEN=your_discord_bot_token
 DISCORD_BOT_PREFIX=!
 GLM_ENABLED=false
 
-# 기본 meetingId (현재 봇은 이 값으로 /internal/v1/speech를 전송)
-DISCORD_DEFAULT_MEETING_ID=1
-
 # Spring internal API base URL (로컬 실행 기준)
 # 로컬에서 봇을 직접 실행하면 http://localhost:8080
 # Docker에서 봇을 실행하고 Spring 서버는 호스트 Mac에서 실행하면 http://host.docker.internal:8080

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -1,5 +1,10 @@
 package com.flodiback.bot.command;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -7,6 +12,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.flodiback.bot.BotEnv;
 import com.flodiback.bot.audio.PerUserAudioReceiveHandler;
 import com.flodiback.domain.speech.stt.SttProvider;
 import com.flodiback.domain.speech.stt.provider.openai.OpenAiSttProvider;
@@ -36,10 +45,14 @@ public class DiscordCommandListener extends ListenerAdapter {
     private final String prefix;
     // 실제 STT 엔진 구현체(현재 OpenAI)
     private final SttProvider sttProvider;
-    // 기본 meetingId (현재는 단일 값 사용)
-    private final long defaultMeetingId;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String internalBaseUrl;
+    private final String internalApiKey;
     // 길드별 오디오 수신 핸들러 캐시
     private final Map<Long, PerUserAudioReceiveHandler> receiveHandlers = new ConcurrentHashMap<>();
+    // 길드별 활성 meetingId
+    private final Map<Long, Long> activeMeetingIdByGuild = new ConcurrentHashMap<>();
 
     public DiscordCommandListener() {
         this("!", new OpenAiSttProvider(), 1L);
@@ -48,7 +61,8 @@ public class DiscordCommandListener extends ListenerAdapter {
     public DiscordCommandListener(String prefix, SttProvider sttProvider, long defaultMeetingId) {
         this.prefix = (prefix == null || prefix.isBlank()) ? "!" : prefix.trim();
         this.sttProvider = Objects.requireNonNull(sttProvider);
-        this.defaultMeetingId = defaultMeetingId;
+        this.internalBaseUrl = normalizeBaseUrl(BotEnv.getOrDefault("INTERNAL_API_BASE_URL", "http://localhost:8080"));
+        this.internalApiKey = BotEnv.get("INTERNAL_API_KEY");
     }
 
     @Override
@@ -84,14 +98,27 @@ public class DiscordCommandListener extends ListenerAdapter {
             return;
         }
 
+        long guildId = event.getGuild().getIdLong();
+        Long meetingId = createMeeting(guildId, event.getGuild().getName());
+        if (meetingId == null) {
+            event.getChannel().sendMessage("회의 생성 실패로 입장을 중단했어. 서버 로그를 확인해줘.").queue();
+            return;
+        }
+
         AudioChannel targetChannel = member.getVoiceState().getChannel();
         AudioManager audioManager = event.getGuild().getAudioManager();
 
+        PerUserAudioReceiveHandler existing = receiveHandlers.remove(guildId);
+        if (existing != null) {
+            existing.closeAllSttSessions();
+        }
+
         // 길드별 핸들러를 1개 유지한다.
         // (디스코드 특성상 봇 1개는 길드 내 음성 채널 1개 연결만 가능)
-        PerUserAudioReceiveHandler handler = receiveHandlers.computeIfAbsent(
-                event.getGuild().getIdLong(),
-                guildId -> new PerUserAudioReceiveHandler(guildId, event.getGuild(), sttProvider, defaultMeetingId));
+        PerUserAudioReceiveHandler handler =
+                new PerUserAudioReceiveHandler(guildId, event.getGuild(), sttProvider, meetingId);
+        receiveHandlers.put(guildId, handler);
+        activeMeetingIdByGuild.put(guildId, meetingId);
         handler.updateCaptionChannel(event.getChannel());
 
         // 오디오 수신 핸들러 연결 + 음성 연결
@@ -122,15 +149,15 @@ public class DiscordCommandListener extends ListenerAdapter {
                 event.getGuild().getId(),
                 targetChannel.getId(),
                 targetChannel.getName(),
-                defaultMeetingId,
+                meetingId,
                 targetChannel.getMembers().size(),
                 summarizeVoiceMembers(targetChannel));
     }
 
     private void handleLeave(MessageReceivedEvent event) {
+        long guildId = event.getGuild().getIdLong();
         AudioManager audioManager = event.getGuild().getAudioManager();
-        PerUserAudioReceiveHandler handler =
-                receiveHandlers.remove(event.getGuild().getIdLong());
+        PerUserAudioReceiveHandler handler = receiveHandlers.remove(guildId);
 
         // leave 시점에는 열린 STT 세션을 먼저 commit/end로 닫는다.
         if (handler != null) {
@@ -142,8 +169,13 @@ public class DiscordCommandListener extends ListenerAdapter {
         audioManager.setReceivingHandler(null);
         audioManager.setConnectionListener(null);
 
+        Long meetingId = activeMeetingIdByGuild.remove(guildId);
+        if (meetingId != null) {
+            endMeeting(guildId, meetingId);
+        }
+
         event.getChannel().sendMessage("퇴장 완료").queue();
-        log.info("[디스코드/퇴장] guildId={}", event.getGuild().getId());
+        log.info("[디스코드/퇴장] guildId={}, meetingId={}", event.getGuild().getId(), meetingId);
     }
 
     private void handleStats(MessageReceivedEvent event) {
@@ -178,6 +210,80 @@ public class DiscordCommandListener extends ListenerAdapter {
                 .limit(10)
                 .reduce((left, right) -> left + ", " + right)
                 .orElse("-");
+    }
+
+    private Long createMeeting(long guildId, String guildName) {
+        try {
+            ObjectNode body = objectMapper.createObjectNode();
+            body.putNull("projectId");
+            body.put("title", "Discord " + guildName + " " + LocalDateTime.now());
+
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(internalBaseUrl + "/api/v1/meetings"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(body)));
+            attachInternalApiKey(requestBuilder);
+
+            HttpResponse<String> response =
+                    httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+                log.warn("[미팅/생성실패] guildId={}, status={}, body={}", guildId, response.statusCode(), response.body());
+                return null;
+            }
+
+            JsonNode root = objectMapper.readTree(response.body());
+            JsonNode idNode = root.path("data").path("id");
+            if (!idNode.isNumber()) {
+                log.warn("[미팅/생성응답오류] guildId={}, body={}", guildId, response.body());
+                return null;
+            }
+
+            long meetingId = idNode.asLong();
+            log.info("[미팅/생성성공] guildId={}, meetingId={}", guildId, meetingId);
+            return meetingId;
+        } catch (Exception exception) {
+            log.warn("[미팅/생성예외] guildId={}", guildId, exception);
+            return null;
+        }
+    }
+
+    private void endMeeting(long guildId, long meetingId) {
+        try {
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(internalBaseUrl + "/api/v1/meetings/" + meetingId + "/end"))
+                    .PUT(HttpRequest.BodyPublishers.noBody());
+            attachInternalApiKey(requestBuilder);
+
+            HttpResponse<String> response =
+                    httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+                log.warn(
+                        "[미팅/종료실패] guildId={}, meetingId={}, status={}, body={}",
+                        guildId,
+                        meetingId,
+                        response.statusCode(),
+                        response.body());
+                return;
+            }
+
+            log.info("[미팅/종료성공] guildId={}, meetingId={}", guildId, meetingId);
+        } catch (Exception exception) {
+            log.warn("[미팅/종료예외] guildId={}, meetingId={}", guildId, meetingId, exception);
+        }
+    }
+
+    private void attachInternalApiKey(HttpRequest.Builder requestBuilder) {
+        if (internalApiKey != null && !internalApiKey.isBlank()) {
+            requestBuilder.header("X-Internal-Api-Key", internalApiKey);
+        }
+    }
+
+    private String normalizeBaseUrl(String baseUrl) {
+        String normalized = baseUrl == null ? "http://localhost:8080" : baseUrl.trim();
+        if (normalized.endsWith("/")) {
+            return normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
     }
 
     private final class LoggingConnectionListener implements ConnectionListener {

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -5,12 +5,12 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -353,7 +353,9 @@ public class BotSttListener implements SttListener {
         try {
             JsonNode root = objectMapper.readTree(responseBody);
             JsonNode aiAnswerNode = root.path("data").path("ai_answer");
-            boolean hasAiAnswer = !aiAnswerNode.isMissingNode() && !aiAnswerNode.isNull() && !aiAnswerNode.asText().isBlank();
+            boolean hasAiAnswer = !aiAnswerNode.isMissingNode()
+                    && !aiAnswerNode.isNull()
+                    && !aiAnswerNode.asText().isBlank();
             int aiAnswerLength = hasAiAnswer ? aiAnswerNode.asText().length() : 0;
             log.info(
                     "[AI/응답체크] sessionId={}, speakerId={}, meetingId={}, wakeWordDetected={}, hasAiAnswer={}, aiAnswerLength={}",

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -17,6 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.flodiback.bot.BotEnv;
@@ -34,6 +36,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
  */
 public class BotSttListener implements SttListener {
     private static final Logger log = LoggerFactory.getLogger(BotSttListener.class);
+    private static final List<String> WAKE_WORDS = List.of("AI야", "ai야", "봇아", "클로드야", "플로디야", "flodiya", "plodiya");
     private static final long CAPTION_DEBOUNCE_MS = 300L;
     private static final int CAPTION_MIN_CHARS = 2;
     private static final ScheduledExecutorService CAPTION_DEBOUNCE_EXECUTOR =
@@ -166,6 +169,13 @@ public class BotSttListener implements SttListener {
                                 speakerDiscordId,
                                 meetingId,
                                 text.length());
+                        log.info(
+                                "[전송/응답바디] sessionId={}, speakerId={}, meetingId={}, body={}",
+                                result.sessionId(),
+                                speakerDiscordId,
+                                meetingId,
+                                response.body());
+                        logAiAnswerStatus(result.sessionId(), text, response.body());
                     });
         } catch (Exception exception) {
             log.warn(
@@ -336,6 +346,44 @@ public class BotSttListener implements SttListener {
                                     throwable));
         }
         clearLiveCaptionState();
+    }
+
+    private void logAiAnswerStatus(String sessionId, String finalText, String responseBody) {
+        boolean wakeWordDetected = containsWakeWord(finalText);
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            JsonNode aiAnswerNode = root.path("data").path("ai_answer");
+            boolean hasAiAnswer = !aiAnswerNode.isMissingNode() && !aiAnswerNode.isNull() && !aiAnswerNode.asText().isBlank();
+            int aiAnswerLength = hasAiAnswer ? aiAnswerNode.asText().length() : 0;
+            log.info(
+                    "[AI/응답체크] sessionId={}, speakerId={}, meetingId={}, wakeWordDetected={}, hasAiAnswer={}, aiAnswerLength={}",
+                    sessionId,
+                    speakerDiscordId,
+                    meetingId,
+                    wakeWordDetected,
+                    hasAiAnswer,
+                    aiAnswerLength);
+        } catch (Exception parseException) {
+            log.warn(
+                    "[AI/응답체크실패] sessionId={}, speakerId={}, meetingId={}, wakeWordDetected={}",
+                    sessionId,
+                    speakerDiscordId,
+                    meetingId,
+                    wakeWordDetected,
+                    parseException);
+        }
+    }
+
+    private boolean containsWakeWord(String text) {
+        if (text == null || text.isBlank()) {
+            return false;
+        }
+        for (String wakeWord : WAKE_WORDS) {
+            if (text.contains(wakeWord)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static final class CaptionDebounceThreadFactory implements ThreadFactory {


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #37

---

## 📝 작업 내용
1. Discord `!join` 시 백엔드 회의 생성 API를 호출해 `meetingId`를 할당하고, `!leave` 시 종료 API를 호출하도록 연동했습니다.
2. STT 최종 전송 경로의 디버깅 가시성을 높이기 위해 응답 바디 및 `ai_answer` 존재 여부/호출어 감지 로그를 추가했습니다.
3. 환경 예시에서 고정 기본값인 `DISCORD_DEFAULT_MEETING_ID` 항목을 제거해 동적 meeting 생성 흐름과 일치시켰습니다.
```java
BotSttListener listener = new BotSttListener(meetingId, speakerId, normalizedSpeakerName, captionChannel);
sttProvider.startSession(sessionId, speakerId, listener);
```

---

## ✅ 주요 변경 사항
1) `DiscordCommandListener`에서 join/leave와 meeting create/end API 연동
2) `BotSttListener`에 `[전송/응답바디]`, `[AI/응답체크]` 로그 추가
3) `.env.example`의 고정 meetingId 예시 제거

---

## 🧪 테스트 결과
```bash
# 별도 테스트 명령 실행 없음 (기능 점검 중심)
```

- [ ] 로컬 테스트 통과
- [x] 관련 시나리오 수동 확인
- [x] 구현 기록이 필요한 변경인지 확인
- [ ] 필요한 경우 `docs/impl/{author}/`에 구현 기록 추가
- [ ] 구현 기록을 AI가 생성한 경우, 사실관계/대안 비교/수치 근거 검토 완료

---

## 👀 리뷰 포인트 (선택)
- join/leave 시점의 meeting 생성/종료 연동이 끊기지 않는지
- `ai_answer`가 null인 경우와 호출어 감지 로그가 기대대로 찍히는지

---

## 📎 참고 사항 (선택)
- 포함 커밋
  - `abbc91e` feat: join/leave에서 meeting 생성·종료 연동
  - `5dbee2a` chore: STT 응답 디버그 로그 추가 및 기본 meetingId 예시 제거
