### PR TITLE
refactor: 발화 저장 후 GLM 호출을 트랜잭션 밖으로 분리

### DIFF
--- a/src/main/java/com/flodiback/domain/speech/dto/SavedSpeechResult.java
+++ b/src/main/java/com/flodiback/domain/speech/dto/SavedSpeechResult.java
@@ -1,0 +1,3 @@
+package com.flodiback.domain.speech.dto;
+
+public record SavedSpeechResult(Long utteranceId, Long meetingId) {}

--- a/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
@@ -1,18 +1,10 @@
 package com.flodiback.domain.speech.service;
 
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
-import com.flodiback.domain.meeting.meeting.entity.Meeting;
-import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
-import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
-import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
-import com.flodiback.domain.meeting.meetinglog.rolling.UtteranceSavedEvent;
 import com.flodiback.domain.speech.dto.InternalSpeechRequest;
 import com.flodiback.domain.speech.dto.InternalSpeechResponse;
-import com.flodiback.global.exception.ServiceException;
+import com.flodiback.domain.speech.dto.SavedSpeechResult;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,48 +12,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class InternalSpeechService {
 
-    private final MeetingRepository meetingRepository;
-    private final UtteranceRepository utteranceRepository;
+    private final SpeechPersistenceService speechPersistenceService;
     private final SpeechAiAnswerService speechAiAnswerService;
-    private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
     public InternalSpeechResponse saveSpeech(InternalSpeechRequest request) {
-        // 발화는 반드시 기존 회의에 연결되어야 하므로 회의를 먼저 조회한다.
-        Meeting meeting = meetingRepository
-                .findById(request.meetingId())
-                .orElseThrow(() -> new ServiceException("404-1", "회의를 찾을 수 없습니다."));
+        SavedSpeechResult savedSpeech = speechPersistenceService.saveUtterance(request);
 
-        // 동시 요청이 들어오면 같은 sequenceNo가 배정될 수 있다.
-        // 현재는 단일 봇 환경이므로 허용하지만, 멀티 봇/고부하 환경에서는 DB 시퀀스나 낙관적 락으로 교체해야 한다.
-        long sequenceNo = utteranceRepository.countByMeeting(meeting) + 1;
+        // DB 저장 트랜잭션이 끝난 뒤 GLM을 호출해 DB 커넥션을 오래 잡지 않게 합니다.
+        String aiAnswer = speechAiAnswerService.generateAnswerIfCalled(savedSpeech.meetingId(), request.text());
 
-        // Discord 봇이 넘긴 발화 시각을 spoken_at으로 저장한다.
-        int tokenCount = estimateTokenCount(request.text());
-        Utterance utterance = Utterance.builder()
-                .meeting(meeting)
-                .speakerDiscordId(request.speakerDiscordId())
-                .speakerName(request.speakerName())
-                .content(request.text())
-                .spokenAt(request.timestamp())
-                .sequenceNo(sequenceNo)
-                .tokenCount(tokenCount)
-                .build();
-
-        Utterance savedUtterance = utteranceRepository.save(utterance);
-        eventPublisher.publishEvent(
-                new UtteranceSavedEvent(meeting.getId(), savedUtterance.getId(), sequenceNo, tokenCount));
-
-        // 호출어가 있는 발화라면 회의 컨텍스트와 GLM을 사용해 봇이 출력할 답변을 만든다.
-        String aiAnswer = speechAiAnswerService.generateAnswerIfCalled(meeting.getId(), request.text());
-
-        return new InternalSpeechResponse(savedUtterance.getId(), meeting.getId(), aiAnswer);
-    }
-
-    private int estimateTokenCount(String text) {
-        if (!StringUtils.hasText(text)) {
-            return 0;
-        }
-        return Math.max(1, text.length() / 4);
+        return new InternalSpeechResponse(savedSpeech.utteranceId(), savedSpeech.meetingId(), aiAnswer);
     }
 }

