### PR TITLE
[Feat] 회의 외 질문 fallback 프롬프트 추가

### DIFF
--- a/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
@@ -25,8 +25,10 @@ public class SpeechAiAnswerService {
     private static final Pattern LEADING_PUNCTUATION = Pattern.compile("^[\\s,，.。?？!！:：;；-]+");
     private static final String SYSTEM_PROMPT = """
             너는 Discord 회의에 참여하는 AI 회의 보조자야.
-            회의 맥락을 바탕으로 한국어로 2~3문장만 답해줘.
-            컨텍스트에 없는 내용은 추측하지 말고 모른다고 말해줘.
+            항상 회의 컨텍스트를 먼저 확인하고 한국어로 2~3문장만 답해줘.
+            회의 컨텍스트에 근거가 있으면 "[회의 기반]"으로 시작해 답해줘.
+            회의 컨텍스트에 답이 없거나 질문이 회의와 무관하면 "회의 내용에서는 해당 내용을 찾지 못했습니다."라고 먼저 말하고, 이어서 "[일반 지식 기반]"으로 네가 알고 있는 범위에서 간결하게 답해줘.
+            실제 웹 검색은 하지 않으므로 "웹에서 찾았다", "검색 결과에 따르면"처럼 외부 검색을 한 것처럼 말하지 마.
             """;
 
     private final ContextService contextService;
@@ -82,6 +84,12 @@ public class SpeechAiAnswerService {
     private String buildUserPrompt(ContextResponse context, String question) {
         // GLM이 회의 맥락을 함께 읽을 수 있도록 컨텍스트를 섹션별 텍스트로 정리합니다.
         StringBuilder prompt = new StringBuilder();
+
+        // 회의 맥락을 우선하되, 근거가 없으면 일반 지식 답변임을 표시하게 합니다.
+        prompt.append("[답변 규칙]\n");
+        prompt.append("- 회의 컨텍스트에 답이 있으면 [회의 기반]으로 답변\n");
+        prompt.append("- 회의 컨텍스트에 답이 없거나 무관하면 회의 내용에 없다고 밝힌 뒤 [일반 지식 기반]으로 답변\n");
+        prompt.append("- 실제 웹 검색은 하지 않았으므로 웹 검색 출처가 있는 것처럼 표현하지 않음\n\n");
 
         prompt.append("[프로젝트 정보]\n");
         prompt.append("프로젝트명: ")

--- a/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
@@ -64,14 +64,44 @@ class SpeechAiAnswerServiceTest {
         assertThat(result).isEqualTo("인증 방식은 JWT로 결정했습니다.");
         verify(contextService).assemble(1L, "인증 방식 뭐로 하기로 했지?");
 
+        ArgumentCaptor<String> systemPromptCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(aiChatService).generateAnswer(anyString(), userPromptCaptor.capture());
+        verify(aiChatService).generateAnswer(systemPromptCaptor.capture(), userPromptCaptor.capture());
+        assertThat(systemPromptCaptor.getValue())
+                .contains("[회의 기반]")
+                .contains("[일반 지식 기반]")
+                .contains("실제 웹 검색은 하지 않으므로");
         assertThat(userPromptCaptor.getValue())
+                .contains("[답변 규칙]")
+                .contains("[회의 기반]")
+                .contains("[일반 지식 기반]")
                 .contains("Flodi")
                 .contains("인증 방식은 JWT로 한다.")
                 .contains("로그인 기능 담당자를 정했다.")
                 .contains("[질문]")
                 .contains("인증 방식 뭐로 하기로 했지?");
+    }
+
+    @Test
+    void generateAnswerIfCalled_allowsGeneralKnowledgeFallback_whenContextDoesNotContainAnswer() {
+        ContextResponse context = ContextResponse.noProject(null, List.of());
+        given(contextService.assemble(1L, "코끼리 나이는 몇 살이야?")).willReturn(context);
+        given(aiChatService.generateAnswer(anyString(), anyString()))
+                .willReturn("회의 내용에서는 해당 내용을 찾지 못했습니다. [일반 지식 기반] 코끼리는 보통 60~70년 정도 살 수 있습니다.");
+
+        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "클로드야, 코끼리 나이는 몇 살이야?");
+
+        assertThat(result).isEqualTo("회의 내용에서는 해당 내용을 찾지 못했습니다. [일반 지식 기반] 코끼리는 보통 60~70년 정도 살 수 있습니다.");
+        verify(contextService).assemble(1L, "코끼리 나이는 몇 살이야?");
+
+        ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(aiChatService).generateAnswer(anyString(), userPromptCaptor.capture());
+        assertThat(userPromptCaptor.getValue())
+                .contains("회의 컨텍스트에 답이 없거나 무관하면")
+                .contains("회의 내용에 없다고 밝힌 뒤")
+                .contains("[일반 지식 기반]")
+                .contains("실제 웹 검색은 하지 않았으므로")
+                .contains("코끼리 나이는 몇 살이야?");
     }
 
     @Test


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #46 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #46 

---

<html>
<body>
<!--StartFragment-->
<h1>회의 외 질문 일반 지식 fallback 응답 추가</h1>

<h3>왜 변경했는가</h3>
<p>
기존 AI 답변 프롬프트는 회의 컨텍스트에 없는 내용에 대해 추측하지 말고 모른다고 답하도록 되어 있었습니다.
이 방식은 회의 관련 질문에는 안전하지만, 사용자가 호출어로 일반 지식 질문을 했을 때 답변 활용도가 떨어질 수 있습니다.
</p>

<p>
이번 변경에서는 AI가 항상 회의 컨텍스트를 먼저 확인하되, 회의 맥락에 답이 없거나 질문이 회의와 무관한 경우에는
그 사실을 먼저 밝히고 일반 지식 기반 답변을 이어서 제공하도록 프롬프트 규칙을 보강했습니다.
</p>

<h3>변경 전 흐름</h3>
<pre><code class="language-java">사용자 발화: "클로드야, 일반 질문 ..."
       ↓
SpeechAiAnswerService
       ↓
회의 컨텍스트 조립
       ↓
GLM 호출
       ↓
컨텍스트에 없으면 모른다고 답변
</code></pre>

<h3>변경 후 흐름</h3>
<pre><code class="language-java">사용자 발화: "클로드야, 일반 질문 ..."
       ↓
SpeechAiAnswerService
       ↓
회의 컨텍스트 조립
       ↓
프롬프트에 답변 규칙 추가
       ↓
GLM 호출
       ↓
1. 회의 컨텍스트에 답이 있으면 [회의 기반]으로 답변
2. 회의 컨텍스트에 답이 없거나 무관하면
   "회의 내용에서는 해당 내용을 찾지 못했습니다."라고 먼저 안내
3. 이어서 [일반 지식 기반]으로 간결하게 답변
</code></pre>

<h3>핵심 변경</h3>
<ul>
  <li><code>SpeechAiAnswerService</code>의 시스템 프롬프트를 보강했습니다.</li>
  <li>회의 컨텍스트에 근거가 있는 답변은 <code>[회의 기반]</code>으로 시작하도록 했습니다.</li>
  <li>회의 컨텍스트에 답이 없거나 질문이 회의와 무관하면 일반 지식 fallback 답변을 허용했습니다.</li>
  <li>fallback 답변은 먼저 회의 내용에서 찾지 못했다고 밝힌 뒤 <code>[일반 지식 기반]</code>으로 이어서 답하도록 했습니다.</li>
  <li>실제 웹 검색을 하지 않았으므로 검색 결과나 외부 출처가 있는 것처럼 말하지 않도록 명시했습니다.</li>
  <li>사용자 프롬프트에도 동일한 답변 규칙 섹션을 추가해 GLM이 규칙을 더 안정적으로 따르도록 했습니다.</li>
</ul>

<h3>추가된 답변 규칙</h3>
<pre><code class="language-java">[답변 규칙]
- 회의 컨텍스트에 답이 있으면 [회의 기반]으로 답변
- 회의 컨텍스트에 답이 없거나 무관하면
  회의 내용에 없다고 밝힌 뒤 [일반 지식 기반]으로 답변
- 실제 웹 검색은 하지 않았으므로
  웹 검색 출처가 있는 것처럼 표현하지 않음
</code></pre>

<h3>예상 응답 형태</h3>
<pre><code class="language-text">회의 관련 질문:
[회의 기반] 인증 방식은 기존 결정사항에 따라 JWT로 하기로 했습니다.

회의 외 질문:
회의 내용에서는 해당 내용을 찾지 못했습니다.
[일반 지식 기반] 제가 알고 있는 범위에서는 ...
</code></pre>

<h3>변경 파일</h3>
<ul>
  <li><code>SpeechAiAnswerService.java</code> - 시스템 프롬프트와 사용자 프롬프트 답변 규칙 보강</li>
  <li><code>SpeechAiAnswerServiceTest.java</code> - 회의 기반/일반 지식 기반 fallback 프롬프트 검증 추가</li>
</ul>

<h3>테스트에서 검증한 것</h3>
<ul>
  <li>시스템 프롬프트에 <code>[회의 기반]</code>, <code>[일반 지식 기반]</code> 규칙이 포함되는지 검증했습니다.</li>
  <li>사용자 프롬프트에 <code>[답변 규칙]</code> 섹션이 포함되는지 검증했습니다.</li>
  <li>회의 컨텍스트에 답이 없는 질문도 AI 답변 흐름을 탈 수 있는지 검증했습니다.</li>
  <li>fallback 답변 시 회의 내용에 없음을 먼저 알리고 일반 지식 기반으로 답하도록 프롬프트가 구성되는지 검증했습니다.</li>
  <li>실제 웹 검색을 한 것처럼 표현하지 말라는 지시가 프롬프트에 포함되는지 검증했습니다.</li>
</ul>

<h3>기대 효과</h3>
<ul>
  <li>회의 관련 질문은 기존처럼 회의 컨텍스트를 우선해 답변할 수 있습니다.</li>
  <li>회의와 직접 관련 없는 질문도 무조건 모른다고 끝내지 않고 일반 지식 기반으로 대응할 수 있습니다.</li>
  <li>회의 기반 답변과 일반 지식 기반 답변을 라벨로 구분해 사용자가 답변 근거를 파악하기 쉬워집니다.</li>
  <li>웹 검색을 하지 않는 현재 구조에서 외부 검색을 한 것처럼 보이는 잘못된 표현을 줄일 수 있습니다.</li>
</ul>

<h3>현재 범위</h3>
<ul>
  <li>이번 PR은 GLM 프롬프트 정책 개선만 다룹니다.</li>
  <li>API 요청/응답 계약은 변경하지 않습니다.</li>
  <li>실제 웹 검색 기능을 추가하지 않습니다.</li>
  <li>회의 컨텍스트 조회 방식이나 GLM 호출 구조는 변경하지 않습니다.</li>
</ul>

<h3>커밋</h3>
<ul>
  <li><code>93d243d feat: 회의 외 질문 fallback 프롬프트 추가</code></li>
</ul>
<!--EndFragment-->
</body>
</html>
