### PR TITLE
[feat] 회의 종료 후 요약 및 저장 로직 연동

### DIFF
--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
@@ -5,6 +5,7 @@ import java.util.NoSuchElementException;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -61,6 +62,7 @@ public class MeetingAnalysisService {
     private final ObjectMapper objectMapper;
 
     @Async("analysisExecutor")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMeetingEnded(MeetingEndedEvent event) {
         try {

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
@@ -3,8 +3,11 @@ package com.flodiback.domain.meeting.analysis.service;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flodiback.domain.meeting.analysis.dto.AnalysisResult;
@@ -12,6 +15,7 @@ import com.flodiback.domain.meeting.analysis.dto.DecisionItem;
 import com.flodiback.domain.meeting.analysis.dto.WorkLogItem;
 import com.flodiback.domain.meeting.meeting.entity.ContextCache;
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.event.MeetingEndedEvent;
 import com.flodiback.domain.meeting.meeting.repository.ContextCacheRepository;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.meeting.meetinglog.dto.ActionItemRequest;
@@ -24,7 +28,9 @@ import com.flodiback.global.client.GlmClient;
 import com.flodiback.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -53,6 +59,16 @@ public class MeetingAnalysisService {
     private final ContextService contextService;
     private final GlmClient glmClient;
     private final ObjectMapper objectMapper;
+
+    @Async("analysisExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMeetingEnded(MeetingEndedEvent event) {
+        try {
+            analyze(event.meetingId());
+        } catch (Exception e) {
+            log.warn("회의 분석 실패 - meetingId={}: {}", event.meetingId(), e.getMessage());
+        }
+    }
 
     public void analyze(Long meetingId) {
         // 1. 회의 조회

--- a/src/main/java/com/flodiback/domain/meeting/meeting/dto/CreateMeetingResponse.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/dto/CreateMeetingResponse.java
@@ -5,4 +5,9 @@ import java.time.LocalDateTime;
 import com.flodiback.global.enums.MeetingStatus;
 
 public record CreateMeetingResponse(
-        Long id, Long projectId, String title, LocalDateTime startedAt, MeetingStatus status) {}
+        Long id,
+        Long projectId,
+        String title,
+        LocalDateTime startedAt,
+        MeetingStatus status,
+        boolean projectConnected) {}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/event/MeetingEndedEvent.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/event/MeetingEndedEvent.java
@@ -1,0 +1,3 @@
+package com.flodiback.domain.meeting.meeting.event;
+
+public record MeetingEndedEvent(Long meetingId) {}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -2,6 +2,7 @@ package com.flodiback.domain.meeting.meeting.service;
 
 import java.util.NoSuchElementException;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,6 +10,7 @@ import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
 import com.flodiback.domain.meeting.meeting.dto.MeetingDetailResponse;
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.event.MeetingEndedEvent;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
@@ -22,6 +24,7 @@ public class MeetingService {
 
     private final MeetingRepository meetingRepository;
     private final ProjectRepository projectRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public CreateMeetingResponse create(CreateMeetingRequest req) {
         Project project = null;
@@ -39,7 +42,8 @@ public class MeetingService {
                 project != null ? project.getId() : null,
                 meeting.getTitle(),
                 meeting.getStartedAt(),
-                meeting.getStatus());
+                meeting.getStatus(),
+                project != null);
     }
 
     public MeetingDetailResponse end(Long id) {
@@ -49,6 +53,7 @@ public class MeetingService {
         meeting.end();
         meetingRepository.save(meeting);
 
+        eventPublisher.publishEvent(new MeetingEndedEvent(meeting.getId()));
         return toDetailResponse(meeting);
     }
 

--- a/src/main/java/com/flodiback/global/config/AsyncConfig.java
+++ b/src/main/java/com/flodiback/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.flodiback.global.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "analysisExecutor")
+    public Executor analysisExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("analysis-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/test/java/com/flodiback/domain/meeting/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meeting/service/MeetingServiceTest.java
@@ -15,11 +15,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
 import com.flodiback.domain.meeting.meeting.dto.MeetingDetailResponse;
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.event.MeetingEndedEvent;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
@@ -36,6 +38,9 @@ class MeetingServiceTest {
 
     @Mock
     private ProjectRepository projectRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     // ─── create ───────────────────────────────────────────
 
@@ -54,6 +59,7 @@ class MeetingServiceTest {
         assertThat(response.projectId()).isNull();
         assertThat(response.title()).isEqualTo("테스트 회의");
         assertThat(response.status()).isEqualTo(MeetingStatus.IN_PROGRESS);
+        assertThat(response.projectConnected()).isFalse();
     }
 
     @Test
@@ -72,6 +78,7 @@ class MeetingServiceTest {
         verify(meetingRepository).save(any(Meeting.class));
         assertThat(response.title()).isEqualTo("테스트 회의");
         assertThat(response.status()).isEqualTo(MeetingStatus.IN_PROGRESS);
+        assertThat(response.projectConnected()).isTrue();
     }
 
     @Test
@@ -133,6 +140,31 @@ class MeetingServiceTest {
                 .hasMessage("존재하지 않는 회의입니다.");
 
         verify(meetingRepository, never()).save(any());
+    }
+
+    @Test
+    void end_유효한_id면_MeetingEndedEvent_발행() {
+        // given
+        Meeting meeting = Meeting.builder().title("테스트 회의").build();
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        meetingService.end(1L);
+
+        // then
+        verify(eventPublisher).publishEvent(any(MeetingEndedEvent.class));
+    }
+
+    @Test
+    void end_존재하지않는_id면_이벤트_미발행() {
+        // given
+        given(meetingRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> meetingService.end(999L)).isInstanceOf(NoSuchElementException.class);
+
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
     // ─── getById ──────────────────────────────────────────


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #38 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #38

---

## 📝 작업 내용

회의 종료 시 분석이 자동으로 실행되도록 이벤트 기반 비동기 트리거를 구현했습니다.

트랜잭션 커밋 이후에만 분석이 실행되어 데이터 정합성을 보장하며, 회의 생성 응답에 프로젝트 연결 여부를 추가해 봇이 사용자에게 저장

불가 여부를 안내할 수 있도록 했습니다.

---

## ✅ 주요 변경 사항

1. `MeetingEndedEvent` 신규 — Spring 내부 이벤트 레코드
2. `AsyncConfig` 신규 — `@EnableAsync` + `analysisExecutor` 스레드풀 (core 2, max 5)
3. `MeetingService.end()` — 회의 저장 후 `MeetingEndedEvent` 발행
4. `MeetingAnalysisService` — `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` 리스너 추가, project 없는 회의는 warn 로그로
스킵
5. `CreateMeetingResponse` — `projectConnected` 필드 추가 (봇이 !join 시 안내용)

---

## 🧪 테스트 결과

```bash
./gradlew test --tests "com.flodiback.domain.meeting.meeting.service.MeetingServiceTest"

- 로컬 테스트 통과
- end() 정상 종료 시 MeetingEndedEvent 발행 검증
- end() 예외 시 이벤트 미발행 검증
- create() 응답의 projectConnected 값 검증
```

---

## 👀 리뷰 포인트 (선택)
<!-- 리뷰어가 집중해서 보면 좋은 부분 -->
- 예) DB 트랜잭션 처리
- 예) 예외 처리 분기

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