--- a/src/main/java/com/flodiback/domain/speech/service/SpeechPersistenceService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/SpeechPersistenceService.java
@@ -1,0 +1,63 @@
+package com.flodiback.domain.speech.service;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
+import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
+import com.flodiback.domain.meeting.meetinglog.rolling.UtteranceSavedEvent;
+import com.flodiback.domain.speech.dto.InternalSpeechRequest;
+import com.flodiback.domain.speech.dto.SavedSpeechResult;
+import com.flodiback.global.exception.ServiceException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SpeechPersistenceService {
+
+    private final MeetingRepository meetingRepository;
+    private final UtteranceRepository utteranceRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public SavedSpeechResult saveUtterance(InternalSpeechRequest request) {
+        // 이 메서드는 발화 저장만 짧게 처리하는 트랜잭션 경계입니다.
+        Meeting meeting = meetingRepository
+                .findById(request.meetingId())
+                .orElseThrow(() -> new ServiceException("404-1", "회의를 찾을 수 없습니다."));
+
+        // 현재 방식은 동시 요청에서 같은 sequenceNo가 생길 수 있어, 별도 이슈에서 보강합니다.
+        long sequenceNo = utteranceRepository.countByMeeting(meeting) + 1;
+
+        int tokenCount = estimateTokenCount(request.text());
+        Utterance utterance = Utterance.builder()
+                .meeting(meeting)
+                .speakerDiscordId(request.speakerDiscordId())
+                .speakerName(request.speakerName())
+                .content(request.text())
+                .spokenAt(request.timestamp())
+                .sequenceNo(sequenceNo)
+                .tokenCount(tokenCount)
+                .build();
+
+        Utterance savedUtterance = utteranceRepository.save(utterance);
+
+        // 저장 커밋 이후 rolling summary가 처리할 수 있도록 발화 저장 이벤트를 발행합니다.
+        eventPublisher.publishEvent(
+                new UtteranceSavedEvent(meeting.getId(), savedUtterance.getId(), sequenceNo, tokenCount));
+
+        return new SavedSpeechResult(savedUtterance.getId(), meeting.getId());
+    }
+
+    private int estimateTokenCount(String text) {
+        if (!StringUtils.hasText(text)) {
+            return 0;
+        }
+        return Math.max(1, text.length() / 4);
+    }
+}

--- a/src/test/java/com/flodiback/domain/speech/service/InternalSpeechServiceTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/InternalSpeechServiceTest.java
@@ -1,89 +1,82 @@
 package com.flodiback.domain.speech.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 
+import java.lang.reflect.Method;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.flodiback.domain.meeting.meeting.entity.Meeting;
-import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
-import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
-import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
-import com.flodiback.domain.meeting.meetinglog.rolling.UtteranceSavedEvent;
 import com.flodiback.domain.speech.dto.InternalSpeechRequest;
