### PR TITLE
[Feat] 프로젝트 생성 및 회의 시작 종료 명령어를 유저 플로우에 맞게 추가

### DIFF
--- a/src/main/java/com/flodiback/api/project/ProjectController.java
+++ b/src/main/java/com/flodiback/api/project/ProjectController.java
@@ -42,6 +42,15 @@ public class ProjectController {
         return RsData.of("200-1", "프로젝트 조회 성공.", projectService.getById(id));
     }
 
+    @GetMapping("/channel/{channelId}")
+    public RsData<ProjectResponse> getByChannelId(@PathVariable String channelId) {
+        ProjectResponse response = projectService.getByChannelId(channelId);
+        if (response == null) {
+            return RsData.of("404-1", "채널에 연결된 프로젝트가 없습니다.", null);
+        }
+        return RsData.of("200-1", "프로젝트 조회 성공.", response);
+    }
+
     @PutMapping("/{id}")
     public RsData<ProjectResponse> update(@PathVariable Long id, @RequestBody UpdateProjectRequest req) {
         return RsData.of("200-1", "프로젝트가 수정되었습니다.", projectService.update(id, req));

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -47,7 +47,11 @@ public class DiscordCommandListener extends ListenerAdapter {
         WAITING_TECH_STACK
     }
 
-    private record ProjectCreationState(ProjectCreationStep step, String name, String description) {}
+    private static final long PENDING_TTL_MS = 60_000;
+
+    private record ProjectCreationState(ProjectCreationStep step, String name, String description, long createdAt) {}
+
+    private record MeetingConfirmationState(long createdAt) {}
 
     // 명령어 접두사(예: !)
     private final String prefix;
@@ -63,6 +67,8 @@ public class DiscordCommandListener extends ListenerAdapter {
     private final Map<Long, Long> activeMeetingIdByGuild = new ConcurrentHashMap<>();
     // 채널별 진행 중인 프로젝트 생성 상태
     private final Map<Long, ProjectCreationState> pendingProjectCreations = new ConcurrentHashMap<>();
+    // 채널별 회의 시작 확인 대기 상태
+    private final Map<Long, MeetingConfirmationState> pendingMeetingConfirmations = new ConcurrentHashMap<>();
 
     public DiscordCommandListener() {
         this("!", new OpenAiSttProvider(), 1L);
@@ -84,6 +90,12 @@ public class DiscordCommandListener extends ListenerAdapter {
 
         long channelId = event.getChannel().getIdLong();
 
+        // 회의 시작 확인 대기 중인 채널이면 먼저 처리
+        if (pendingMeetingConfirmations.containsKey(channelId)) {
+            handleMeetingConfirmationStep(event, channelId);
+            return;
+        }
+
         // 프로젝트 생성 대화 중인 채널이면 명령어보다 먼저 처리
         if (pendingProjectCreations.containsKey(channelId)) {
             handleProjectCreationStep(event, channelId);
@@ -102,6 +114,8 @@ public class DiscordCommandListener extends ListenerAdapter {
             case "leave" -> handleLeave(event);
             case "stats" -> handleStats(event);
             case "project start" -> handleProjectStart(event, channelId);
+            case "meeting start" -> handleMeetingStart(event, channelId);
+            case "meeting end" -> handleMeetingEnd(event);
             default -> {
                 // 미지원 명령은 조용히 무시
             }
@@ -109,13 +123,24 @@ public class DiscordCommandListener extends ListenerAdapter {
     }
 
     private void handleProjectStart(MessageReceivedEvent event, long channelId) {
-        pendingProjectCreations.put(channelId, new ProjectCreationState(ProjectCreationStep.WAITING_NAME, null, null));
+        pendingProjectCreations.put(
+                channelId,
+                new ProjectCreationState(ProjectCreationStep.WAITING_NAME, null, null, System.currentTimeMillis()));
         event.getChannel().sendMessage("프로젝트 이름을 입력해주세요.").queue();
     }
 
     private void handleProjectCreationStep(MessageReceivedEvent event, long channelId) {
-        String input = event.getMessage().getContentRaw().trim();
         ProjectCreationState state = pendingProjectCreations.get(channelId);
+
+        if (System.currentTimeMillis() - state.createdAt() > PENDING_TTL_MS) {
+            pendingProjectCreations.remove(channelId);
+            event.getChannel()
+                    .sendMessage("⏰ 프로젝트 생성 시간이 초과됐습니다. 다시 `!project start`를 입력해주세요.")
+                    .queue();
+            return;
+        }
+
+        String input = event.getMessage().getContentRaw().trim();
 
         switch (state.step()) {
             case WAITING_NAME -> {
@@ -126,14 +151,17 @@ public class DiscordCommandListener extends ListenerAdapter {
                     return;
                 }
                 pendingProjectCreations.put(
-                        channelId, new ProjectCreationState(ProjectCreationStep.WAITING_DESCRIPTION, input, null));
+                        channelId,
+                        new ProjectCreationState(
+                                ProjectCreationStep.WAITING_DESCRIPTION, input, null, state.createdAt()));
                 event.getChannel().sendMessage("프로젝트 설명을 입력해주세요. (건너뛰려면 '.')").queue();
             }
             case WAITING_DESCRIPTION -> {
                 String description = ".".equals(input) ? null : input;
                 pendingProjectCreations.put(
                         channelId,
-                        new ProjectCreationState(ProjectCreationStep.WAITING_TECH_STACK, state.name(), description));
+                        new ProjectCreationState(
+                                ProjectCreationStep.WAITING_TECH_STACK, state.name(), description, state.createdAt()));
                 event.getChannel().sendMessage("기술 스택을 입력해주세요. (건너뛰려면 '.')").queue();
             }
             case WAITING_TECH_STACK -> {
@@ -153,6 +181,145 @@ public class DiscordCommandListener extends ListenerAdapter {
                 }
             }
         }
+    }
+
+    private void handleMeetingStart(MessageReceivedEvent event, long channelId) {
+        Member member = event.getMember();
+        if (member == null
+                || member.getVoiceState() == null
+                || member.getVoiceState().getChannel() == null) {
+            event.getChannel().sendMessage("먼저 음성 채널에 들어가줘.").queue();
+            return;
+        }
+
+        Long projectId = fetchProjectIdByChannel(channelId);
+        if (projectId != null) {
+            startMeeting(event, projectId);
+            return;
+        }
+
+        // 채널에 연결된 프로젝트가 없으면 확인 요청
+        pendingMeetingConfirmations.put(channelId, new MeetingConfirmationState(System.currentTimeMillis()));
+        event.getChannel()
+                .sendMessage("⚠️ 이 채널에 연결된 프로젝트가 없어서 회의가 저장되지 않아요.\n" + "그래도 진행하시겠어요? (yes / no)")
+                .queue();
+    }
+
+    private void handleMeetingConfirmationStep(MessageReceivedEvent event, long channelId) {
+        MeetingConfirmationState state = pendingMeetingConfirmations.get(channelId);
+
+        if (System.currentTimeMillis() - state.createdAt() > PENDING_TTL_MS) {
+            pendingMeetingConfirmations.remove(channelId);
+            event.getChannel()
+                    .sendMessage("⏰ 응답 시간이 초과됐습니다. 다시 `!meeting start`를 입력해주세요.")
+                    .queue();
+            return;
+        }
+
+        String input = event.getMessage().getContentRaw().trim().toLowerCase();
+        pendingMeetingConfirmations.remove(channelId);
+
+        if ("yes".equals(input)) {
+            startMeeting(event, null);
+        } else if ("no".equals(input)) {
+            event.getChannel().sendMessage("회의 시작을 취소했습니다.").queue();
+        } else {
+            event.getChannel()
+                    .sendMessage("'yes' 또는 'no'로 답해주세요. 다시 `!meeting start`를 입력해주세요.")
+                    .queue();
+        }
+    }
+
+    private void handleMeetingEnd(MessageReceivedEvent event) {
+        long guildId = event.getGuild().getIdLong();
+        AudioManager audioManager = event.getGuild().getAudioManager();
+        PerUserAudioReceiveHandler handler = receiveHandlers.remove(guildId);
+
+        if (handler != null) {
+            handler.closeAllSttSessions();
+        }
+
+        audioManager.closeAudioConnection();
+        audioManager.setReceivingHandler(null);
+        audioManager.setConnectionListener(null);
+
+        Long meetingId = activeMeetingIdByGuild.remove(guildId);
+        if (meetingId == null) {
+            event.getChannel().sendMessage("진행 중인 회의가 없어요.").queue();
+            return;
+        }
+
+        endMeeting(guildId, meetingId);
+        event.getChannel().sendMessage("✅ 회의가 종료됐습니다. 요약을 생성 중이에요...").queue();
+        log.info("[미팅/종료명령] guildId={}, meetingId={}", guildId, meetingId);
+    }
+
+    private Long fetchProjectIdByChannel(long channelId) {
+        try {
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(internalBaseUrl + "/api/v1/projects/channel/" + channelId))
+                    .GET();
+            attachInternalApiKey(requestBuilder);
+
+            HttpResponse<String> response =
+                    httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 404) {
+                return null;
+            }
+            if (response.statusCode() / 100 != 2) {
+                log.warn("[프로젝트/채널조회실패] channelId={}, status={}", channelId, response.statusCode());
+                return null;
+            }
+
+            JsonNode idNode =
+                    objectMapper.readTree(response.body()).path("data").path("id");
+            return idNode.isNumber() ? idNode.asLong() : null;
+        } catch (Exception e) {
+            log.warn("[프로젝트/채널조회예외] channelId={}", channelId, e);
+            return null;
+        }
+    }
+
+    private void startMeeting(MessageReceivedEvent event, Long projectId) {
+        Member member = event.getMember();
+        AudioChannel targetChannel = member.getVoiceState().getChannel();
+        long guildId = event.getGuild().getIdLong();
+
+        Long meetingId = createMeeting(guildId, event.getGuild().getName(), projectId);
+        if (meetingId == null) {
+            event.getChannel().sendMessage("❌ 회의 생성 실패. 서버 로그를 확인해줘.").queue();
+            return;
+        }
+
+        AudioManager audioManager = event.getGuild().getAudioManager();
+        PerUserAudioReceiveHandler existing = receiveHandlers.remove(guildId);
+        if (existing != null) {
+            existing.closeAllSttSessions();
+        }
+
+        PerUserAudioReceiveHandler handler =
+                new PerUserAudioReceiveHandler(guildId, event.getGuild(), sttProvider, meetingId);
+        receiveHandlers.put(guildId, handler);
+        activeMeetingIdByGuild.put(guildId, meetingId);
+        handler.updateCaptionChannel(event.getChannel());
+
+        audioManager.setReceivingHandler(handler);
+        audioManager.setConnectionListener(new LoggingConnectionListener(guildId, targetChannel));
+        audioManager.setAutoReconnect(true);
+        audioManager.setSelfMuted(false);
+        audioManager.setSelfDeafened(false);
+        audioManager.openAudioConnection(targetChannel);
+
+        event.getChannel()
+                .sendMessage("🎙️ 회의 시작! 음성 채널 [" + targetChannel.getName() + "]에 입장했어요. (meetingId=" + meetingId + ")")
+                .queue();
+        log.info(
+                "[미팅/시작] guildId={}, meetingId={}, projectId={}, channel={}",
+                guildId,
+                meetingId,
+                projectId,
+                targetChannel.getName());
     }
 
     private Long createProject(
@@ -221,7 +388,7 @@ public class DiscordCommandListener extends ListenerAdapter {
         }
 
         long guildId = event.getGuild().getIdLong();
-        Long meetingId = createMeeting(guildId, event.getGuild().getName());
+        Long meetingId = createMeeting(guildId, event.getGuild().getName(), null);
         if (meetingId == null) {
             event.getChannel().sendMessage("회의 생성 실패로 입장을 중단했어. 서버 로그를 확인해줘.").queue();
             return;
@@ -334,10 +501,11 @@ public class DiscordCommandListener extends ListenerAdapter {
                 .orElse("-");
     }
 
-    private Long createMeeting(long guildId, String guildName) {
+    private Long createMeeting(long guildId, String guildName, Long projectId) {
         try {
             ObjectNode body = objectMapper.createObjectNode();
-            body.putNull("projectId");
+            if (projectId != null) body.put("projectId", projectId);
+            else body.putNull("projectId");
             body.put("title", "Discord " + guildName + " " + LocalDateTime.now());
 
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -114,7 +114,7 @@ public class DiscordCommandListener extends ListenerAdapter {
             case "leave" -> handleLeave(event);
             case "stats" -> handleStats(event);
             case "project start" -> handleProjectStart(event, channelId);
-            case "meeting start" -> handleMeetingStart(event, channelId);
+            case "meeting start" -> new Thread(() -> handleMeetingStart(event, channelId)).start();
             case "meeting end" -> handleMeetingEnd(event);
             default -> {
                 // 미지원 명령은 조용히 무시

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -22,9 +22,11 @@ import com.flodiback.domain.speech.stt.provider.openai.OpenAiSttProvider;
 
 import net.dv8tion.jda.api.audio.hooks.ConnectionListener;
 import net.dv8tion.jda.api.audio.hooks.ConnectionStatus;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.managers.AudioManager;
@@ -51,7 +53,16 @@ public class DiscordCommandListener extends ListenerAdapter {
 
     private record ProjectCreationState(ProjectCreationStep step, String name, String description, long createdAt) {}
 
-    private record MeetingConfirmationState(long createdAt) {}
+    private record MeetingStartContext(
+            long guildId,
+            String guildName,
+            AudioChannel voiceChannel,
+            MessageChannel textChannel,
+            AudioManager audioManager,
+            Guild guild,
+            long channelId) {}
+
+    private record MeetingConfirmationState(MeetingStartContext ctx, long createdAt) {}
 
     // 명령어 접두사(예: !)
     private final String prefix;
@@ -114,7 +125,24 @@ public class DiscordCommandListener extends ListenerAdapter {
             case "leave" -> handleLeave(event);
             case "stats" -> handleStats(event);
             case "project start" -> handleProjectStart(event, channelId);
-            case "meeting start" -> new Thread(() -> handleMeetingStart(event, channelId)).start();
+            case "meeting start" -> {
+                Member member = event.getMember();
+                if (member == null
+                        || member.getVoiceState() == null
+                        || member.getVoiceState().getChannel() == null) {
+                    event.getChannel().sendMessage("먼저 음성 채널에 들어가줘.").queue();
+                    return;
+                }
+                MeetingStartContext ctx = new MeetingStartContext(
+                        event.getGuild().getIdLong(),
+                        event.getGuild().getName(),
+                        member.getVoiceState().getChannel(),
+                        event.getChannel(),
+                        event.getGuild().getAudioManager(),
+                        event.getGuild(),
+                        channelId);
+                new Thread(() -> handleMeetingStart(ctx)).start();
+            }
             case "meeting end" -> handleMeetingEnd(event);
             default -> {
                 // 미지원 명령은 조용히 무시
@@ -183,24 +211,16 @@ public class DiscordCommandListener extends ListenerAdapter {
         }
     }
 
-    private void handleMeetingStart(MessageReceivedEvent event, long channelId) {
-        Member member = event.getMember();
-        if (member == null
-                || member.getVoiceState() == null
-                || member.getVoiceState().getChannel() == null) {
-            event.getChannel().sendMessage("먼저 음성 채널에 들어가줘.").queue();
-            return;
-        }
-
-        Long projectId = fetchProjectIdByChannel(channelId);
+    private void handleMeetingStart(MeetingStartContext ctx) {
+        Long projectId = fetchProjectIdByChannel(ctx.channelId());
         if (projectId != null) {
-            startMeeting(event, projectId);
+            startMeeting(ctx, projectId);
             return;
         }
 
         // 채널에 연결된 프로젝트가 없으면 확인 요청
-        pendingMeetingConfirmations.put(channelId, new MeetingConfirmationState(System.currentTimeMillis()));
-        event.getChannel()
+        pendingMeetingConfirmations.put(ctx.channelId(), new MeetingConfirmationState(ctx, System.currentTimeMillis()));
+        ctx.textChannel()
                 .sendMessage("⚠️ 이 채널에 연결된 프로젝트가 없어서 회의가 저장되지 않아요.\n" + "그래도 진행하시겠어요? (yes / no)")
                 .queue();
     }
@@ -220,7 +240,8 @@ public class DiscordCommandListener extends ListenerAdapter {
         pendingMeetingConfirmations.remove(channelId);
 
         if ("yes".equals(input)) {
-            startMeeting(event, null);
+            MeetingStartContext ctx = state.ctx();
+            new Thread(() -> startMeeting(ctx, null)).start();
         } else if ("no".equals(input)) {
             event.getChannel().sendMessage("회의 시작을 취소했습니다.").queue();
         } else {
@@ -281,45 +302,41 @@ public class DiscordCommandListener extends ListenerAdapter {
         }
     }
 
-    private void startMeeting(MessageReceivedEvent event, Long projectId) {
-        Member member = event.getMember();
-        AudioChannel targetChannel = member.getVoiceState().getChannel();
-        long guildId = event.getGuild().getIdLong();
-
-        Long meetingId = createMeeting(guildId, event.getGuild().getName(), projectId);
+    private void startMeeting(MeetingStartContext ctx, Long projectId) {
+        Long meetingId = createMeeting(ctx.guildId(), ctx.guildName(), projectId);
         if (meetingId == null) {
-            event.getChannel().sendMessage("❌ 회의 생성 실패. 서버 로그를 확인해줘.").queue();
+            ctx.textChannel().sendMessage("❌ 회의 생성 실패. 서버 로그를 확인해줘.").queue();
             return;
         }
 
-        AudioManager audioManager = event.getGuild().getAudioManager();
-        PerUserAudioReceiveHandler existing = receiveHandlers.remove(guildId);
+        PerUserAudioReceiveHandler existing = receiveHandlers.remove(ctx.guildId());
         if (existing != null) {
             existing.closeAllSttSessions();
         }
 
         PerUserAudioReceiveHandler handler =
-                new PerUserAudioReceiveHandler(guildId, event.getGuild(), sttProvider, meetingId);
-        receiveHandlers.put(guildId, handler);
-        activeMeetingIdByGuild.put(guildId, meetingId);
-        handler.updateCaptionChannel(event.getChannel());
+                new PerUserAudioReceiveHandler(ctx.guildId(), ctx.guild(), sttProvider, meetingId);
+        receiveHandlers.put(ctx.guildId(), handler);
+        activeMeetingIdByGuild.put(ctx.guildId(), meetingId);
+        handler.updateCaptionChannel(ctx.textChannel());
 
-        audioManager.setReceivingHandler(handler);
-        audioManager.setConnectionListener(new LoggingConnectionListener(guildId, targetChannel));
-        audioManager.setAutoReconnect(true);
-        audioManager.setSelfMuted(false);
-        audioManager.setSelfDeafened(false);
-        audioManager.openAudioConnection(targetChannel);
+        ctx.audioManager().setReceivingHandler(handler);
+        ctx.audioManager().setConnectionListener(new LoggingConnectionListener(ctx.guildId(), ctx.voiceChannel()));
+        ctx.audioManager().setAutoReconnect(true);
+        ctx.audioManager().setSelfMuted(false);
+        ctx.audioManager().setSelfDeafened(false);
+        ctx.audioManager().openAudioConnection(ctx.voiceChannel());
 
-        event.getChannel()
-                .sendMessage("🎙️ 회의 시작! 음성 채널 [" + targetChannel.getName() + "]에 입장했어요. (meetingId=" + meetingId + ")")
+        ctx.textChannel()
+                .sendMessage(
+                        "🎙️ 회의 시작! 음성 채널 [" + ctx.voiceChannel().getName() + "]에 입장했어요. (meetingId=" + meetingId + ")")
                 .queue();
         log.info(
                 "[미팅/시작] guildId={}, meetingId={}, projectId={}, channel={}",
-                guildId,
+                ctx.guildId(),
                 meetingId,
                 projectId,
-                targetChannel.getName());
+                ctx.voiceChannel().getName());
     }
 
     private Long createProject(

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -41,6 +41,14 @@ import net.dv8tion.jda.api.managers.AudioManager;
 public class DiscordCommandListener extends ListenerAdapter {
     private static final Logger log = LoggerFactory.getLogger(DiscordCommandListener.class);
 
+    private enum ProjectCreationStep {
+        WAITING_NAME,
+        WAITING_DESCRIPTION,
+        WAITING_TECH_STACK
+    }
+
+    private record ProjectCreationState(ProjectCreationStep step, String name, String description) {}
+
     // 명령어 접두사(예: !)
     private final String prefix;
     // 실제 STT 엔진 구현체(현재 OpenAI)
@@ -53,6 +61,8 @@ public class DiscordCommandListener extends ListenerAdapter {
     private final Map<Long, PerUserAudioReceiveHandler> receiveHandlers = new ConcurrentHashMap<>();
     // 길드별 활성 meetingId
     private final Map<Long, Long> activeMeetingIdByGuild = new ConcurrentHashMap<>();
+    // 채널별 진행 중인 프로젝트 생성 상태
+    private final Map<Long, ProjectCreationState> pendingProjectCreations = new ConcurrentHashMap<>();
 
     public DiscordCommandListener() {
         this("!", new OpenAiSttProvider(), 1L);
@@ -72,6 +82,14 @@ public class DiscordCommandListener extends ListenerAdapter {
             return;
         }
 
+        long channelId = event.getChannel().getIdLong();
+
+        // 프로젝트 생성 대화 중인 채널이면 명령어보다 먼저 처리
+        if (pendingProjectCreations.containsKey(channelId)) {
+            handleProjectCreationStep(event, channelId);
+            return;
+        }
+
         String raw = event.getMessage().getContentRaw().trim();
         if (!raw.startsWith(prefix)) {
             return;
@@ -83,9 +101,113 @@ public class DiscordCommandListener extends ListenerAdapter {
             case "join" -> handleJoin(event);
             case "leave" -> handleLeave(event);
             case "stats" -> handleStats(event);
+            case "project start" -> handleProjectStart(event, channelId);
             default -> {
                 // 미지원 명령은 조용히 무시
             }
+        }
+    }
+
+    private void handleProjectStart(MessageReceivedEvent event, long channelId) {
+        pendingProjectCreations.put(channelId, new ProjectCreationState(ProjectCreationStep.WAITING_NAME, null, null));
+        event.getChannel().sendMessage("프로젝트 이름을 입력해주세요.").queue();
+    }
+
+    private void handleProjectCreationStep(MessageReceivedEvent event, long channelId) {
+        String input = event.getMessage().getContentRaw().trim();
+        ProjectCreationState state = pendingProjectCreations.get(channelId);
+
+        switch (state.step()) {
+            case WAITING_NAME -> {
+                if (input.isBlank()) {
+                    event.getChannel()
+                            .sendMessage("프로젝트 이름은 필수입니다. 이름을 입력해주세요.")
+                            .queue();
+                    return;
+                }
+                pendingProjectCreations.put(
+                        channelId, new ProjectCreationState(ProjectCreationStep.WAITING_DESCRIPTION, input, null));
+                event.getChannel().sendMessage("프로젝트 설명을 입력해주세요. (건너뛰려면 '.')").queue();
+            }
+            case WAITING_DESCRIPTION -> {
+                String description = ".".equals(input) ? null : input;
+                pendingProjectCreations.put(
+                        channelId,
+                        new ProjectCreationState(ProjectCreationStep.WAITING_TECH_STACK, state.name(), description));
+                event.getChannel().sendMessage("기술 스택을 입력해주세요. (건너뛰려면 '.')").queue();
+            }
+            case WAITING_TECH_STACK -> {
+                String techStack = ".".equals(input) ? null : input;
+                pendingProjectCreations.remove(channelId);
+                Long projectId = createProject(
+                        event.getChannel().getIdLong(),
+                        event.getGuild().getIdLong(),
+                        state.name(),
+                        state.description(),
+                        techStack,
+                        event);
+                if (projectId != null) {
+                    event.getChannel()
+                            .sendMessage("✅ 프로젝트 [" + state.name() + "]가 생성됐습니다! (id=" + projectId + ")")
+                            .queue();
+                }
+            }
+        }
+    }
+
+    private Long createProject(
+            long channelId,
+            long guildId,
+            String name,
+            String description,
+            String techStack,
+            MessageReceivedEvent event) {
+        try {
+            ObjectNode body = objectMapper.createObjectNode();
+            body.put("name", name);
+            if (description != null) body.put("description", description);
+            else body.putNull("description");
+            if (techStack != null) body.put("techStack", techStack);
+            else body.putNull("techStack");
+            body.putNull("serverId");
+            body.put("channelId", String.valueOf(channelId));
+
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(internalBaseUrl + "/api/v1/projects"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(body)));
+            attachInternalApiKey(requestBuilder);
+
+            HttpResponse<String> response =
+                    httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() / 100 != 2) {
+                log.warn(
+                        "[프로젝트/생성실패] channelId={}, status={}, body={}",
+                        channelId,
+                        response.statusCode(),
+                        response.body());
+                event.getChannel()
+                        .sendMessage("❌ 프로젝트 생성에 실패했습니다. 서버 로그를 확인해주세요.")
+                        .queue();
+                return null;
+            }
+
+            JsonNode root = objectMapper.readTree(response.body());
+            JsonNode idNode = root.path("data").path("id");
+            if (!idNode.isNumber()) {
+                log.warn("[프로젝트/생성응답오류] channelId={}, body={}", channelId, response.body());
+                event.getChannel().sendMessage("❌ 프로젝트 생성 응답 오류입니다.").queue();
+                return null;
+            }
+
+            long projectId = idNode.asLong();
+            log.info("[프로젝트/생성성공] channelId={}, projectId={}", channelId, projectId);
+            return projectId;
+        } catch (Exception e) {
+            log.warn("[프로젝트/생성예외] channelId={}", channelId, e);
+            event.getChannel().sendMessage("❌ 프로젝트 생성 중 오류가 발생했습니다.").queue();
+            return null;
         }
     }
 

--- a/src/main/java/com/flodiback/domain/project/project/dto/CreateProjectRequest.java
+++ b/src/main/java/com/flodiback/domain/project/project/dto/CreateProjectRequest.java
@@ -2,4 +2,5 @@ package com.flodiback.domain.project.project.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record CreateProjectRequest(@NotBlank String name, String description, String techStack, Long serverId) {}
+public record CreateProjectRequest(
+        @NotBlank String name, String description, String techStack, Long serverId, String channelId) {}

--- a/src/main/java/com/flodiback/domain/project/project/entity/Project.java
+++ b/src/main/java/com/flodiback/domain/project/project/entity/Project.java
@@ -33,6 +33,9 @@ public class Project {
     @JoinColumn(name = "server_id", nullable = true)
     private DiscordServer server;
 
+    @Column(name = "channel_id", length = 50)
+    private String channelId;
+
     @Column(name = "name", nullable = false, length = 100)
     private String name;
 
@@ -64,8 +67,15 @@ public class Project {
     }
 
     @Builder
-    public Project(DiscordServer server, String name, String description, String techStack, String metadata) {
+    public Project(
+            DiscordServer server,
+            String channelId,
+            String name,
+            String description,
+            String techStack,
+            String metadata) {
         this.server = server;
+        this.channelId = channelId;
         this.name = name;
         this.description = description;
         this.techStack = techStack;

--- a/src/main/java/com/flodiback/domain/project/project/repository/ProjectRepository.java
+++ b/src/main/java/com/flodiback/domain/project/project/repository/ProjectRepository.java
@@ -1,7 +1,12 @@
 package com.flodiback.domain.project.project.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.flodiback.domain.project.project.entity.Project;
 
-public interface ProjectRepository extends JpaRepository<Project, Long> {}
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    Optional<Project> findByChannelId(String channelId);
+}

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -13,6 +13,7 @@ import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
 import com.flodiback.domain.server.server.entity.DiscordServer;
 import com.flodiback.domain.server.server.repository.DiscordServerRepository;
+import com.flodiback.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +26,12 @@ public class ProjectService {
     private final DiscordServerRepository discordServerRepository;
 
     public ProjectResponse create(CreateProjectRequest req) {
+        if (req.channelId() != null) {
+            projectRepository.findByChannelId(req.channelId()).ifPresent(p -> {
+                throw new ServiceException("400-2", "이 채널에는 이미 프로젝트가 연결되어 있습니다.");
+            });
+        }
+
         DiscordServer server = null;
         if (req.serverId() != null) {
             server = discordServerRepository
@@ -34,6 +41,7 @@ public class ProjectService {
 
         Project project = Project.builder()
                 .server(server)
+                .channelId(req.channelId())
                 .name(req.name())
                 .description(req.description())
                 .techStack(req.techStack())

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -57,6 +57,14 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
+    public ProjectResponse getByChannelId(String channelId) {
+        return projectRepository
+                .findByChannelId(channelId)
+                .map(this::toResponse)
+                .orElse(null);
+    }
+
+    @Transactional(readOnly = true)
     public ProjectResponse getById(Long id) {
         Project project =
                 projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));

--- a/src/main/resources/db/migration/V7__project_channel_id.sql
+++ b/src/main/resources/db/migration/V7__project_channel_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD COLUMN channel_id VARCHAR(50);

--- a/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
@@ -43,7 +43,7 @@ class ProjectServiceTest {
     @Test
     void create_serverId없으면_server_null로_프로젝트생성() {
         // given
-        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", null);
+        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", null, null);
         given(projectRepository.save(any(Project.class))).willAnswer(inv -> inv.getArgument(0));
 
         // when
@@ -63,7 +63,7 @@ class ProjectServiceTest {
         // given
         DiscordServer server =
                 DiscordServer.builder().guildId("guild-123").guildName("플로디 서버").build();
-        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", 1L);
+        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", 1L, null);
         given(discordServerRepository.findById(1L)).willReturn(Optional.of(server));
         given(projectRepository.save(any(Project.class))).willAnswer(inv -> inv.getArgument(0));
 
@@ -79,7 +79,7 @@ class ProjectServiceTest {
     @Test
     void create_존재하지않는_serverId면_예외발생() {
         // given
-        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", 999L);
+        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", 999L, null);
         given(discordServerRepository.findById(999L)).willReturn(Optional.empty());
 
         // when & then


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #58 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #58 

---

## 📝 작업 내용

디스코드 봇에 프로젝트 생성(`!project start`)과 회의 시작/종료(`!meeting start`, `!meeting end`) 명령어를 유저 플로우에 맞게 구현했습니다. 채널-프로젝트 연결을 위해 Project 엔티티에 `channel_id`를 추가하고, 관련 API도 함께 추가했습니다.
기존의 '!join'과 '!leave' 명령어는 삭제하지 않고 우선 남겨두었습니다.

---

## ✅ 주요 변경 사항

1) ****`!project start`**** - 이름/설명/기술스택을 순서대로 입력받는 대화형 플로우 구현 (TTL 1분)

2) ****`!meeting start`**** - 채널에 연결된 프로젝트 자동 조회, 없을 시 저장 여부 사용자 확인 후 음성 채널 입장 및 회의 생성 (TTL 포함)

3) ****`!meeting end`**** - 음성 채널 퇴장 + 회의 종료 → 요약 트리거

4) ****Project `channel*_id` 추가** - `GET /api/v1/projects/channel/{channelId}`, `PUT /api/v1/projects/{id}` API 추가, V7 마이그레이션 포함***

***5) **버그 수정** - `!meeting start`에서 JDA MainWS-ReadThread를 HTTP 호출로 블로킹해 DAVE 세션 협상이 실패하던 문제 → 별도 스레드로 분리***

***---***

***## 🧪 테스트 결과***

***```bash***

***# 봇 직접 실행 후 디스코드에서 수동 확인***

***docker compose -f docker-compose.bot.yml up***

- !project start 대화형 플로우 정상 동작 확인

- !meeting start 음성 채널 입장 및 회의 생성 확인

- !meeting end 회의 종료 확인

- 로컬 테스트 통과

---

**👀 리뷰 포인트 (선택)**

- DiscordCommandListener에서 HTTP 호출을 JDA 이벤트 스레드에서 직접 하고 있어 !meeting start만 new Thread()로 분리했습니다. 장기적으로는 다른 HTTP 호출 명령어들도 스레드 분리가 필요할 수 있습니다.

- 대화 상태(pendingProjectCreations, pendingMeetingConfirmations)는 TTL 1분으로 메모리에서 관리합니다. 봇 재시작 시 초기화됩니다.

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
