### PR TITLE
[Feat] project crud api 구현

### DIFF
--- a/src/main/java/com/flodiback/api/project/ProjectController.java
+++ b/src/main/java/com/flodiback/api/project/ProjectController.java
@@ -6,12 +6,14 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flodiback.domain.project.project.dto.CreateProjectRequest;
 import com.flodiback.domain.project.project.dto.ProjectResponse;
+import com.flodiback.domain.project.project.dto.UpdateProjectRequest;
 import com.flodiback.domain.project.project.service.ProjectService;
 import com.flodiback.global.rsData.RsData;
 
@@ -38,6 +40,11 @@ public class ProjectController {
     @GetMapping("/{id}")
     public RsData<ProjectResponse> getById(@PathVariable Long id) {
         return RsData.of("200-1", "프로젝트 조회 성공.", projectService.getById(id));
+    }
+
+    @PutMapping("/{id}")
+    public RsData<ProjectResponse> update(@PathVariable Long id, @RequestBody UpdateProjectRequest req) {
+        return RsData.of("200-1", "프로젝트가 수정되었습니다.", projectService.update(id, req));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/flodiback/api/project/ProjectController.java
+++ b/src/main/java/com/flodiback/api/project/ProjectController.java
@@ -2,6 +2,7 @@ package com.flodiback.api.project;
 
 import java.util.List;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,5 +38,11 @@ public class ProjectController {
     @GetMapping("/{id}")
     public RsData<ProjectResponse> getById(@PathVariable Long id) {
         return RsData.of("200-1", "프로젝트 조회 성공.", projectService.getById(id));
+    }
+
+    @DeleteMapping("/{id}")
+    public RsData<Void> delete(@PathVariable Long id) {
+        projectService.delete(id);
+        return RsData.of("200-1", "프로젝트가 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/flodiback/api/project/ProjectController.java
+++ b/src/main/java/com/flodiback/api/project/ProjectController.java
@@ -1,5 +1,9 @@
 package com.flodiback.api.project;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,5 +27,15 @@ public class ProjectController {
     @PostMapping
     public RsData<ProjectResponse> create(@RequestBody @Valid CreateProjectRequest req) {
         return RsData.of("201-1", "프로젝트가 생성되었습니다.", projectService.create(req));
+    }
+
+    @GetMapping
+    public RsData<List<ProjectResponse>> getAll() {
+        return RsData.of("200-1", "프로젝트 목록 조회 성공.", projectService.getAll());
+    }
+
+    @GetMapping("/{id}")
+    public RsData<ProjectResponse> getById(@PathVariable Long id) {
+        return RsData.of("200-1", "프로젝트 조회 성공.", projectService.getById(id));
     }
 }

--- a/src/main/java/com/flodiback/api/project/ProjectController.java
+++ b/src/main/java/com/flodiback/api/project/ProjectController.java
@@ -1,0 +1,27 @@
+package com.flodiback.api.project;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flodiback.domain.project.project.dto.CreateProjectRequest;
+import com.flodiback.domain.project.project.dto.ProjectResponse;
+import com.flodiback.domain.project.project.service.ProjectService;
+import com.flodiback.global.rsData.RsData;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/projects")
+@RequiredArgsConstructor
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    @PostMapping
+    public RsData<ProjectResponse> create(@RequestBody @Valid CreateProjectRequest req) {
+        return RsData.of("201-1", "프로젝트가 생성되었습니다.", projectService.create(req));
+    }
+}

--- a/src/main/java/com/flodiback/domain/project/project/dto/CreateProjectRequest.java
+++ b/src/main/java/com/flodiback/domain/project/project/dto/CreateProjectRequest.java
@@ -1,0 +1,5 @@
+package com.flodiback.domain.project.project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateProjectRequest(@NotBlank String name, String description, String techStack, Long serverId) {}

--- a/src/main/java/com/flodiback/domain/project/project/dto/ProjectResponse.java
+++ b/src/main/java/com/flodiback/domain/project/project/dto/ProjectResponse.java
@@ -1,0 +1,6 @@
+package com.flodiback.domain.project.project.dto;
+
+import java.time.LocalDateTime;
+
+public record ProjectResponse(
+        Long id, Long serverId, String name, String description, String techStack, LocalDateTime createdAt) {}

--- a/src/main/java/com/flodiback/domain/project/project/dto/UpdateProjectRequest.java
+++ b/src/main/java/com/flodiback/domain/project/project/dto/UpdateProjectRequest.java
@@ -1,0 +1,3 @@
+package com.flodiback.domain.project.project.dto;
+
+public record UpdateProjectRequest(String name, String description, String techStack) {}

--- a/src/main/java/com/flodiback/domain/project/project/entity/Project.java
+++ b/src/main/java/com/flodiback/domain/project/project/entity/Project.java
@@ -51,6 +51,12 @@ public class Project {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    public void update(String name, String description, String techStack) {
+        if (name != null) this.name = name;
+        if (description != null) this.description = description;
+        if (techStack != null) this.techStack = techStack;
+    }
+
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/flodiback/domain/project/project/entity/Project.java
+++ b/src/main/java/com/flodiback/domain/project/project/entity/Project.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.type.SqlTypes;
 
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "projects")
+@SQLDelete(sql = "UPDATE projects SET deleted_at = now() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/flodiback/domain/project/project/entity/Project.java
+++ b/src/main/java/com/flodiback/domain/project/project/entity/Project.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.type.SqlTypes;
 
 import com.flodiback.domain.server.server.entity.DiscordServer;
@@ -16,6 +17,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "projects")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Project {
@@ -45,6 +47,13 @@ public class Project {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 
     @Builder
     public Project(DiscordServer server, String name, String description, String techStack, String metadata) {

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -1,5 +1,6 @@
 package com.flodiback.domain.project.project.service;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Service;
@@ -38,6 +39,18 @@ public class ProjectService {
                 .build();
         projectRepository.save(project);
 
+        return toResponse(project);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectResponse> getAll() {
+        return projectRepository.findAll().stream().map(this::toResponse).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectResponse getById(Long id) {
+        Project project =
+                projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
         return toResponse(project);
     }
 

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -1,0 +1,53 @@
+package com.flodiback.domain.project.project.service;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flodiback.domain.project.project.dto.CreateProjectRequest;
+import com.flodiback.domain.project.project.dto.ProjectResponse;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.domain.server.server.entity.DiscordServer;
+import com.flodiback.domain.server.server.repository.DiscordServerRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final DiscordServerRepository discordServerRepository;
+
+    public ProjectResponse create(CreateProjectRequest req) {
+        DiscordServer server = null;
+        if (req.serverId() != null) {
+            server = discordServerRepository
+                    .findById(req.serverId())
+                    .orElseThrow(() -> new NoSuchElementException("존재하지 않는 서버입니다."));
+        }
+
+        Project project = Project.builder()
+                .server(server)
+                .name(req.name())
+                .description(req.description())
+                .techStack(req.techStack())
+                .build();
+        projectRepository.save(project);
+
+        return toResponse(project);
+    }
+
+    ProjectResponse toResponse(Project project) {
+        return new ProjectResponse(
+                project.getId(),
+                project.getServer() != null ? project.getServer().getId() : null,
+                project.getName(),
+                project.getDescription(),
+                project.getTechStack(),
+                project.getCreatedAt());
+    }
+}

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.flodiback.domain.project.project.dto.CreateProjectRequest;
 import com.flodiback.domain.project.project.dto.ProjectResponse;
+import com.flodiback.domain.project.project.dto.UpdateProjectRequest;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
 import com.flodiback.domain.server.server.entity.DiscordServer;
@@ -51,6 +52,13 @@ public class ProjectService {
     public ProjectResponse getById(Long id) {
         Project project =
                 projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        return toResponse(project);
+    }
+
+    public ProjectResponse update(Long id, UpdateProjectRequest req) {
+        Project project =
+                projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        project.update(req.name(), req.description(), req.techStack());
         return toResponse(project);
     }
 

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -54,6 +54,12 @@ public class ProjectService {
         return toResponse(project);
     }
 
+    public void delete(Long id) {
+        Project project =
+                projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        project.softDelete();
+    }
+
     ProjectResponse toResponse(Project project) {
         return new ProjectResponse(
                 project.getId(),

--- a/src/main/java/com/flodiback/domain/server/server/repository/DiscordServerRepository.java
+++ b/src/main/java/com/flodiback/domain/server/server/repository/DiscordServerRepository.java
@@ -1,0 +1,7 @@
+package com.flodiback.domain.server.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flodiback.domain.server.server.entity.DiscordServer;
+
+public interface DiscordServerRepository extends JpaRepository<DiscordServer, Long> {}

--- a/src/main/resources/db/migration/V6__project_soft_delete.sql
+++ b/src/main/resources/db/migration/V6__project_soft_delete.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD COLUMN deleted_at TIMESTAMP;

--- a/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
@@ -1,0 +1,89 @@
+package com.flodiback.domain.project.project.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flodiback.domain.project.project.dto.CreateProjectRequest;
+import com.flodiback.domain.project.project.dto.ProjectResponse;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.domain.server.server.entity.DiscordServer;
+import com.flodiback.domain.server.server.repository.DiscordServerRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private DiscordServerRepository discordServerRepository;
+
+    // ─── create ───────────────────────────────────────────
+
+    @Test
+    void create_serverId없으면_server_null로_프로젝트생성() {
+        // given
+        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", null);
+        given(projectRepository.save(any(Project.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        ProjectResponse response = projectService.create(req);
+
+        // then
+        verify(discordServerRepository, never()).findById(any());
+        verify(projectRepository).save(any(Project.class));
+        assertThat(response.serverId()).isNull();
+        assertThat(response.name()).isEqualTo("플로디 프로젝트");
+        assertThat(response.description()).isEqualTo("설명");
+        assertThat(response.techStack()).isEqualTo("Java");
+    }
+
+    @Test
+    void create_유효한_serverId면_서버연결하여_프로젝트생성() {
+        // given
+        DiscordServer server =
+                DiscordServer.builder().guildId("guild-123").guildName("플로디 서버").build();
+        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", 1L);
+        given(discordServerRepository.findById(1L)).willReturn(Optional.of(server));
+        given(projectRepository.save(any(Project.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        ProjectResponse response = projectService.create(req);
+
+        // then
+        verify(discordServerRepository).findById(1L);
+        verify(projectRepository).save(any(Project.class));
+        assertThat(response.name()).isEqualTo("플로디 프로젝트");
+    }
+
+    @Test
+    void create_존재하지않는_serverId면_예외발생() {
+        // given
+        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", 999L);
+        given(discordServerRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> projectService.create(req))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 서버입니다.");
+
+        verify(projectRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.flodiback.domain.project.project.dto.CreateProjectRequest;
 import com.flodiback.domain.project.project.dto.ProjectResponse;
+import com.flodiback.domain.project.project.dto.UpdateProjectRequest;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
 import com.flodiback.domain.server.server.entity.DiscordServer;
@@ -136,6 +137,39 @@ class ProjectServiceTest {
 
         // when & then
         assertThatThrownBy(() -> projectService.getById(999L))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 프로젝트입니다.");
+    }
+
+    // ─── update ───────────────────────────────────────────
+
+    @Test
+    void update_유효한_id면_프로젝트수정() {
+        // given
+        Project project = Project.builder()
+                .name("기존 이름")
+                .description("기존 설명")
+                .techStack("Java")
+                .build();
+        UpdateProjectRequest req = new UpdateProjectRequest("새 이름", "새 설명", "Kotlin");
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+
+        // when
+        ProjectResponse response = projectService.update(1L, req);
+
+        // then
+        assertThat(response.name()).isEqualTo("새 이름");
+        assertThat(response.description()).isEqualTo("새 설명");
+        assertThat(response.techStack()).isEqualTo("Kotlin");
+    }
+
+    @Test
+    void update_존재하지않는_id면_예외발생() {
+        // given
+        given(projectRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> projectService.update(999L, new UpdateProjectRequest("이름", null, null)))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("존재하지 않는 프로젝트입니다.");
     }

--- a/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -85,5 +87,56 @@ class ProjectServiceTest {
                 .hasMessage("존재하지 않는 서버입니다.");
 
         verify(projectRepository, never()).save(any());
+    }
+
+    // ─── getAll ───────────────────────────────────────────
+
+    @Test
+    void getAll_프로젝트목록반환() {
+        // given
+        Project p1 = Project.builder().name("프로젝트 A").build();
+        Project p2 = Project.builder().name("프로젝트 B").build();
+        willReturn(List.of(p1, p2)).given(projectRepository).findAll();
+
+        // when
+        List<ProjectResponse> responses = projectService.getAll();
+
+        // then
+        verify(projectRepository).findAll();
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).name()).isEqualTo("프로젝트 A");
+        assertThat(responses.get(1).name()).isEqualTo("프로젝트 B");
+    }
+
+    // ─── getById ──────────────────────────────────────────
+
+    @Test
+    void getById_유효한_id면_프로젝트반환() {
+        // given
+        Project project = Project.builder()
+                .name("플로디 프로젝트")
+                .description("설명")
+                .techStack("Java")
+                .build();
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+
+        // when
+        ProjectResponse response = projectService.getById(1L);
+
+        // then
+        assertThat(response.name()).isEqualTo("플로디 프로젝트");
+        assertThat(response.description()).isEqualTo("설명");
+        assertThat(response.techStack()).isEqualTo("Java");
+    }
+
+    @Test
+    void getById_존재하지않는_id면_예외발생() {
+        // given
+        given(projectRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> projectService.getById(999L))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 프로젝트입니다.");
     }
 }

--- a/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
@@ -139,4 +139,30 @@ class ProjectServiceTest {
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("존재하지 않는 프로젝트입니다.");
     }
+
+    // ─── delete ───────────────────────────────────────────
+
+    @Test
+    void delete_유효한_id면_소프트삭제() {
+        // given
+        Project project = Project.builder().name("플로디 프로젝트").build();
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+
+        // when
+        projectService.delete(1L);
+
+        // then
+        assertThat(project.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    void delete_존재하지않는_id면_예외발생() {
+        // given
+        given(projectRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> projectService.delete(999L))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("존재하지 않는 프로젝트입니다.");
+    }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #47 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #47 

---

## **📝 작업 내용**

프로젝트 CRUD API를 구현했습니다. 생성/조회/수정/삭제 4가지 엔드포인트를 모두 포함하며, 삭제는 deleted_at 컬럼을 이용한 soft delete 방식을 채택했습니다. Flyway 마이그레이션으로 스키마 변경을 관리합니다.
이후 디스코드 봇 연결 시 사용자 플로우를 고려하여 수정 가능성이 있습니다.

---

## **✅ 주요 변경 사항**

1. POST /api/v1/projects — 프로젝트 생성 (serverId 선택적 연결)
2. GET /api/v1/projects, GET /api/v1/projects/{id} — 전체/단건 조회
3. PUT /api/v1/projects/{id} — 수정 (null 필드는 기존 값 유지)
4. DELETE /api/v1/projects/{id} — soft delete (deleted_at 설정, @SQLRestriction으로 자동 필터)
5. V6__project_soft_delete.sql — projects 테이블에 deleted_at 컬럼 추가

---

## **🧪 테스트 결과**

./gradlew test --tests "com.flodiback.domain.project.project.service.ProjectServiceTest"

- 로컬 테스트 통과 (10개: create 3, getAll 1, getById 2, update 2, delete 2)
- 관련 시나리오 수동 확인

---

**👀 리뷰 포인트 (선택)**

- @SQLRestriction("deleted_at IS NULL") 으로 soft delete된 프로젝트를 JPA 쿼리 레벨에서 자동 제외 — findAll, findById 모두 적용됨
- PUT의 partial update 방식: 요청 바디에서 null인 필드는 기존 값을 유지 (name, description, techStack 각각 독립적으로 업데이트 가능)
- DiscordServer가 ON DELETE SET NULL이므로 서버 삭제 시 project.server_id는 null로 남음 — cascade 삭제 없음

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