+import com.flodiback.domain.speech.dto.InternalSpeechResponse;
+import com.flodiback.domain.speech.dto.SavedSpeechResult;
 
 @ExtendWith(MockitoExtension.class)
 class InternalSpeechServiceTest {
 
     @Mock
-    private MeetingRepository meetingRepository;
-
-    @Mock
-    private UtteranceRepository utteranceRepository;
+    private SpeechPersistenceService speechPersistenceService;
 
     @Mock
     private SpeechAiAnswerService speechAiAnswerService;
-
-    @Mock
-    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private InternalSpeechService internalSpeechService;
 
     @Test
-    void saveSpeech_발화저장시_tokenCount와_event를_생성() {
-        Meeting meeting = org.mockito.Mockito.mock(Meeting.class);
-        given(meeting.getId()).willReturn(1L);
-        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
-        given(utteranceRepository.countByMeeting(meeting)).willReturn(0L);
-        Utterance savedUtterance = org.mockito.Mockito.mock(Utterance.class);
-        given(savedUtterance.getId()).willReturn(100L);
-        given(utteranceRepository.save(any(Utterance.class))).willReturn(savedUtterance);
+    void saveSpeech_returnsAiAnswerAfterSpeechIsPersisted() {
+        InternalSpeechRequest request = request("AI야, 인증 방식 뭐로 정했어?");
+        given(speechPersistenceService.saveUtterance(request)).willReturn(new SavedSpeechResult(100L, 1L));
+        given(speechAiAnswerService.generateAnswerIfCalled(1L, request.text())).willReturn("인증 방식은 JWT로 정했습니다.");
 
-        InternalSpeechRequest request = new InternalSpeechRequest(
-                1L, "discord-1", "김철수", "12345678901234567890", LocalDateTime.of(2026, 5, 3, 10, 0));
+        InternalSpeechResponse response = internalSpeechService.saveSpeech(request);
 
-        internalSpeechService.saveSpeech(request);
+        assertThat(response.utteranceId()).isEqualTo(100L);
+        assertThat(response.meetingId()).isEqualTo(1L);
+        assertThat(response.aiAnswer()).isEqualTo("인증 방식은 JWT로 정했습니다.");
 
-        ArgumentCaptor<Utterance> utteranceCaptor = ArgumentCaptor.forClass(Utterance.class);
-        verify(utteranceRepository).save(utteranceCaptor.capture());
-        assertThat(utteranceCaptor.getValue().getTokenCount()).isEqualTo(5);
-
-        ArgumentCaptor<UtteranceSavedEvent> eventCaptor = ArgumentCaptor.forClass(UtteranceSavedEvent.class);
-        verify(eventPublisher).publishEvent(eventCaptor.capture());
-        assertThat(eventCaptor.getValue().meetingId()).isEqualTo(1L);
-        assertThat(eventCaptor.getValue().utteranceId()).isEqualTo(100L);
-        assertThat(eventCaptor.getValue().sequenceNo()).isEqualTo(1L);
-        assertThat(eventCaptor.getValue().tokenCount()).isEqualTo(5);
+        InOrder inOrder = inOrder(speechPersistenceService, speechAiAnswerService);
+        inOrder.verify(speechPersistenceService).saveUtterance(request);
+        inOrder.verify(speechAiAnswerService).generateAnswerIfCalled(1L, request.text());
     }
 
     @Test
-    void saveSpeech_blankText는_tokenCount_0() {
-        Meeting meeting = org.mockito.Mockito.mock(Meeting.class);
-        given(meeting.getId()).willReturn(1L);
-        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
-        Utterance savedUtterance = org.mockito.Mockito.mock(Utterance.class);
-        given(savedUtterance.getId()).willReturn(100L);
-        given(utteranceRepository.save(any(Utterance.class))).willReturn(savedUtterance);
+    void saveSpeech_keepsSavedSpeechResponseWhenAiAnswerIsNull() {
+        InternalSpeechRequest request = request("이번 회의 목표를 정해봅시다.");
+        given(speechPersistenceService.saveUtterance(request)).willReturn(new SavedSpeechResult(101L, 1L));
 
-        InternalSpeechRequest request =
-                new InternalSpeechRequest(1L, "discord-1", "김철수", " ", LocalDateTime.of(2026, 5, 3, 10, 0));
+        InternalSpeechResponse response = internalSpeechService.saveSpeech(request);
 
-        internalSpeechService.saveSpeech(request);
+        assertThat(response.utteranceId()).isEqualTo(101L);
+        assertThat(response.meetingId()).isEqualTo(1L);
+        assertThat(response.aiAnswer()).isNull();
+        verify(speechAiAnswerService).generateAnswerIfCalled(1L, request.text());
+    }
 
-        ArgumentCaptor<Utterance> utteranceCaptor = ArgumentCaptor.forClass(Utterance.class);
-        verify(utteranceRepository).save(utteranceCaptor.capture());
-        assertThat(utteranceCaptor.getValue().getTokenCount()).isZero();
+    @Test
+    void saveSpeech_doesNotOwnTransactionBoundary() throws NoSuchMethodException {
+        Method saveSpeech = InternalSpeechService.class.getMethod("saveSpeech", InternalSpeechRequest.class);
+        Method saveUtterance = SpeechPersistenceService.class.getMethod("saveUtterance", InternalSpeechRequest.class);
+
+        assertThat(AnnotatedElementUtils.hasAnnotation(InternalSpeechService.class, Transactional.class))
+                .isFalse();
+        assertThat(AnnotatedElementUtils.hasAnnotation(saveSpeech, Transactional.class))
+                .isFalse();
+        assertThat(AnnotatedElementUtils.hasAnnotation(saveUtterance, Transactional.class))
+                .isTrue();
+    }
+
+    private InternalSpeechRequest request(String text) {
+        return new InternalSpeechRequest(1L, "discord-1", "김철수", text, LocalDateTime.of(2026, 5, 3, 10, 0));
     }
 }

--- a/src/test/java/com/flodiback/domain/speech/service/SpeechPersistenceServiceTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/SpeechPersistenceServiceTest.java
@@ -1,0 +1,112 @@
+package com.flodiback.domain.speech.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
+import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
+import com.flodiback.domain.meeting.meetinglog.rolling.UtteranceSavedEvent;
+import com.flodiback.domain.speech.dto.InternalSpeechRequest;
+import com.flodiback.domain.speech.dto.SavedSpeechResult;
+import com.flodiback.global.exception.ServiceException;
+
+@ExtendWith(MockitoExtension.class)
+class SpeechPersistenceServiceTest {
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @Mock
+    private UtteranceRepository utteranceRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private SpeechPersistenceService speechPersistenceService;
+
+    @Test
+    void saveUtterance_savesTokenCountAndPublishesEvent() {
+        Meeting meeting = mock(Meeting.class);
+        given(meeting.getId()).willReturn(1L);
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(utteranceRepository.countByMeeting(meeting)).willReturn(0L);
+
+        Utterance savedUtterance = mock(Utterance.class);
+        given(savedUtterance.getId()).willReturn(100L);
+        given(utteranceRepository.save(any(Utterance.class))).willReturn(savedUtterance);
+
+        InternalSpeechRequest request = request("12345678901234567890");
+
+        SavedSpeechResult result = speechPersistenceService.saveUtterance(request);
+
+        assertThat(result.utteranceId()).isEqualTo(100L);
+        assertThat(result.meetingId()).isEqualTo(1L);
+
+        ArgumentCaptor<Utterance> utteranceCaptor = ArgumentCaptor.forClass(Utterance.class);
+        verify(utteranceRepository).save(utteranceCaptor.capture());
+        Utterance utterance = utteranceCaptor.getValue();
+        assertThat(utterance.getMeeting()).isEqualTo(meeting);
+        assertThat(utterance.getSpeakerDiscordId()).isEqualTo("discord-1");
+        assertThat(utterance.getSpeakerName()).isEqualTo("김철수");
+        assertThat(utterance.getContent()).isEqualTo("12345678901234567890");
+        assertThat(utterance.getSpokenAt()).isEqualTo(LocalDateTime.of(2026, 5, 3, 10, 0));
+        assertThat(utterance.getSequenceNo()).isEqualTo(1L);
+        assertThat(utterance.getTokenCount()).isEqualTo(5);
+
+        ArgumentCaptor<UtteranceSavedEvent> eventCaptor = ArgumentCaptor.forClass(UtteranceSavedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().meetingId()).isEqualTo(1L);
+        assertThat(eventCaptor.getValue().utteranceId()).isEqualTo(100L);
+        assertThat(eventCaptor.getValue().sequenceNo()).isEqualTo(1L);
+        assertThat(eventCaptor.getValue().tokenCount()).isEqualTo(5);
+    }
+
+    @Test
+    void saveUtterance_setsTokenCountZeroWhenTextIsBlank() {
+        Meeting meeting = mock(Meeting.class);
+        given(meeting.getId()).willReturn(1L);
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+
+        Utterance savedUtterance = mock(Utterance.class);
+        given(savedUtterance.getId()).willReturn(100L);
+        given(utteranceRepository.save(any(Utterance.class))).willReturn(savedUtterance);
+
+        speechPersistenceService.saveUtterance(request(" "));
+
+        ArgumentCaptor<Utterance> utteranceCaptor = ArgumentCaptor.forClass(Utterance.class);
+        verify(utteranceRepository).save(utteranceCaptor.capture());
+        assertThat(utteranceCaptor.getValue().getTokenCount()).isZero();
+    }
+
+    @Test
+    void saveUtterance_throwsNotFoundWhenMeetingDoesNotExist() {
+        given(meetingRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> speechPersistenceService.saveUtterance(request("hello")))
+                .isInstanceOf(ServiceException.class)
+                .extracting("resultCode")
+                .isEqualTo("404-1");
+    }
+
+    private InternalSpeechRequest request(String text) {
+        return new InternalSpeechRequest(1L, "discord-1", "김철수", text, LocalDateTime.of(2026, 5, 3, 10, 0));
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #43 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #43 

---

<html>
<body>
<!--StartFragment-->
<h1>STT 발화 저장과 GLM 답변 생성 트랜잭션 분리</h1>

<h3>개념</h3>
<pre><code class="language-java">[기존 흐름]
InternalSpeechService.saveSpeech()
  @Transactional
    ├─ Meeting 조회
    ├─ Utterance 저장
    ├─ UtteranceSavedEvent 발행
    └─ GLM 답변 생성 호출

문제:
DB 저장 트랜잭션 안에서 GLM 호출까지 실행되어
외부 AI 응답 시간이 길어지면 DB 커넥션을 오래 잡을 수 있음


[변경 후 흐름]
InternalSpeechService.saveSpeech()
    ↓
SpeechPersistenceService.saveUtterance()
  @Transactional
    ├─ Meeting 조회
    ├─ Utterance 저장
    └─ UtteranceSavedEvent 발행
    ↓
트랜잭션 종료
    ↓
SpeechAiAnswerService.generateAnswerIfCalled()
    └─ GLM 답변 생성

발화 저장은 짧은 트랜잭션으로 끝내고,
GLM 호출은 트랜잭션 밖에서 실행
</code></pre>

<h3>이번 브랜치 변경 요약</h3>
<ul>
  <li>STT 발화 저장 로직과 GLM 답변 생성 로직의 트랜잭션 경계를 분리했다.</li>
  <li><code>InternalSpeechService</code>는 더 이상 직접 DB 저장 트랜잭션을 소유하지 않는다.</li>
  <li>발화 저장 전용 <code>SpeechPersistenceService</code>를 새로 추가했다.</li>
  <li><code>SpeechPersistenceService.saveUtterance()</code>만 <code>@Transactional</code>을 갖도록 변경했다.</li>
  <li>발화 저장이 끝난 뒤 <code>SpeechAiAnswerService</code>를 호출해 GLM 답변을 생성한다.</li>
  <li>저장 결과 전달용 <code>SavedSpeechResult</code> DTO를 추가했다.</li>
  <li>기존 <code>UtteranceSavedEvent</code> 발행 흐름은 유지했다.</li>
</ul>

<h3>변경 파일</h3>
<ul>
  <li><code>SavedSpeechResult.java</code> - 저장된 발화 ID와 회의 ID를 전달하는 DTO 추가</li>
  <li><code>InternalSpeechService.java</code> - 오케스트레이션 역할로 축소, 저장 후 AI 답변 생성 호출</li>
  <li><code>SpeechPersistenceService.java</code> - 발화 저장 전용 트랜잭션 서비스 추가</li>
  <li><code>InternalSpeechServiceTest.java</code> - 저장 후 AI 호출 순서와 트랜잭션 경계 검증으로 수정</li>
  <li><code>SpeechPersistenceServiceTest.java</code> - 발화 저장, tokenCount, 이벤트 발행, 예외 처리 테스트 추가</li>
</ul>

<h3>새 저장 흐름</h3>
<pre><code class="language-java">InternalSpeechService.saveSpeech(request)
       ↓
speechPersistenceService.saveUtterance(request)
       ↓
SavedSpeechResult(utteranceId, meetingId)
       ↓
speechAiAnswerService.generateAnswerIfCalled(meetingId, request.text())
       ↓
InternalSpeechResponse(utteranceId, meetingId, aiAnswer)
</code></pre>

<h3>SpeechPersistenceService 역할</h3>
<ul>
  <li><code>meetingId</code>로 회의를 조회한다.</li>
  <li>회의가 없으면 <code>ServiceException("404-1")</code>을 발생시킨다.</li>
  <li>기존 발화 수를 기준으로 <code>sequenceNo</code>를 계산한다.</li>
  <li>발화 텍스트 길이를 기준으로 간단한 <code>tokenCount</code>를 추정한다.</li>
  <li><code>Utterance</code>를 저장한다.</li>
  <li>rolling summary 처리를 위해 <code>UtteranceSavedEvent</code>를 발행한다.</li>
  <li>저장 결과로 <code>utteranceId</code>, <code>meetingId</code>만 반환한다.</li>
</ul>

<h3>트랜잭션 경계</h3>
<pre><code class="language-java">InternalSpeechService
  - @Transactional 없음
  - DB 저장과 AI 답변 생성을 순서대로 조율

SpeechPersistenceService.saveUtterance()
  - @Transactional 있음
  - 발화 저장만 짧게 처리

SpeechAiAnswerService.generateAnswerIfCalled()
  - DB 저장 트랜잭션 종료 후 호출
  - GLM 외부 호출이 DB 커넥션을 오래 점유하지 않음
</code></pre>

<h3>테스트에서 검증한 것</h3>
<ul>
  <li>발화 저장이 먼저 실행되고 그 다음 AI 답변 생성이 호출되는지 검증했다.</li>
  <li>AI 답변이 null이어도 저장된 발화 응답은 정상 반환되는지 검증했다.</li>
  <li><code>InternalSpeechService.saveSpeech()</code>에는 <code>@Transactional</code>이 없는지 검증했다.</li>
  <li><code>SpeechPersistenceService.saveUtterance()</code>에만 <code>@Transactional</code>이 있는지 검증했다.</li>
  <li>발화 저장 시 meeting, speaker 정보, content, spokenAt, sequenceNo, tokenCount가 올바르게 들어가는지 검증했다.</li>
  <li>발화 저장 후 <code>UtteranceSavedEvent</code>가 발행되는지 검증했다.</li>
  <li>공백 텍스트의 tokenCount가 0으로 계산되는지 검증했다.</li>
  <li>존재하지 않는 회의 ID면 <code>404-1</code> 예외가 발생하는지 검증했다.</li>
</ul>

<h3>기대 효과</h3>
<ul>
  <li>GLM 호출 지연이 DB 트랜잭션 시간을 늘리지 않는다.</li>
  <li>STT 발화 저장 책임과 AI 답변 생성 책임이 분리되어 코드 역할이 명확해졌다.</li>
  <li>발화 저장만 별도로 테스트할 수 있어 rolling summary 이벤트 발행 흐름 검증이 쉬워졌다.</li>
  <li>외부 AI 호출 실패/지연과 DB 저장 경계를 더 안전하게 분리할 수 있는 구조가 되었다.</li>
</ul>

<h3>현재 범위</h3>
<ul>
  <li>이번 PR은 트랜잭션 경계 분리 리팩터링만 다룬다.</li>
  <li>API 응답 계약은 변경하지 않는다.</li>
  <li><code>sequenceNo</code> 동시성 보강은 기존 주석대로 별도 이슈에서 다룬다.</li>
</ul>
<!--EndFragment-->
</body>
</html>
