### PR TITLE
[Feat] 명령어 구현

### DIFF
--- a/src/main/java/com/flodiback/api/meeting/MeetingController.java
+++ b/src/main/java/com/flodiback/api/meeting/MeetingController.java
@@ -25,7 +25,7 @@ public class MeetingController {
     }
 
     @GetMapping
-    public RsData<List<MeetingDetailResponse>> getMeetings(@RequestParam(required = false) Long projectId) {
+    public RsData<List<MeetingDetailResponse>> getMeetings(@RequestParam Long projectId) {
         return RsData.of("200-1", "회의 목록 조회 성공.", service.getByProjectId(projectId));
     }
 

--- a/src/main/java/com/flodiback/api/meeting/MeetingController.java
+++ b/src/main/java/com/flodiback/api/meeting/MeetingController.java
@@ -1,5 +1,7 @@
 package com.flodiback.api.meeting;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.*;
 
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
@@ -22,6 +24,11 @@ public class MeetingController {
         return RsData.of("201-1", "회의가 생성되었습니다.", service.create(req));
     }
 
+    @GetMapping
+    public RsData<List<MeetingDetailResponse>> getMeetings(@RequestParam(required = false) Long projectId) {
+        return RsData.of("200-1", "회의 목록 조회 성공.", service.getByProjectId(projectId));
+    }
+
     @PutMapping("/{id}/end")
     public RsData<MeetingDetailResponse> endMeeting(@PathVariable Long id) {
         return RsData.of("200-1", "회의가 종료되었습니다.", service.end(id));
@@ -30,5 +37,11 @@ public class MeetingController {
     @GetMapping("/{id}")
     public RsData<MeetingDetailResponse> getMeeting(@PathVariable Long id) {
         return RsData.of("200-1", "회의 조회 성공.", service.getById(id));
+    }
+
+    @DeleteMapping("/{id}")
+    public RsData<Void> deleteMeeting(@PathVariable Long id) {
+        service.delete(id);
+        return RsData.of("200-1", "회의가 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/flodiback/api/project/ProjectController.java
+++ b/src/main/java/com/flodiback/api/project/ProjectController.java
@@ -56,6 +56,18 @@ public class ProjectController {
         return RsData.of("200-1", "프로젝트가 수정되었습니다.", projectService.update(id, req));
     }
 
+    @PutMapping("/{id}/channel/{channelId}")
+    public RsData<Void> connectChannel(@PathVariable Long id, @PathVariable String channelId) {
+        projectService.connectChannel(id, channelId);
+        return RsData.of("200-1", "채널이 연결되었습니다.");
+    }
+
+    @DeleteMapping("/{id}/channel")
+    public RsData<Void> disconnectChannel(@PathVariable Long id) {
+        projectService.disconnectChannel(id);
+        return RsData.of("200-1", "채널 연결이 해제되었습니다.");
+    }
+
     @DeleteMapping("/{id}")
     public RsData<Void> delete(@PathVariable Long id) {
         projectService.delete(id);

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -98,6 +98,11 @@ public class DiscordCommandListener extends ListenerAdapter {
 
     private record MeetingConfirmationState(MeetingStartContext ctx, long createdAt) {}
 
+    private record ProjectEditState(
+            ProjectCreationStep step, String name, String description, long projectId, long createdAt) {}
+
+    private record ProjectDeletionState(long projectId, long createdAt) {}
+
     // 명령어 접두사. 기본값은 !.
     private final String prefix;
     // 실제 STT 엔진 구현체. 현재 기본값은 OpenAI.
@@ -114,6 +119,10 @@ public class DiscordCommandListener extends ListenerAdapter {
     private final Map<Long, ProjectCreationState> pendingProjectCreations = new ConcurrentHashMap<>();
     // 채널별 회의 시작 확인 대기 상태
     private final Map<Long, MeetingConfirmationState> pendingMeetingConfirmations = new ConcurrentHashMap<>();
+    // 채널별 프로젝트 수정 상태
+    private final Map<Long, ProjectEditState> pendingProjectEdits = new ConcurrentHashMap<>();
+    // 채널별 프로젝트 삭제 확인 대기 상태
+    private final Map<Long, ProjectDeletionState> pendingProjectDeletions = new ConcurrentHashMap<>();
 
     public DiscordCommandListener() {
         this("!", new OpenAiSttProvider(), 1L);
@@ -147,6 +156,18 @@ public class DiscordCommandListener extends ListenerAdapter {
             return;
         }
 
+        // 프로젝트 수정 대화 중인 채널이면 먼저 처리
+        if (pendingProjectEdits.containsKey(channelId)) {
+            new Thread(() -> handleProjectEditStep(event, channelId)).start();
+            return;
+        }
+
+        // 프로젝트 삭제 확인 대기 중인 채널이면 먼저 처리
+        if (pendingProjectDeletions.containsKey(channelId)) {
+            new Thread(() -> handleProjectDeletionStep(event, channelId)).start();
+            return;
+        }
+
         String raw = event.getMessage().getContentRaw().trim();
         if (!raw.startsWith(prefix)) {
             return;
@@ -163,6 +184,10 @@ public class DiscordCommandListener extends ListenerAdapter {
             case "project" -> new Thread(() -> handleProject(event, channelId)).start();
             case "meeting" -> handleMeeting(event);
             case "project start" -> handleProjectStart(event, channelId);
+            case "project list" -> new Thread(() -> handleProjectList(event)).start();
+            case "project end" -> new Thread(() -> handleProjectEnd(event, channelId)).start();
+            case "project edit" -> new Thread(() -> handleProjectEdit(event, channelId)).start();
+            case "project delete" -> new Thread(() -> handleProjectDelete(event, channelId)).start();
             case "meeting start" -> {
                 Member member = event.getMember();
                 if (member == null
@@ -183,7 +208,11 @@ public class DiscordCommandListener extends ListenerAdapter {
             }
             case "meeting end" -> handleMeetingEnd(event);
             default -> {
-                // 알 수 없는 명령은 조용히 무시
+                if (command.startsWith("project start ")) {
+                    String arg = command.substring("project start ".length()).trim();
+                    new Thread(() -> handleProjectStartWithArg(event, channelId, arg)).start();
+                }
+                // 그 외 알 수 없는 명령은 조용히 무시
             }
         }
     }
@@ -726,6 +755,249 @@ public class DiscordCommandListener extends ListenerAdapter {
                 ? "🎙️ **현재 회의 진행 중** (meetingId=" + meetingId + ")"
                 : "현재 진행 중인 회의가 없어요. `!meeting start`로 시작하세요.";
         event.getChannel().sendMessage(header + "\n\n" + MEETING_COMMANDS).queue();
+    }
+
+    private void handleProjectList(MessageReceivedEvent event) {
+        try {
+            HttpRequest.Builder req = HttpRequest.newBuilder()
+                    .uri(URI.create(internalBaseUrl + "/api/v1/projects"))
+                    .GET();
+            attachInternalApiKey(req);
+            HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
+            JsonNode data = objectMapper.readTree(response.body()).path("data");
+            if (!data.isArray() || data.isEmpty()) {
+                event.getChannel().sendMessage("📋 등록된 프로젝트가 없어요.").queue();
+                return;
+            }
+            StringBuilder sb = new StringBuilder("📋 **프로젝트 목록**\n");
+            for (JsonNode p : data) {
+                sb.append("`id=").append(p.path("id").asText()).append("` ");
+                sb.append(p.path("name").asText()).append("\n");
+            }
+            event.getChannel().sendMessage(sb.toString().trim()).queue();
+        } catch (Exception e) {
+            log.warn("[프로젝트/목록예외]", e);
+            event.getChannel().sendMessage("❌ 프로젝트 목록 조회 중 오류가 발생했습니다.").queue();
+        }
+    }
+
+    private void handleProjectStartWithArg(MessageReceivedEvent event, long channelId, String arg) {
+        try {
+            // id로 조회 시도, 실패하면 name으로 검색
+            Long projectId = null;
+            try {
+                long id = Long.parseLong(arg);
+                HttpRequest.Builder req = HttpRequest.newBuilder()
+                        .uri(URI.create(internalBaseUrl + "/api/v1/projects/" + id))
+                        .GET();
+                attachInternalApiKey(req);
+                HttpResponse<String> resp = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
+                if (resp.statusCode() / 100 == 2) {
+                    projectId = objectMapper
+                            .readTree(resp.body())
+                            .path("data")
+                            .path("id")
+                            .asLong();
+                }
+            } catch (NumberFormatException ignored) {
+                // 숫자가 아니면 name으로 검색
+                HttpRequest.Builder req = HttpRequest.newBuilder()
+                        .uri(URI.create(internalBaseUrl + "/api/v1/projects"))
+                        .GET();
+                attachInternalApiKey(req);
+                HttpResponse<String> resp = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
+                JsonNode list = objectMapper.readTree(resp.body()).path("data");
+                for (JsonNode p : list) {
+                    if (arg.equalsIgnoreCase(p.path("name").asText())) {
+                        projectId = p.path("id").asLong();
+                        break;
+                    }
+                }
+            }
+
+            if (projectId == null) {
+                event.getChannel()
+                        .sendMessage("❌ `" + arg + "`에 해당하는 프로젝트를 찾을 수 없어요.")
+                        .queue();
+                return;
+            }
+
+            // 채널에 프로젝트 연결
+            HttpRequest.Builder connectReq = HttpRequest.newBuilder()
+                    .uri(URI.create(internalBaseUrl + "/api/v1/projects/" + projectId + "/channel/" + channelId))
+                    .PUT(HttpRequest.BodyPublishers.noBody());
+            attachInternalApiKey(connectReq);
+            HttpResponse<String> connectResp =
+                    httpClient.send(connectReq.build(), HttpResponse.BodyHandlers.ofString());
+            if (connectResp.statusCode() / 100 != 2) {
+                event.getChannel().sendMessage("❌ 프로젝트 연결에 실패했습니다.").queue();
+                return;
+            }
+
+            JsonNode data = objectMapper.readTree(connectResp.body());
+            event.getChannel()
+                    .sendMessage("✅ 프로젝트 (id=" + projectId + ")에 이 채널을 연결했습니다.")
+                    .queue();
+            log.info("[프로젝트/채널연결] projectId={}, channelId={}", projectId, channelId);
+        } catch (Exception e) {
+            log.warn("[프로젝트/선택예외] arg={}", arg, e);
+            event.getChannel().sendMessage("❌ 프로젝트 선택 중 오류가 발생했습니다.").queue();
+        }
+    }
+
+    private void handleProjectEnd(MessageReceivedEvent event, long channelId) {
+        Long projectId = fetchProjectIdByChannel(channelId);
+        if (projectId == null) {
+            event.getChannel().sendMessage("이 채널에 연결된 프로젝트가 없어요.").queue();
+            return;
+        }
+        try {
+            HttpRequest.Builder req = HttpRequest.newBuilder()
+                    .uri(URI.create(internalBaseUrl + "/api/v1/projects/" + projectId + "/channel"))
+                    .DELETE();
+            attachInternalApiKey(req);
+            HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+                event.getChannel().sendMessage("❌ 프로젝트 연결 해제에 실패했습니다.").queue();
+                return;
+            }
+            event.getChannel().sendMessage("✅ 프로젝트 연결이 해제됐습니다.").queue();
+            log.info("[프로젝트/채널해제] projectId={}, channelId={}", projectId, channelId);
+        } catch (Exception e) {
+            log.warn("[프로젝트/채널해제예외] projectId={}", projectId, e);
+            event.getChannel().sendMessage("❌ 프로젝트 연결 해제 중 오류가 발생했습니다.").queue();
+        }
+    }
+
+    private void handleProjectEdit(MessageReceivedEvent event, long channelId) {
+        Long projectId = fetchProjectIdByChannel(channelId);
+        if (projectId == null) {
+            event.getChannel()
+                    .sendMessage("이 채널에 연결된 프로젝트가 없어요. `!project start {id}`로 프로젝트를 선택해주세요.")
+                    .queue();
+            return;
+        }
+        pendingProjectEdits.put(
+                channelId,
+                new ProjectEditState(
+                        ProjectCreationStep.WAITING_NAME, null, null, projectId, System.currentTimeMillis()));
+        event.getChannel().sendMessage("새 프로젝트 이름을 입력해주세요. (건너뛰려면 '.')").queue();
+    }
+
+    private void handleProjectDelete(MessageReceivedEvent event, long channelId) {
+        Long projectId = fetchProjectIdByChannel(channelId);
+        if (projectId == null) {
+            event.getChannel().sendMessage("이 채널에 연결된 프로젝트가 없어요.").queue();
+            return;
+        }
+        pendingProjectDeletions.put(channelId, new ProjectDeletionState(projectId, System.currentTimeMillis()));
+        event.getChannel()
+                .sendMessage("⚠️ 정말로 프로젝트를 삭제하시겠어요? 이 작업은 되돌릴 수 없습니다. (yes / no)")
+                .queue();
+    }
+
+    private void handleProjectEditStep(MessageReceivedEvent event, long channelId) {
+        ProjectEditState state = pendingProjectEdits.get(channelId);
+
+        if (System.currentTimeMillis() - state.createdAt() > PENDING_TTL_MS) {
+            pendingProjectEdits.remove(channelId);
+            event.getChannel()
+                    .sendMessage("⏰ 수정 시간이 초과됐습니다. 다시 `!project edit`를 입력해주세요.")
+                    .queue();
+            return;
+        }
+
+        String input = event.getMessage().getContentRaw().trim();
+        String value = ".".equals(input) ? null : input;
+
+        switch (state.step()) {
+            case WAITING_NAME -> {
+                pendingProjectEdits.put(
+                        channelId,
+                        new ProjectEditState(
+                                ProjectCreationStep.WAITING_DESCRIPTION,
+                                value,
+                                null,
+                                state.projectId(),
+                                state.createdAt()));
+                event.getChannel().sendMessage("설명을 입력해주세요. (건너뛰려면 '.')").queue();
+            }
+            case WAITING_DESCRIPTION -> {
+                pendingProjectEdits.put(
+                        channelId,
+                        new ProjectEditState(
+                                ProjectCreationStep.WAITING_TECH_STACK,
+                                state.name(),
+                                value,
+                                state.projectId(),
+                                state.createdAt()));
+                event.getChannel().sendMessage("기술 스택을 입력해주세요. (건너뛰려면 '.')").queue();
+            }
+            case WAITING_TECH_STACK -> {
+                pendingProjectEdits.remove(channelId);
+                try {
+                    ObjectNode body = objectMapper.createObjectNode();
+                    body.put("name", state.name());
+                    body.put("description", state.description());
+                    body.put("techStack", value);
+
+                    HttpRequest.Builder req = HttpRequest.newBuilder()
+                            .uri(URI.create(internalBaseUrl + "/api/v1/projects/" + state.projectId()))
+                            .header("Content-Type", "application/json")
+                            .PUT(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(body)));
+                    attachInternalApiKey(req);
+                    HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
+                    if (response.statusCode() / 100 != 2) {
+                        event.getChannel().sendMessage("❌ 프로젝트 수정에 실패했습니다.").queue();
+                        return;
+                    }
+                    event.getChannel().sendMessage("✅ 프로젝트가 수정됐습니다.").queue();
+                } catch (Exception e) {
+                    log.warn("[프로젝트/수정예외] projectId={}", state.projectId(), e);
+                    event.getChannel().sendMessage("❌ 프로젝트 수정 중 오류가 발생했습니다.").queue();
+                }
+            }
+        }
+    }
+
+    private void handleProjectDeletionStep(MessageReceivedEvent event, long channelId) {
+        ProjectDeletionState state = pendingProjectDeletions.get(channelId);
+
+        if (System.currentTimeMillis() - state.createdAt() > PENDING_TTL_MS) {
+            pendingProjectDeletions.remove(channelId);
+            event.getChannel()
+                    .sendMessage("⏰ 응답 시간이 초과됐습니다. 다시 `!project delete`를 입력해주세요.")
+                    .queue();
+            return;
+        }
+
+        String input = event.getMessage().getContentRaw().trim().toLowerCase();
+        pendingProjectDeletions.remove(channelId);
+
+        if ("yes".equals(input)) {
+            try {
+                HttpRequest.Builder req = HttpRequest.newBuilder()
+                        .uri(URI.create(internalBaseUrl + "/api/v1/projects/" + state.projectId()))
+                        .DELETE();
+                attachInternalApiKey(req);
+                HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() / 100 != 2) {
+                    event.getChannel().sendMessage("❌ 프로젝트 삭제에 실패했습니다.").queue();
+                    return;
+                }
+                event.getChannel().sendMessage("✅ 프로젝트가 삭제됐습니다.").queue();
+                log.info("[프로젝트/삭제] projectId={}", state.projectId());
+            } catch (Exception e) {
+                log.warn("[프로젝트/삭제예외] projectId={}", state.projectId(), e);
+                event.getChannel().sendMessage("❌ 프로젝트 삭제 중 오류가 발생했습니다.").queue();
+            }
+        } else if ("no".equals(input)) {
+            event.getChannel().sendMessage("프로젝트 삭제를 취소했습니다.").queue();
+        } else {
+            event.getChannel()
+                    .sendMessage("'yes' 또는 'no'로 답해주세요. 다시 `!project delete`를 입력해주세요.")
+                    .queue();
+        }
     }
 
     private void handleProjectStart(MessageReceivedEvent event, long channelId) {

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -103,6 +103,8 @@ public class DiscordCommandListener extends ListenerAdapter {
 
     private record ProjectDeletionState(long projectId, long createdAt) {}
 
+    private record MeetingDeletionState(long meetingId, long createdAt) {}
+
     // 명령어 접두사. 기본값은 !.
     private final String prefix;
     // 실제 STT 엔진 구현체. 현재 기본값은 OpenAI.
@@ -123,6 +125,8 @@ public class DiscordCommandListener extends ListenerAdapter {
     private final Map<Long, ProjectEditState> pendingProjectEdits = new ConcurrentHashMap<>();
     // 채널별 프로젝트 삭제 확인 대기 상태
     private final Map<Long, ProjectDeletionState> pendingProjectDeletions = new ConcurrentHashMap<>();
+    // 채널별 회의 삭제 확인 대기 상태
+    private final Map<Long, MeetingDeletionState> pendingMeetingDeletions = new ConcurrentHashMap<>();
 
     public DiscordCommandListener() {
         this("!", new OpenAiSttProvider(), 1L);
@@ -168,6 +172,12 @@ public class DiscordCommandListener extends ListenerAdapter {
             return;
         }
 
+        // 회의 삭제 확인 대기 중인 채널이면 먼저 처리
+        if (pendingMeetingDeletions.containsKey(channelId)) {
+            new Thread(() -> handleMeetingDeletionStep(event, channelId)).start();
+            return;
+        }
+
         String raw = event.getMessage().getContentRaw().trim();
         if (!raw.startsWith(prefix)) {
             return;
@@ -206,11 +216,15 @@ public class DiscordCommandListener extends ListenerAdapter {
                         channelId);
                 new Thread(() -> handleMeetingStart(ctx)).start();
             }
+            case "meeting list" -> new Thread(() -> handleMeetingList(event, channelId)).start();
             case "meeting end" -> handleMeetingEnd(event);
             default -> {
                 if (command.startsWith("project start ")) {
                     String arg = command.substring("project start ".length()).trim();
                     new Thread(() -> handleProjectStartWithArg(event, channelId, arg)).start();
+                } else if (command.startsWith("meeting delete ")) {
+                    String arg = command.substring("meeting delete ".length()).trim();
+                    new Thread(() -> handleMeetingDelete(event, arg)).start();
                 }
                 // 그 외 알 수 없는 명령은 조용히 무시
             }
@@ -1127,6 +1141,106 @@ public class DiscordCommandListener extends ListenerAdapter {
         endMeeting(guildId, meetingId);
         channel.sendMessage("회의가 종료됐습니다. 요약을 생성 중이에요...").queue();
         log.info("[미팅/종료명령] guildId={}, meetingId={}", guildId, meetingId);
+    }
+
+    private void handleMeetingList(MessageReceivedEvent event, long channelId) {
+        Long projectId = fetchProjectIdByChannel(channelId);
+        if (projectId == null) {
+            event.getChannel()
+                    .sendMessage("이 채널에 연결된 프로젝트가 없어요. `!project start {id}`로 프로젝트를 선택해주세요.")
+                    .queue();
+            return;
+        }
+        try {
+            HttpRequest.Builder req = HttpRequest.newBuilder()
+                    .uri(URI.create(internalBaseUrl + "/api/v1/meetings?projectId=" + projectId))
+                    .GET();
+            attachInternalApiKey(req);
+            HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
+            JsonNode data = objectMapper.readTree(response.body()).path("data");
+            if (!data.isArray() || data.isEmpty()) {
+                event.getChannel().sendMessage("📋 프로젝트에 등록된 회의가 없어요.").queue();
+                return;
+            }
+            StringBuilder sb = new StringBuilder("📋 **회의 목록** (projectId=" + projectId + ")\n");
+            for (JsonNode m : data) {
+                sb.append("`id=").append(m.path("id").asText()).append("` ");
+                sb.append(m.path("title").asText()).append(" | ");
+                sb.append(m.path("startedAt").asText("")).append(" ~ ");
+                sb.append(m.path("endedAt").asText("진행 중")).append("\n");
+            }
+            event.getChannel().sendMessage(sb.toString().trim()).queue();
+        } catch (Exception e) {
+            log.warn("[회의/목록예외] channelId={}", channelId, e);
+            event.getChannel().sendMessage("❌ 회의 목록 조회 중 오류가 발생했습니다.").queue();
+        }
+    }
+
+    private void handleMeetingDelete(MessageReceivedEvent event, String arg) {
+        long meetingId;
+        try {
+            meetingId = Long.parseLong(arg);
+        } catch (NumberFormatException e) {
+            event.getChannel().sendMessage("사용법: `!meeting delete {id}`").queue();
+            return;
+        }
+
+        long guildId = event.getGuild().getIdLong();
+        Long activeMeetingId = activeMeetingIdByGuild.get(guildId);
+        if (activeMeetingId != null && activeMeetingId == meetingId) {
+            event.getChannel()
+                    .sendMessage("진행 중인 회의는 삭제할 수 없어요. 먼저 `!meeting end`로 종료해주세요.")
+                    .queue();
+            return;
+        }
+
+        long channelId = event.getChannel().getIdLong();
+        pendingMeetingDeletions.put(channelId, new MeetingDeletionState(meetingId, System.currentTimeMillis()));
+        event.getChannel()
+                .sendMessage("⚠️ 회의 (id=" + meetingId + ")를 삭제하시겠어요? 이 작업은 되돌릴 수 없습니다. (yes / no)")
+                .queue();
+    }
+
+    private void handleMeetingDeletionStep(MessageReceivedEvent event, long channelId) {
+        MeetingDeletionState state = pendingMeetingDeletions.get(channelId);
+
+        if (System.currentTimeMillis() - state.createdAt() > PENDING_TTL_MS) {
+            pendingMeetingDeletions.remove(channelId);
+            event.getChannel()
+                    .sendMessage("⏰ 응답 시간이 초과됐습니다. 다시 `!meeting delete {id}`를 입력해주세요.")
+                    .queue();
+            return;
+        }
+
+        String input = event.getMessage().getContentRaw().trim().toLowerCase();
+        pendingMeetingDeletions.remove(channelId);
+
+        if ("yes".equals(input)) {
+            try {
+                HttpRequest.Builder req = HttpRequest.newBuilder()
+                        .uri(URI.create(internalBaseUrl + "/api/v1/meetings/" + state.meetingId()))
+                        .DELETE();
+                attachInternalApiKey(req);
+                HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() / 100 != 2) {
+                    event.getChannel().sendMessage("❌ 회의 삭제에 실패했습니다.").queue();
+                    return;
+                }
+                event.getChannel()
+                        .sendMessage("✅ 회의 (id=" + state.meetingId() + ")가 삭제됐습니다.")
+                        .queue();
+                log.info("[회의/삭제] meetingId={}", state.meetingId());
+            } catch (Exception e) {
+                log.warn("[회의/삭제예외] meetingId={}", state.meetingId(), e);
+                event.getChannel().sendMessage("❌ 회의 삭제 중 오류가 발생했습니다.").queue();
+            }
+        } else if ("no".equals(input)) {
+            event.getChannel().sendMessage("회의 삭제를 취소했습니다.").queue();
+        } else {
+            event.getChannel()
+                    .sendMessage("'yes' 또는 'no'로 답해주세요. 다시 `!meeting delete {id}`를 입력해주세요.")
+                    .queue();
+        }
     }
 
     private Long fetchProjectIdByChannel(long channelId) {

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -159,6 +159,9 @@ public class DiscordCommandListener extends ListenerAdapter {
             case "join" -> handleJoin(event);
             case "leave" -> handleLeave(event);
             case "stats" -> handleStats(event);
+            case "help" -> handleHelp(event);
+            case "project" -> new Thread(() -> handleProject(event, channelId)).start();
+            case "meeting" -> handleMeeting(event);
             case "project start" -> handleProjectStart(event, channelId);
             case "meeting start" -> {
                 Member member = event.getMember();
@@ -665,6 +668,64 @@ public class DiscordCommandListener extends ListenerAdapter {
             return value;
         }
         return value.substring(0, maxLength - 3) + "...";
+    }
+
+    private static final String PROJECT_COMMANDS = """
+            **프로젝트 명령어**
+            `!project`                현재 프로젝트 조회
+            `!project list`           프로젝트 목록 조회
+            `!project start`          새 프로젝트 생성
+            `!project start {id}`     기존 프로젝트 선택
+            `!project end`            현재 프로젝트 연결 해제
+            `!project edit`           프로젝트 정보 수정
+            `!project delete`         프로젝트 삭제""";
+
+    private static final String MEETING_COMMANDS = """
+            **회의 명령어**
+            `!meeting`                현재 회의 조회
+            `!meeting list`           현재 프로젝트 회의 목록 조회
+            `!meeting start`          회의 시작
+            `!meeting end`            회의 종료
+            `!meeting delete`         회의 기록 삭제""";
+
+    private void handleHelp(MessageReceivedEvent event) {
+        event.getChannel()
+                .sendMessage("📋 **Flodi 봇 명령어 안내**\n\n" + PROJECT_COMMANDS + "\n\n" + MEETING_COMMANDS)
+                .queue();
+    }
+
+    private void handleProject(MessageReceivedEvent event, long channelId) {
+        Long projectId = fetchProjectIdByChannel(channelId);
+        String header;
+        if (projectId == null) {
+            header = "⚠️ 연결된 프로젝트가 없어요. `!project start`로 생성하거나 `!project start {id}`로 선택하세요.";
+        } else {
+            try {
+                HttpRequest.Builder req = HttpRequest.newBuilder()
+                        .uri(URI.create(internalBaseUrl + "/api/v1/projects/" + projectId))
+                        .GET();
+                attachInternalApiKey(req);
+                HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
+                JsonNode data = objectMapper.readTree(response.body()).path("data");
+                String name = data.path("name").asText("-");
+                String description = data.path("description").asText("-");
+                String techStack = data.path("techStack").asText("-");
+                header = "📁 **현재 프로젝트**\n이름: " + name + "\n설명: " + description + "\n기술스택: " + techStack;
+            } catch (Exception e) {
+                log.warn("[프로젝트/조회예외] channelId={}", channelId, e);
+                header = "❌ 프로젝트 조회 중 오류가 발생했습니다.";
+            }
+        }
+        event.getChannel().sendMessage(header + "\n\n" + PROJECT_COMMANDS).queue();
+    }
+
+    private void handleMeeting(MessageReceivedEvent event) {
+        long guildId = event.getGuild().getIdLong();
+        Long meetingId = activeMeetingIdByGuild.get(guildId);
+        String header = meetingId != null
+                ? "🎙️ **현재 회의 진행 중** (meetingId=" + meetingId + ")"
+                : "현재 진행 중인 회의가 없어요. `!meeting start`로 시작하세요.";
+        event.getChannel().sendMessage(header + "\n\n" + MEETING_COMMANDS).queue();
     }
 
     private void handleProjectStart(MessageReceivedEvent event, long channelId) {

--- a/src/main/java/com/flodiback/domain/meeting/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/repository/MeetingRepository.java
@@ -17,6 +17,8 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     List<Meeting> findByStatus(MeetingStatus status);
 
+    List<Meeting> findByProjectId(Long projectId);
+
     @Query("select m.id from Meeting m where m.status = :status")
     List<Long> findIdsByStatus(@Param("status") MeetingStatus status);
 

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -1,5 +1,6 @@
 package com.flodiback.domain.meeting.meeting.service;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -63,6 +64,19 @@ public class MeetingService {
                 meetingRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회의입니다."));
 
         return toDetailResponse(meeting);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MeetingDetailResponse> getByProjectId(Long projectId) {
+        List<Meeting> meetings =
+                projectId != null ? meetingRepository.findByProjectId(projectId) : meetingRepository.findAll();
+        return meetings.stream().map(this::toDetailResponse).toList();
+    }
+
+    public void delete(Long id) {
+        Meeting meeting =
+                meetingRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회의입니다."));
+        meetingRepository.delete(meeting);
     }
 
     private MeetingDetailResponse toDetailResponse(Meeting meeting) {

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -68,9 +68,9 @@ public class MeetingService {
 
     @Transactional(readOnly = true)
     public List<MeetingDetailResponse> getByProjectId(Long projectId) {
-        List<Meeting> meetings =
-                projectId != null ? meetingRepository.findByProjectId(projectId) : meetingRepository.findAll();
-        return meetings.stream().map(this::toDetailResponse).toList();
+        return meetingRepository.findByProjectId(projectId).stream()
+                .map(this::toDetailResponse)
+                .toList();
     }
 
     public void delete(Long id) {

--- a/src/main/java/com/flodiback/domain/project/project/entity/Project.java
+++ b/src/main/java/com/flodiback/domain/project/project/entity/Project.java
@@ -62,6 +62,14 @@ public class Project {
         if (techStack != null) this.techStack = techStack;
     }
 
+    public void connectChannel(String channelId) {
+        this.channelId = channelId;
+    }
+
+    public void disconnectChannel() {
+        this.channelId = null;
+    }
+
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -78,6 +78,18 @@ public class ProjectService {
         return toResponse(project);
     }
 
+    public void connectChannel(Long id, String channelId) {
+        Project project =
+                projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        project.connectChannel(channelId);
+    }
+
+    public void disconnectChannel(Long id) {
+        Project project =
+                projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        project.disconnectChannel();
+    }
+
     public void delete(Long id) {
         Project project =
                 projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));

--- a/src/test/java/com/flodiback/api/meeting/MeetingControllerTest.java
+++ b/src/test/java/com/flodiback/api/meeting/MeetingControllerTest.java
@@ -1,0 +1,134 @@
+package com.flodiback.api.meeting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.global.embedding.OpenAiEmbeddingClient;
+
+@Testcontainers
+@SpringBootTest(
+        properties = {
+            "spring.flyway.enabled=false",
+            "spring.jpa.hibernate.ddl-auto=create-drop",
+            "openai.api-key=test-key"
+        })
+@AutoConfigureMockMvc
+class MeetingControllerTest {
+
+    private static final DockerImageName PGVECTOR_IMAGE =
+            DockerImageName.parse("pgvector/pgvector:pg16").asCompatibleSubstituteFor("postgres");
+
+    @Container
+    private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(PGVECTOR_IMAGE)
+            .withDatabaseName("flodi_test")
+            .withUsername("postgres")
+            .withPassword("postgres")
+            .withInitScript("init-pgvector.sql");
+
+    @DynamicPropertySource
+    static void registerDataSourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @MockitoBean
+    private OpenAiEmbeddingClient embeddingClient;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    private final List<Long> testMeetingIds = new ArrayList<>();
+    private final List<Long> testProjectIds = new ArrayList<>();
+
+    private Project project;
+
+    @BeforeEach
+    void setUp() {
+        testMeetingIds.clear();
+        testProjectIds.clear();
+        project = saveProject("플로디");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (!testMeetingIds.isEmpty()) {
+            meetingRepository.deleteAllByIdInBatch(testMeetingIds);
+            testMeetingIds.clear();
+        }
+        if (!testProjectIds.isEmpty()) {
+            projectRepository.deleteAllByIdInBatch(testProjectIds);
+            testProjectIds.clear();
+        }
+    }
+
+    @Test
+    void getMeetings_projectId로_회의_목록을_조회한다() throws Exception {
+        saveMeeting(project, "1차 기획 회의");
+        saveMeeting(project, "2차 개발 회의");
+
+        mockMvc.perform(get("/api/v1/meetings")
+                        .param("projectId", project.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].title").value("1차 기획 회의"))
+                .andExpect(jsonPath("$.data[1].title").value("2차 개발 회의"));
+    }
+
+    @Test
+    void deleteMeeting_회의를_삭제한다() throws Exception {
+        Meeting meeting = saveMeeting(project, "삭제할 회의");
+
+        mockMvc.perform(delete("/api/v1/meetings/{id}", meeting.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"));
+
+        assertThat(meetingRepository.findById(meeting.getId())).isEmpty();
+        testMeetingIds.remove(meeting.getId());
+    }
+
+    private Meeting saveMeeting(Project project, String title) {
+        Meeting saved = meetingRepository.save(
+                Meeting.builder().project(project).title(title).build());
+        testMeetingIds.add(saved.getId());
+        return saved;
+    }
+
+    private Project saveProject(String name) {
+        Project saved = projectRepository.save(Project.builder().name(name).build());
+        testProjectIds.add(saved.getId());
+        return saved;
+    }
+}

--- a/src/test/java/com/flodiback/api/project/ProjectControllerTest.java
+++ b/src/test/java/com/flodiback/api/project/ProjectControllerTest.java
@@ -1,0 +1,136 @@
+package com.flodiback.api.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.global.embedding.OpenAiEmbeddingClient;
+
+@Testcontainers
+@SpringBootTest(
+        properties = {
+            "spring.flyway.enabled=false",
+            "spring.jpa.hibernate.ddl-auto=create-drop",
+            "openai.api-key=test-key"
+        })
+@AutoConfigureMockMvc
+class ProjectControllerTest {
+
+    private static final DockerImageName PGVECTOR_IMAGE =
+            DockerImageName.parse("pgvector/pgvector:pg16").asCompatibleSubstituteFor("postgres");
+
+    @Container
+    private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(PGVECTOR_IMAGE)
+            .withDatabaseName("flodi_test")
+            .withUsername("postgres")
+            .withPassword("postgres")
+            .withInitScript("init-pgvector.sql");
+
+    @DynamicPropertySource
+    static void registerDataSourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @MockitoBean
+    private OpenAiEmbeddingClient embeddingClient;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    private final List<Long> testProjectIds = new ArrayList<>();
+
+    private Project project;
+
+    @BeforeEach
+    void setUp() {
+        testProjectIds.clear();
+        project = saveProject("플로디", null, null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (!testProjectIds.isEmpty()) {
+            projectRepository.deleteAllByIdInBatch(testProjectIds);
+            testProjectIds.clear();
+        }
+    }
+
+    @Test
+    void connectChannel_채널을_프로젝트에_연결한다() throws Exception {
+        mockMvc.perform(put("/api/v1/projects/{id}/channel/{channelId}", project.getId(), "channel-123"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"));
+
+        Project updated = projectRepository.findById(project.getId()).orElseThrow();
+        assertThat(updated.getChannelId()).isEqualTo("channel-123");
+    }
+
+    @Test
+    void disconnectChannel_채널_연결을_해제한다() throws Exception {
+        project.connectChannel("channel-123");
+        projectRepository.save(project);
+
+        mockMvc.perform(delete("/api/v1/projects/{id}/channel", project.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"));
+
+        Project updated = projectRepository.findById(project.getId()).orElseThrow();
+        assertThat(updated.getChannelId()).isNull();
+    }
+
+    @Test
+    void getByChannelId_채널에_연결된_프로젝트를_조회한다() throws Exception {
+        project.connectChannel("channel-123");
+        projectRepository.save(project);
+
+        mockMvc.perform(get("/api/v1/projects/channel/{channelId}", "channel-123"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data.name").value("플로디"));
+    }
+
+    @Test
+    void getByChannelId_연결된_프로젝트가_없으면_404를_반환한다() throws Exception {
+        mockMvc.perform(get("/api/v1/projects/channel/{channelId}", "없는채널"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("404-1"));
+    }
+
+    private Project saveProject(String name, String description, String techStack) {
+        Project saved = projectRepository.save(Project.builder()
+                .name(name)
+                .description(description)
+                .techStack(techStack)
+                .build());
+        testProjectIds.add(saved.getId());
+        return saved;
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
refs #63 
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #63

---

## 📝 작업 내용

디스코드 봇에 프로젝트/회의 관련 전체 명령어 세트를 구현했습니다. 채널-프로젝트 연결 관리 API와 회의 목록/삭제 API를 추가하고, 봇 명령어와 백엔드를 함께

연동했습니다.

---

## ✅ 주요 변경 사항

1) ****봇 명령어 전체 구현**** - `!help`, `!project`, `!project list/start {id|name}/end/edit/delete`, `!meeting`, `!meeting list`, `!meeting delete {id}`

2) ****채널-프로젝트 연결/해제 API 추가**** - `PUT /api/v1/projects/{id}/channel/{channelId}`, `DELETE /api/v1/projects/{id}/channel`

3) ****회의 목록/삭제 API 추가**** - `GET /api/v1/meetings?projectId={id}` (projectId 필수), `DELETE /api/v1/meetings/{id}`

4) ****대화형 플로우**** - project edit/delete, meeting delete 모두 TTL 1분 yes/no 확인 적용

5) ****JDA 스레드 안전성 개선**** - `!meeting start`에서 JDA 객체를 이벤트 스레드에서 선추출 후 `MeetingStartContext`로 전달

---

## 🧪 테스트 결과

```bash

docker compose -f docker-compose.bot.yml up --build

- !help / !project / !meeting 명령어 응답 확인

- !project start 대화형 플로우 및 채널 연결 확인

- !meeting start 음성 채널 입장 확인

- 로컬 빌드 통과

---

**👀 리뷰 포인트 (선택)**

- 봇의 HTTP 호출 명령어들은 JDA 이벤트 스레드 블로킹 방지를 위해 new Thread()로 분리했습니다. 추후 명령어가 늘어나면 ExecutorService로 전환을 고려할 수 있습니다.

- 대화 상태(pendingProjectEdits, pendingProjectDeletions, pendingMeetingDeletions 등)는 TTL 1분으로 메모리에서 관리하며, 봇 재시작 시 초기화됩니다.

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
