### PR TITLE
fix: AI 답변 디스코드 채팅 전송

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ DISCORD_TOKEN=your_discord_bot_token
 
 # Text command prefix
 DISCORD_BOT_PREFIX=!
+# Optional: comma-separated Discord guild IDs this bot instance should handle.
+# 여러 Docker 인스턴스가 같은 DISCORD_TOKEN을 쓰면 각 인스턴스에 담당 서버 ID를 지정하세요.
+# 비워두면 봇이 초대된 모든 서버 이벤트를 처리합니다.
+DISCORD_ALLOWED_GUILD_IDS=
 GLM_ENABLED=false
 
 # Spring internal API base URL (로컬 실행 기준)

--- a/docs/references/discord-bot-jda-dave.md
+++ b/docs/references/discord-bot-jda-dave.md
@@ -16,7 +16,7 @@ export DISCORD_DEFAULT_MEETING_ID=1
 export INTERNAL_API_BASE_URL=http://localhost:8080
 export OPENAI_API_KEY=...
 export OPENAI_REALTIME_WS_URL='wss://api.openai.com/v1/realtime?intent=transcription'
-export OPENAI_TRANSCRIBE_MODEL=gpt-4o-transcribe
+export OPENAI_TRANSCRIBE_MODEL=gpt-realtime-whisper
 export OPENAI_TRANSCRIBE_LANGUAGE=ko
 ```
 

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -7,9 +7,11 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -76,6 +78,7 @@ public class DiscordCommandListener extends ListenerAdapter {
     private static final int PROJECT_SELECT_LIMIT = 25;
     private static final int DECISION_PREVIEW_LIMIT = 3;
     private static final int TEMPORARY_MESSAGE_SECONDS = 45;
+    private static final String ENV_ALLOWED_GUILD_IDS = "DISCORD_ALLOWED_GUILD_IDS";
 
     private enum ProjectCreationStep {
         WAITING_NAME,
@@ -98,6 +101,8 @@ public class DiscordCommandListener extends ListenerAdapter {
 
     private record MeetingConfirmationState(MeetingStartContext ctx, long createdAt) {}
 
+    private record MeetingEndResult(Long meetingId, boolean hadVoiceState) {}
+
     // 명령어 접두사. 기본값은 !.
     private final String prefix;
     // 실제 STT 엔진 구현체. 현재 기본값은 OpenAI.
@@ -106,10 +111,13 @@ public class DiscordCommandListener extends ListenerAdapter {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final String internalBaseUrl;
     private final String internalApiKey;
+    private final Set<Long> allowedGuildIds;
     // 길드별 오디오 수신 핸들러 캐시
     private final Map<Long, PerUserAudioReceiveHandler> receiveHandlers = new ConcurrentHashMap<>();
     // 길드별 활성 meetingId
     private final Map<Long, Long> activeMeetingIdByGuild = new ConcurrentHashMap<>();
+    // 길드별 회의 생성 중복 요청 방지
+    private final Set<Long> startingGuildIds = ConcurrentHashMap.newKeySet();
     // 채널별 진행 중인 프로젝트 생성 상태
     private final Map<Long, ProjectCreationState> pendingProjectCreations = new ConcurrentHashMap<>();
     // 채널별 회의 시작 확인 대기 상태
@@ -124,12 +132,18 @@ public class DiscordCommandListener extends ListenerAdapter {
         this.sttProvider = Objects.requireNonNull(sttProvider);
         this.internalBaseUrl = normalizeBaseUrl(BotEnv.getOrDefault("INTERNAL_API_BASE_URL", "http://localhost:8080"));
         this.internalApiKey = BotEnv.get("INTERNAL_API_KEY");
+        this.allowedGuildIds = parseAllowedGuildIds(BotEnv.get(ENV_ALLOWED_GUILD_IDS));
     }
 
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
         // 봇 메시지와 DM은 명령 처리 대상에서 제외
         if (event.getAuthor().isBot() || !event.isFromGuild()) {
+            return;
+        }
+        if (!isAllowedGuild(event.getGuild().getIdLong())) {
+            log.debug(
+                    "[봇/서버무시] guildId={}, reason=not_allowed", event.getGuild().getIdLong());
             return;
         }
 
@@ -191,6 +205,13 @@ public class DiscordCommandListener extends ListenerAdapter {
             event.reply("서버 채널에서만 사용할 수 있어요.").setEphemeral(true).queue();
             return;
         }
+        if (!isAllowedGuild(event.getGuild().getIdLong())) {
+            log.debug(
+                    "[봇/인터랙션무시] guildId={}, componentId={}, reason=not_allowed",
+                    event.getGuild().getIdLong(),
+                    event.getComponentId());
+            return;
+        }
 
         switch (event.getComponentId()) {
             case BUTTON_PANEL_OPEN -> {
@@ -213,9 +234,9 @@ public class DiscordCommandListener extends ListenerAdapter {
             }
             case BUTTON_MEETING_END -> {
                 event.deferReply(true).queue();
-                handleMeetingEnd(event.getGuild(), event.getChannel());
+                MeetingEndResult result = endActiveMeeting(event.getGuild());
                 event.getHook()
-                        .sendMessage("회의 종료 요청을 처리했어요.")
+                        .sendMessage(buildMeetingEndMessage(result))
                         .setEphemeral(true)
                         .queue();
             }
@@ -228,6 +249,9 @@ public class DiscordCommandListener extends ListenerAdapter {
     @Override
     public void onStringSelectInteraction(StringSelectInteractionEvent event) {
         if (!SELECT_PROJECT.equals(event.getComponentId())) {
+            return;
+        }
+        if (!event.isFromGuild() || !isAllowedGuild(event.getGuild().getIdLong())) {
             return;
         }
         event.deferReply(true).queue();
@@ -259,6 +283,9 @@ public class DiscordCommandListener extends ListenerAdapter {
     @Override
     public void onModalInteraction(ModalInteractionEvent event) {
         if (!MODAL_PROJECT_CREATE.equals(event.getModalId())) {
+            return;
+        }
+        if (!event.isFromGuild() || !isAllowedGuild(event.getGuild().getIdLong())) {
             return;
         }
 
@@ -769,13 +796,16 @@ public class DiscordCommandListener extends ListenerAdapter {
     }
 
     private void handleMeetingEnd(MessageReceivedEvent event) {
-        handleMeetingEnd(event.getGuild(), event.getChannel());
+        MeetingEndResult result = endActiveMeeting(event.getGuild());
+        sendTemporaryMessage(event.getChannel(), buildMeetingEndMessage(result));
     }
 
-    private void handleMeetingEnd(Guild guild, MessageChannel channel) {
+    private MeetingEndResult endActiveMeeting(Guild guild) {
         long guildId = guild.getIdLong();
         AudioManager audioManager = guild.getAudioManager();
         PerUserAudioReceiveHandler handler = receiveHandlers.remove(guildId);
+        Long meetingId = activeMeetingIdByGuild.remove(guildId);
+        boolean hadVoiceState = handler != null || audioManager.isConnected();
 
         if (handler != null) {
             handler.closeAllSttSessions();
@@ -785,15 +815,11 @@ public class DiscordCommandListener extends ListenerAdapter {
         audioManager.setReceivingHandler(null);
         audioManager.setConnectionListener(null);
 
-        Long meetingId = activeMeetingIdByGuild.remove(guildId);
-        if (meetingId == null) {
-            sendTemporaryMessage(channel, "진행 중인 회의가 없어요.");
-            return;
+        if (meetingId != null) {
+            endMeeting(guildId, meetingId);
         }
-
-        endMeeting(guildId, meetingId);
-        channel.sendMessage("회의가 종료됐습니다. 요약을 생성 중이에요...").queue();
-        log.info("[미팅/종료명령] guildId={}, meetingId={}", guildId, meetingId);
+        log.info("[미팅/종료명령] guildId={}, meetingId={}, hadVoiceState={}", guildId, meetingId, hadVoiceState);
+        return new MeetingEndResult(meetingId, hadVoiceState);
     }
 
     private Long fetchProjectIdByChannel(long channelId) {
@@ -824,40 +850,53 @@ public class DiscordCommandListener extends ListenerAdapter {
     }
 
     private void startMeeting(MeetingStartContext ctx, Long projectId) {
-        Long meetingId = createMeeting(ctx.guildId(), ctx.guildName(), projectId);
-        if (meetingId == null) {
-            ctx.textChannel().sendMessage("회의 생성 실패. 서버 로그를 확인해주세요.").queue();
+        if (activeMeetingIdByGuild.containsKey(ctx.guildId())) {
+            ctx.textChannel().sendMessage("이미 진행 중인 회의가 있어요. 먼저 회의 종료를 눌러주세요.").queue();
+            return;
+        }
+        if (!startingGuildIds.add(ctx.guildId())) {
+            ctx.textChannel().sendMessage("회의 시작 요청을 처리 중이에요. 잠시만 기다려주세요.").queue();
             return;
         }
 
-        PerUserAudioReceiveHandler existing = receiveHandlers.remove(ctx.guildId());
-        if (existing != null) {
-            existing.closeAllSttSessions();
+        Long meetingId = createMeeting(ctx.guildId(), ctx.guildName(), projectId);
+        try {
+            if (meetingId == null) {
+                ctx.textChannel().sendMessage("회의 생성 실패. 서버 로그를 확인해주세요.").queue();
+                return;
+            }
+
+            PerUserAudioReceiveHandler existing = receiveHandlers.remove(ctx.guildId());
+            if (existing != null) {
+                existing.closeAllSttSessions();
+            }
+
+            PerUserAudioReceiveHandler handler =
+                    new PerUserAudioReceiveHandler(ctx.guildId(), ctx.guild(), sttProvider, meetingId);
+            receiveHandlers.put(ctx.guildId(), handler);
+            activeMeetingIdByGuild.put(ctx.guildId(), meetingId);
+            handler.updateCaptionChannel(ctx.textChannel());
+
+            ctx.audioManager().setReceivingHandler(handler);
+            ctx.audioManager().setConnectionListener(new LoggingConnectionListener(ctx.guildId(), ctx.voiceChannel()));
+            ctx.audioManager().setAutoReconnect(true);
+            ctx.audioManager().setSelfMuted(false);
+            ctx.audioManager().setSelfDeafened(false);
+            ctx.audioManager().openAudioConnection(ctx.voiceChannel());
+
+            ctx.textChannel()
+                    .sendMessage(
+                            "회의 시작! 음성 채널 [" + ctx.voiceChannel().getName() + "]에 입장했어요. (meetingId=" + meetingId + ")")
+                    .queue();
+            log.info(
+                    "[미팅/시작] guildId={}, meetingId={}, projectId={}, channel={}",
+                    ctx.guildId(),
+                    meetingId,
+                    projectId,
+                    ctx.voiceChannel().getName());
+        } finally {
+            startingGuildIds.remove(ctx.guildId());
         }
-
-        PerUserAudioReceiveHandler handler =
-                new PerUserAudioReceiveHandler(ctx.guildId(), ctx.guild(), sttProvider, meetingId);
-        receiveHandlers.put(ctx.guildId(), handler);
-        activeMeetingIdByGuild.put(ctx.guildId(), meetingId);
-        handler.updateCaptionChannel(ctx.textChannel());
-
-        ctx.audioManager().setReceivingHandler(handler);
-        ctx.audioManager().setConnectionListener(new LoggingConnectionListener(ctx.guildId(), ctx.voiceChannel()));
-        ctx.audioManager().setAutoReconnect(true);
-        ctx.audioManager().setSelfMuted(false);
-        ctx.audioManager().setSelfDeafened(false);
-        ctx.audioManager().openAudioConnection(ctx.voiceChannel());
-
-        ctx.textChannel()
-                .sendMessage(
-                        "회의 시작! 음성 채널 [" + ctx.voiceChannel().getName() + "]에 입장했어요. (meetingId=" + meetingId + ")")
-                .queue();
-        log.info(
-                "[미팅/시작] guildId={}, meetingId={}, projectId={}, channel={}",
-                ctx.guildId(),
-                meetingId,
-                projectId,
-                ctx.voiceChannel().getName());
     }
 
     private Long createProject(
@@ -984,27 +1023,8 @@ public class DiscordCommandListener extends ListenerAdapter {
     }
 
     private void handleLeave(MessageReceivedEvent event) {
-        long guildId = event.getGuild().getIdLong();
-        AudioManager audioManager = event.getGuild().getAudioManager();
-        PerUserAudioReceiveHandler handler = receiveHandlers.remove(guildId);
-
-        // leave 시점에는 열린 STT 세션을 먼저 commit/end로 닫는다.
-        if (handler != null) {
-            handler.closeAllSttSessions();
-        }
-
-        // Discord 음성 연결 종료 및 핸들러 해제
-        audioManager.closeAudioConnection();
-        audioManager.setReceivingHandler(null);
-        audioManager.setConnectionListener(null);
-
-        Long meetingId = activeMeetingIdByGuild.remove(guildId);
-        if (meetingId != null) {
-            endMeeting(guildId, meetingId);
-        }
-
-        event.getChannel().sendMessage("퇴장 완료").queue();
-        log.info("[디스코드/퇴장] guildId={}, meetingId={}", event.getGuild().getId(), meetingId);
+        MeetingEndResult result = endActiveMeeting(event.getGuild());
+        sendTemporaryMessage(event.getChannel(), buildMeetingEndMessage(result));
     }
 
     private void handleStats(MessageReceivedEvent event) {
@@ -1103,6 +1123,39 @@ public class DiscordCommandListener extends ListenerAdapter {
             return normalized.substring(0, normalized.length() - 1);
         }
         return normalized;
+    }
+
+    private String buildMeetingEndMessage(MeetingEndResult result) {
+        if (result.meetingId() != null) {
+            return "회의가 종료됐고 음성 연결도 정리했어요. 요약을 생성 중이에요... (meetingId=" + result.meetingId() + ")";
+        }
+        if (result.hadVoiceState()) {
+            return "저장 중인 회의는 없었지만 남아 있던 음성 연결은 정리했어요.";
+        }
+        return "이 봇 인스턴스에는 진행 중인 회의나 음성 연결이 없어요.";
+    }
+
+    private boolean isAllowedGuild(long guildId) {
+        return allowedGuildIds.isEmpty() || allowedGuildIds.contains(guildId);
+    }
+
+    static Set<Long> parseAllowedGuildIds(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return Set.of();
+        }
+        Set<Long> result = new HashSet<>();
+        for (String token : raw.split(",")) {
+            String trimmed = token.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            try {
+                result.add(Long.parseLong(trimmed));
+            } catch (NumberFormatException exception) {
+                log.warn("[봇/서버필터무시] value={}, reason=invalid_guild_id", trimmed);
+            }
+        }
+        return Set.copyOf(result);
     }
 
     private final class LoggingConnectionListener implements ConnectionListener {

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -7,6 +7,8 @@ import java.net.http.HttpResponse;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -39,9 +41,12 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
  */
 public class BotSttListener implements SttListener {
     private static final Logger log = LoggerFactory.getLogger(BotSttListener.class);
-    private static final List<String> WAKE_WORDS = List.of("AI야", "ai야", "봇아", "클로드야", "플로디야", "flodiya", "plodiya");
+    private static final List<String> WAKE_WORDS =
+            List.of("AI야", "ai야", "봇아", "클로드야", "플로디야", "플로드야", "flodiya", "plodiya");
     private static final long CAPTION_DEBOUNCE_MS = 150L;
     private static final int CAPTION_MIN_CHARS = 2;
+    private static final int DISCORD_MESSAGE_LIMIT = 2000;
+    private static final String AI_ANSWER_HEADER = "**Flodi 답변**\n";
     private static final long STT_QUALITY_LOG_INTERVAL_MS = 60_000L;
     private static final ScheduledExecutorService CAPTION_DEBOUNCE_EXECUTOR =
             Executors.newSingleThreadScheduledExecutor(new CaptionDebounceThreadFactory());
@@ -200,7 +205,7 @@ public class BotSttListener implements SttListener {
                                 speakerDiscordId,
                                 meetingId,
                                 response.body());
-                        logAiAnswerStatus(result.sessionId(), text, response.body());
+                        handleAiAnswerResponse(result.sessionId(), text, response.body());
                     });
         } catch (Exception exception) {
             log.warn(
@@ -401,15 +406,12 @@ public class BotSttListener implements SttListener {
         clearLiveCaptionState();
     }
 
-    private void logAiAnswerStatus(String sessionId, String finalText, String responseBody) {
+    private void handleAiAnswerResponse(String sessionId, String finalText, String responseBody) {
         boolean wakeWordDetected = containsWakeWord(finalText);
         try {
-            JsonNode root = objectMapper.readTree(responseBody);
-            JsonNode aiAnswerNode = root.path("data").path("ai_answer");
-            boolean hasAiAnswer = !aiAnswerNode.isMissingNode()
-                    && !aiAnswerNode.isNull()
-                    && !aiAnswerNode.asText().isBlank();
-            int aiAnswerLength = hasAiAnswer ? aiAnswerNode.asText().length() : 0;
+            String aiAnswer = extractAiAnswer(responseBody);
+            boolean hasAiAnswer = aiAnswer != null;
+            int aiAnswerLength = hasAiAnswer ? aiAnswer.length() : 0;
             log.info(
                     "[AI/응답체크] sessionId={}, speakerId={}, meetingId={}, wakeWordDetected={}, hasAiAnswer={}, aiAnswerLength={}",
                     sessionId,
@@ -418,6 +420,9 @@ public class BotSttListener implements SttListener {
                     wakeWordDetected,
                     hasAiAnswer,
                     aiAnswerLength);
+            if (hasAiAnswer) {
+                sendAiAnswerToDiscord(sessionId, aiAnswer);
+            }
         } catch (Exception parseException) {
             log.warn(
                     "[AI/응답체크실패] sessionId={}, speakerId={}, meetingId={}, wakeWordDetected={}",
@@ -427,6 +432,88 @@ public class BotSttListener implements SttListener {
                     wakeWordDetected,
                     parseException);
         }
+    }
+
+    String extractAiAnswer(String responseBody) throws java.io.IOException {
+        JsonNode root = objectMapper.readTree(responseBody);
+        JsonNode aiAnswerNode = root.path("data").path("ai_answer");
+        if (aiAnswerNode.isMissingNode() || aiAnswerNode.isNull()) {
+            return null;
+        }
+
+        String aiAnswer = aiAnswerNode.asText();
+        if (aiAnswer == null || aiAnswer.isBlank()) {
+            return null;
+        }
+        return aiAnswer.strip();
+    }
+
+    private void sendAiAnswerToDiscord(String sessionId, String aiAnswer) {
+        if (captionChannel == null) {
+            log.info(
+                    "[AI/디스코드응답스킵] sessionId={}, speakerId={}, meetingId={}, reason=no_caption_channel",
+                    sessionId,
+                    speakerDiscordId,
+                    meetingId);
+            return;
+        }
+
+        List<String> chunks = splitAiAnswerForDiscord(aiAnswer);
+        for (int index = 0; index < chunks.size(); index++) {
+            String content = chunks.get(index);
+            int chunkIndex = index + 1;
+            captionChannel
+                    .sendMessage(content)
+                    .setAllowedMentions(Collections.emptySet())
+                    .queue(
+                            message -> log.info(
+                                    "[AI/디스코드응답전송완료] sessionId={}, speakerId={}, meetingId={}, messageId={}, chunk={}/{}, textLength={}",
+                                    sessionId,
+                                    speakerDiscordId,
+                                    meetingId,
+                                    message.getId(),
+                                    chunkIndex,
+                                    chunks.size(),
+                                    content.length()),
+                            throwable -> log.warn(
+                                    "[AI/디스코드응답전송실패] sessionId={}, speakerId={}, meetingId={}, chunk={}/{}",
+                                    sessionId,
+                                    speakerDiscordId,
+                                    meetingId,
+                                    chunkIndex,
+                                    chunks.size(),
+                                    throwable));
+        }
+    }
+
+    List<String> splitAiAnswerForDiscord(String aiAnswer) {
+        String content = AI_ANSWER_HEADER + aiAnswer.strip();
+        if (content.length() <= DISCORD_MESSAGE_LIMIT) {
+            return List.of(content);
+        }
+
+        int bodyLimit = DISCORD_MESSAGE_LIMIT - AI_ANSWER_HEADER.length();
+        List<String> chunks = new ArrayList<>();
+        String remaining = aiAnswer.strip();
+        boolean first = true;
+        while (!remaining.isEmpty()) {
+            int limit = first ? bodyLimit : DISCORD_MESSAGE_LIMIT;
+            int end = Math.min(limit, remaining.length());
+            if (end < remaining.length()) {
+                int newlineIndex = remaining.lastIndexOf('\n', end);
+                int spaceIndex = remaining.lastIndexOf(' ', end);
+                int splitIndex = Math.max(newlineIndex, spaceIndex);
+                if (splitIndex > 0) {
+                    end = splitIndex;
+                }
+            }
+
+            String chunkBody = remaining.substring(0, end).strip();
+            chunks.add(first ? AI_ANSWER_HEADER + chunkBody : chunkBody);
+            remaining = remaining.substring(end).strip();
+            first = false;
+        }
+        return chunks;
     }
 
     private void logFinalQuality(SttResult result, String text) {

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.flodiback.bot.BotEnv;
+import com.flodiback.domain.speech.service.AssistantCallExtractor;
 import com.flodiback.domain.speech.stt.SttListener;
 import com.flodiback.domain.speech.stt.SttResult;
 
@@ -41,8 +42,6 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
  */
 public class BotSttListener implements SttListener {
     private static final Logger log = LoggerFactory.getLogger(BotSttListener.class);
-    private static final List<String> WAKE_WORDS =
-            List.of("AI야", "ai야", "봇아", "클로드야", "플로디야", "플로드야", "flodiya", "plodiya");
     private static final long CAPTION_DEBOUNCE_MS = 150L;
     private static final int CAPTION_MIN_CHARS = 2;
     private static final int DISCORD_MESSAGE_LIMIT = 2000;
@@ -556,15 +555,7 @@ public class BotSttListener implements SttListener {
     }
 
     private boolean containsWakeWord(String text) {
-        if (text == null || text.isBlank()) {
-            return false;
-        }
-        for (String wakeWord : WAKE_WORDS) {
-            if (text.contains(wakeWord)) {
-                return true;
-            }
-        }
-        return false;
+        return AssistantCallExtractor.containsWakeWord(text);
     }
 
     private static final class CaptionDebounceThreadFactory implements ThreadFactory {

--- a/src/main/java/com/flodiback/domain/speech/service/AssistantCallExtractor.java
+++ b/src/main/java/com/flodiback/domain/speech/service/AssistantCallExtractor.java
@@ -1,0 +1,125 @@
+package com.flodiback.domain.speech.service;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.util.StringUtils;
+
+public final class AssistantCallExtractor {
+
+    private static final List<String> EXACT_WAKE_WORDS =
+            List.of("AI야", "ai야", "에이아이야", "봇아", "클로드야", "플로디야", "플로디아", "플로드야", "flodiya", "plodiya");
+    private static final List<String> FUZZY_FLODI_WAKE_WORDS = List.of("플로디야", "플로디아");
+    private static final Pattern LEADING_PUNCTUATION = Pattern.compile("^[\\s,，.。?？!！:：;；-]+");
+    private static final Pattern WORD_TOKEN = Pattern.compile("[\\p{L}\\p{N}]+");
+
+    private AssistantCallExtractor() {}
+
+    public static String extractQuestion(String speechText) {
+        if (!StringUtils.hasText(speechText)) {
+            return null;
+        }
+
+        Match match = findEarliestMatch(speechText);
+        if (match == null) {
+            return null;
+        }
+
+        String rawQuestion = speechText.substring(match.endIndex());
+        String question =
+                LEADING_PUNCTUATION.matcher(rawQuestion).replaceFirst("").strip();
+
+        return StringUtils.hasText(question) ? question : null;
+    }
+
+    public static boolean containsWakeWord(String text) {
+        if (!StringUtils.hasText(text)) {
+            return false;
+        }
+        return findEarliestMatch(text) != null;
+    }
+
+    private static Match findEarliestMatch(String text) {
+        Match exactMatch = findExactMatch(text);
+        Match fuzzyMatch = findFuzzyFlodiMatch(text);
+
+        if (exactMatch == null) {
+            return fuzzyMatch;
+        }
+        if (fuzzyMatch == null) {
+            return exactMatch;
+        }
+        return exactMatch.startIndex() <= fuzzyMatch.startIndex() ? exactMatch : fuzzyMatch;
+    }
+
+    private static Match findExactMatch(String text) {
+        int wakeWordIndex = Integer.MAX_VALUE;
+        String matchedWakeWord = null;
+
+        for (String wakeWord : EXACT_WAKE_WORDS) {
+            int index = text.indexOf(wakeWord);
+            if (index >= 0 && index < wakeWordIndex) {
+                wakeWordIndex = index;
+                matchedWakeWord = wakeWord;
+            }
+        }
+
+        if (matchedWakeWord == null) {
+            return null;
+        }
+        return new Match(wakeWordIndex, wakeWordIndex + matchedWakeWord.length());
+    }
+
+    private static Match findFuzzyFlodiMatch(String text) {
+        Matcher matcher = WORD_TOKEN.matcher(text);
+        while (matcher.find()) {
+            String token = matcher.group();
+            if (isLikelyFlodiWakeWord(token)) {
+                return new Match(matcher.start(), matcher.end());
+            }
+        }
+        return null;
+    }
+
+    private static boolean isLikelyFlodiWakeWord(String token) {
+        if (token.length() < 3 || token.length() > 5) {
+            return false;
+        }
+        if (!(token.endsWith("야") || token.endsWith("아"))) {
+            return false;
+        }
+        if (!(token.startsWith("플") || token.startsWith("필"))) {
+            return false;
+        }
+
+        for (String wakeWord : FUZZY_FLODI_WAKE_WORDS) {
+            if (levenshteinDistance(token, wakeWord) <= 1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int levenshteinDistance(String left, String right) {
+        int[][] distance = new int[left.length() + 1][right.length() + 1];
+        for (int i = 0; i <= left.length(); i++) {
+            distance[i][0] = i;
+        }
+        for (int j = 0; j <= right.length(); j++) {
+            distance[0][j] = j;
+        }
+
+        for (int i = 1; i <= left.length(); i++) {
+            for (int j = 1; j <= right.length(); j++) {
+                int substitutionCost = left.charAt(i - 1) == right.charAt(j - 1) ? 0 : 1;
+                distance[i][j] = Math.min(
+                        Math.min(distance[i - 1][j] + 1, distance[i][j - 1] + 1),
+                        distance[i - 1][j - 1] + substitutionCost);
+            }
+        }
+        return distance[left.length()][right.length()];
+    }
+
+    private record Match(int startIndex, int endIndex) {}
+}

--- a/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
@@ -1,7 +1,6 @@
 package com.flodiback.domain.speech.service;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -24,9 +23,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SpeechAiAnswerService {
 
-    private static final List<String> WAKE_WORDS =
-            List.of("AI야", "ai야", "봇아", "클로드야", "플로디야", "플로드야", "flodiya", "plodiya");
-    private static final Pattern LEADING_PUNCTUATION = Pattern.compile("^[\\s,，.。?？!！:：;；-]+");
     private static final String SYSTEM_PROMPT = """
             너는 Discord 회의에 참여하는 AI 회의 보조자야.
             항상 회의 컨텍스트를 먼저 확인하고 한국어로 2~3문장만 답해줘.
@@ -39,7 +35,7 @@ public class SpeechAiAnswerService {
     private final AiChatService aiChatService;
 
     public String generateAnswerIfCalled(Long meetingId, String speechText) {
-        String question = extractQuestion(speechText);
+        String question = AssistantCallExtractor.extractQuestion(speechText);
         if (!StringUtils.hasText(question)) {
             return null;
         }
@@ -53,36 +49,6 @@ public class SpeechAiAnswerService {
             log.warn("AI 답변 생성에 실패했습니다. meetingId={}, reason={}", meetingId, e.getMessage());
             return null;
         }
-    }
-
-    private String extractQuestion(String speechText) {
-        // 빈 STT 문장은 AI가 답할 질문으로 볼 수 없으므로 바로 종료합니다.
-        if (!StringUtils.hasText(speechText)) {
-            return null;
-        }
-
-        int wakeWordIndex = Integer.MAX_VALUE;
-        String matchedWakeWord = null;
-
-        // 한 문장에 호출어가 여러 개 있어도 가장 앞에 나온 호출어를 기준으로 질문을 자릅니다.
-        for (String wakeWord : WAKE_WORDS) {
-            int index = speechText.indexOf(wakeWord);
-            if (index >= 0 && index < wakeWordIndex) {
-                wakeWordIndex = index;
-                matchedWakeWord = wakeWord;
-            }
-        }
-
-        if (matchedWakeWord == null) {
-            return null;
-        }
-
-        // 호출어 뒤에 붙은 쉼표, 물음표, 공백을 제거해 실제 질문만 남깁니다.
-        String rawQuestion = speechText.substring(wakeWordIndex + matchedWakeWord.length());
-        String question =
-                LEADING_PUNCTUATION.matcher(rawQuestion).replaceFirst("").strip();
-
-        return StringUtils.hasText(question) ? question : null;
     }
 
     private String buildUserPrompt(ContextResponse context, String question) {

--- a/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
@@ -24,7 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SpeechAiAnswerService {
 
-    private static final List<String> WAKE_WORDS = List.of("AI야", "ai야", "봇아", "클로드야", "플로디야", "flodiya", "plodiya");
+    private static final List<String> WAKE_WORDS =
+            List.of("AI야", "ai야", "봇아", "클로드야", "플로디야", "플로드야", "flodiya", "plodiya");
     private static final Pattern LEADING_PUNCTUATION = Pattern.compile("^[\\s,，.。?？!！:：;；-]+");
     private static final String SYSTEM_PROMPT = """
             너는 Discord 회의에 참여하는 AI 회의 보조자야.

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeClient.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeClient.java
@@ -30,7 +30,7 @@ final class OpenAiRealtimeClient {
     private static final String ENV_OPENAI_TRANSCRIBE_MODEL = "OPENAI_TRANSCRIBE_MODEL";
     private static final String ENV_OPENAI_TRANSCRIBE_LANGUAGE = "OPENAI_TRANSCRIBE_LANGUAGE";
 
-    private static final String DEFAULT_TRANSCRIBE_MODEL = "gpt-4o-transcribe";
+    private static final String DEFAULT_TRANSCRIBE_MODEL = "gpt-realtime-whisper";
     private static final String DEFAULT_TRANSCRIBE_LANGUAGE = "ko";
     private static final Duration COMMIT_WAIT_TIMEOUT = Duration.ofSeconds(8);
     private static final int REALTIME_SAMPLE_RATE = 24_000;

--- a/src/test/java/com/flodiback/bot/command/DiscordCommandListenerTest.java
+++ b/src/test/java/com/flodiback/bot/command/DiscordCommandListenerTest.java
@@ -1,0 +1,25 @@
+package com.flodiback.bot.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DiscordCommandListenerTest {
+
+    @Test
+    void parseAllowedGuildIds_returnsEmptySetForBlankValue() {
+        assertThat(DiscordCommandListener.parseAllowedGuildIds(null)).isEmpty();
+        assertThat(DiscordCommandListener.parseAllowedGuildIds("   ")).isEmpty();
+    }
+
+    @Test
+    void parseAllowedGuildIds_parsesCommaSeparatedGuildIds() {
+        assertThat(DiscordCommandListener.parseAllowedGuildIds("123, 456,,789"))
+                .containsExactlyInAnyOrder(123L, 456L, 789L);
+    }
+
+    @Test
+    void parseAllowedGuildIds_ignoresInvalidTokens() {
+        assertThat(DiscordCommandListener.parseAllowedGuildIds("123,abc,456")).containsExactlyInAnyOrder(123L, 456L);
+    }
+}

--- a/src/test/java/com/flodiback/bot/stt/BotSttListenerTest.java
+++ b/src/test/java/com/flodiback/bot/stt/BotSttListenerTest.java
@@ -1,0 +1,51 @@
+package com.flodiback.bot.stt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class BotSttListenerTest {
+
+    private final BotSttListener listener = new BotSttListener(1L, "123456789", "김철수");
+
+    @Test
+    void extractAiAnswer_returnsAnswer_whenResponseContainsAiAnswer() throws Exception {
+        String responseBody = """
+                {
+                  "resultCode": "200-1",
+                  "msg": "발화가 저장되었습니다.",
+                  "data": {
+                    "utterance_id": 11,
+                    "meeting_id": 1,
+                    "ai_answer": "  인증 방식은 JWT로 결정했습니다.  "
+                  }
+                }
+                """;
+
+        String aiAnswer = listener.extractAiAnswer(responseBody);
+
+        assertThat(aiAnswer).isEqualTo("인증 방식은 JWT로 결정했습니다.");
+    }
+
+    @Test
+    void extractAiAnswer_returnsNull_whenAiAnswerIsNullOrBlank() throws Exception {
+        String nullAnswerResponse = """
+                {"data":{"ai_answer":null}}
+                """;
+        String blankAnswerResponse = """
+                {"data":{"ai_answer":"   "}}
+                """;
+
+        assertThat(listener.extractAiAnswer(nullAnswerResponse)).isNull();
+        assertThat(listener.extractAiAnswer(blankAnswerResponse)).isNull();
+    }
+
+    @Test
+    void splitAiAnswerForDiscord_keepsEveryChunkWithinDiscordLimit() {
+        String aiAnswer = "a".repeat(4_500);
+
+        assertThat(listener.splitAiAnswerForDiscord(aiAnswer)).hasSize(3).allSatisfy(chunk -> assertThat(chunk)
+                .hasSizeLessThanOrEqualTo(2_000));
+        assertThat(listener.splitAiAnswerForDiscord(aiAnswer).get(0)).startsWith("**Flodi 답변**\n");
+    }
+}

--- a/src/test/java/com/flodiback/domain/speech/service/AssistantCallExtractorTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/AssistantCallExtractorTest.java
@@ -1,0 +1,38 @@
+package com.flodiback.domain.speech.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AssistantCallExtractorTest {
+
+    @Test
+    void extractQuestion_returnsQuestionAfterExactWakeWord() {
+        assertThat(AssistantCallExtractor.extractQuestion("클로드야, 아까 말랑이 얘기 요약해줘"))
+                .isEqualTo("아까 말랑이 얘기 요약해줘");
+        assertThat(AssistantCallExtractor.extractQuestion("AI야 인증 방식 뭐였지?")).isEqualTo("인증 방식 뭐였지?");
+        assertThat(AssistantCallExtractor.extractQuestion("봇아: 회의 결론 알려줘")).isEqualTo("회의 결론 알려줘");
+    }
+
+    @Test
+    void extractQuestion_acceptsCommonFlodiSttMisrecognitions() {
+        assertThat(AssistantCallExtractor.extractQuestion("플로디아 아까 말랑이 얘기 요약해줘"))
+                .isEqualTo("아까 말랑이 얘기 요약해줘");
+        assertThat(AssistantCallExtractor.extractQuestion("플로드야 아까 말랑이 얘기 요약해줘"))
+                .isEqualTo("아까 말랑이 얘기 요약해줘");
+        assertThat(AssistantCallExtractor.extractQuestion("필로디야 아까 말랑이 얘기 요약해줘"))
+                .isEqualTo("아까 말랑이 얘기 요약해줘");
+    }
+
+    @Test
+    void extractQuestion_returnsNullWhenWakeWordHasNoQuestion() {
+        assertThat(AssistantCallExtractor.extractQuestion("플로디야!")).isNull();
+        assertThat(AssistantCallExtractor.extractQuestion("클로드야")).isNull();
+    }
+
+    @Test
+    void extractQuestion_avoidsBroadContextOnlyRequestsWithoutAssistantCall() {
+        assertThat(AssistantCallExtractor.extractQuestion("아까 말랑이 얘기 요약해줘")).isNull();
+        assertThat(AssistantCallExtractor.extractQuestion("플로디가 아까 정리한 내용 말해줘")).isNull();
+    }
+}

--- a/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
@@ -117,6 +117,18 @@ class SpeechAiAnswerServiceTest {
     }
 
     @Test
+    void generateAnswerIfCalled_acceptsMisrecognizedFlodiWakeWord() {
+        ContextResponse context = ContextResponse.noProject(null, List.of());
+        given(contextService.assemble(1L, "아까 말랑이 관련 이야기 요약 좀 해줄래?")).willReturn(context);
+        given(aiChatService.generateAnswer(anyString(), anyString())).willReturn("말랑이 관련 이야기를 요약했습니다.");
+
+        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "플로드야 아까 말랑이 관련 이야기 요약 좀 해줄래?");
+
+        assertThat(result).isEqualTo("말랑이 관련 이야기를 요약했습니다.");
+        verify(contextService).assemble(1L, "아까 말랑이 관련 이야기 요약 좀 해줄래?");
+    }
+
+    @Test
     void generateAnswerIfCalled_returnsNull_whenQuestionIsBlank() {
         String result = speechAiAnswerService.generateAnswerIfCalled(1L, "플로디야!");
 

--- a/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
@@ -122,7 +122,7 @@ class SpeechAiAnswerServiceTest {
         given(contextService.assemble(1L, "아까 말랑이 관련 이야기 요약 좀 해줄래?")).willReturn(context);
         given(aiChatService.generateAnswer(anyString(), anyString())).willReturn("말랑이 관련 이야기를 요약했습니다.");
 
-        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "플로드야 아까 말랑이 관련 이야기 요약 좀 해줄래?");
+        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "플로디아 아까 말랑이 관련 이야기 요약 좀 해줄래?");
 
         assertThat(result).isEqualTo("말랑이 관련 이야기를 요약했습니다.");
         verify(contextService).assemble(1L, "아까 말랑이 관련 이야기 요약 좀 해줄래?");


### PR DESCRIPTION
## 변경 사항
- 내부 speech API 응답의 `data.ai_answer`를 봇 리스너에서 파싱해 Discord 자막 채널로 전송합니다.
- Discord 2000자 제한을 넘는 답변은 여러 메시지로 분할하고, AI 답변 메시지에서 멘션을 비활성화했습니다.
- STT가 호출어를 `플로드야`, `플로디아`처럼 오인식해도 AI 호출로 감지하도록 호출어 추출 로직을 `AssistantCallExtractor`로 분리했습니다.
- OpenAI Realtime STT 모델 설정을 실시간 Whisper 계열로 전환해 한국어 전사 품질과 오출력 빈도를 개선했습니다.
- 같은 Discord 토큰으로 여러 테스트 봇 인스턴스를 띄울 때 서버별 이벤트 처리를 제한할 수 있도록 `DISCORD_ALLOWED_GUILD_IDS`를 추가했습니다.
- 회의 시작 중복 요청을 방지하고, 회의 종료/퇴장 시 STT 세션과 Discord 음성 연결을 일관되게 정리하도록 봇 명령 리스너를 보강했습니다.

## 배경
`클로드야`, `플로디야`처럼 호출어가 포함된 발화의 AI 답변은 `/internal/v1/speech` 응답으로 내려오고 있었지만, 봇에서는 응답 여부와 길이만 로그로 남기고 Discord 메시지로 보내지 않았습니다.

테스트 중에는 동일한 Discord bot token으로 여러 Docker 인스턴스가 떠 있으면 같은 명령 이벤트를 여러 인스턴스가 동시에 처리해 패널이 중복 생성되고, 회의 종료 버튼을 다른 인스턴스가 처리해 음성방 퇴장이 누락될 수 있었습니다. 이를 테스트 환경에서는 `DISCORD_ALLOWED_GUILD_IDS`로 분리하고, 실배포에서는 봇 프로세스 1개 운영을 전제로 정리했습니다.

## 검증
- `./gradlew test`
- `./gradlew spotlessCheck`
- `docker compose -f docker-compose.bot.yml up -d --force-recreate discord-bot`
- 봇 기동 로그 확인: `Login Successful`, `Connected to WebSocket`, `[봇/준비완료]`

## 운영 메모
- 실배포에서는 `runDiscordBot`/`DiscordBotMain` 실행 인스턴스를 1개만 운영합니다.
- 여러 개발자가 같은 token으로 테스트할 때는 각자 `.env`에 `DISCORD_ALLOWED_GUILD_IDS=<담당 서버 ID>`를 설정해야 중복 응답을 피할 수 있습니다.
