### PR TITLE
feat: Discord 봇 명령어 기반 최소 인증/인가 구현

### DIFF
--- a/src/main/java/com/flodiback/api/meeting/MeetingController.java
+++ b/src/main/java/com/flodiback/api/meeting/MeetingController.java
@@ -25,23 +25,27 @@ public class MeetingController {
     }
 
     @GetMapping
-    public RsData<List<MeetingDetailResponse>> getMeetings(@RequestParam Long projectId) {
-        return RsData.of("200-1", "회의 목록 조회 성공.", service.getByProjectId(projectId));
+    public RsData<List<MeetingDetailResponse>> getMeetings(
+            @RequestParam Long projectId, @RequestHeader(name = "X-Guild-Id", required = false) String guildId) {
+        return RsData.of("200-1", "회의 목록 조회 성공.", service.getByProjectId(projectId, guildId));
     }
 
     @PutMapping("/{id}/end")
-    public RsData<MeetingDetailResponse> endMeeting(@PathVariable Long id) {
-        return RsData.of("200-1", "회의가 종료되었습니다.", service.end(id));
+    public RsData<MeetingDetailResponse> endMeeting(
+            @PathVariable Long id, @RequestHeader(name = "X-Requester-Id", required = false) String requesterId) {
+        return RsData.of("200-1", "회의가 종료되었습니다.", service.end(id, requesterId));
     }
 
     @GetMapping("/{id}")
-    public RsData<MeetingDetailResponse> getMeeting(@PathVariable Long id) {
-        return RsData.of("200-1", "회의 조회 성공.", service.getById(id));
+    public RsData<MeetingDetailResponse> getMeeting(
+            @PathVariable Long id, @RequestHeader(name = "X-Guild-Id", required = false) String guildId) {
+        return RsData.of("200-1", "회의 조회 성공.", service.getById(id, guildId));
     }
 
     @DeleteMapping("/{id}")
-    public RsData<Void> deleteMeeting(@PathVariable Long id) {
-        service.delete(id);
+    public RsData<Void> deleteMeeting(
+            @PathVariable Long id, @RequestHeader(name = "X-Requester-Id", required = false) String requesterId) {
+        service.delete(id, requesterId);
         return RsData.of("200-1", "회의가 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/flodiback/api/project/ProjectController.java
+++ b/src/main/java/com/flodiback/api/project/ProjectController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,39 +39,45 @@ public class ProjectController {
     }
 
     @GetMapping("/{id}")
-    public RsData<ProjectResponse> getById(@PathVariable Long id) {
-        return RsData.of("200-1", "프로젝트 조회 성공.", projectService.getById(id));
+    public RsData<ProjectResponse> getById(
+            @PathVariable Long id, @RequestHeader(name = "X-Guild-Id", required = false) String guildId) {
+        return RsData.of("200-1", "프로젝트 조회 성공.", projectService.getById(id, guildId));
     }
 
     @GetMapping("/channel/{channelId}")
-    public RsData<ProjectResponse> getByChannelId(@PathVariable String channelId) {
-        ProjectResponse response = projectService.getByChannelId(channelId);
-        if (response == null) {
-            return RsData.of("404-1", "채널에 연결된 프로젝트가 없습니다.", null);
-        }
-        return RsData.of("200-1", "프로젝트 조회 성공.", response);
+    public RsData<ProjectResponse> getByChannelId(
+            @PathVariable String channelId, @RequestHeader(name = "X-Guild-Id", required = false) String guildId) {
+        return RsData.of("200-1", "프로젝트 조회 성공.", projectService.getByChannelId(channelId, guildId));
     }
 
     @PutMapping("/{id}")
-    public RsData<ProjectResponse> update(@PathVariable Long id, @RequestBody UpdateProjectRequest req) {
-        return RsData.of("200-1", "프로젝트가 수정되었습니다.", projectService.update(id, req));
+    public RsData<ProjectResponse> update(
+            @PathVariable Long id,
+            @RequestBody UpdateProjectRequest req,
+            @RequestHeader(name = "X-Requester-Id", required = false) String requesterId) {
+        return RsData.of("200-1", "프로젝트가 수정되었습니다.", projectService.update(id, req, requesterId));
     }
 
     @PutMapping("/{id}/channel/{channelId}")
-    public RsData<Void> connectChannel(@PathVariable Long id, @PathVariable String channelId) {
-        projectService.connectChannel(id, channelId);
+    public RsData<Void> connectChannel(
+            @PathVariable Long id,
+            @PathVariable String channelId,
+            @RequestHeader(name = "X-Requester-Id", required = false) String requesterId) {
+        projectService.connectChannel(id, channelId, requesterId);
         return RsData.of("200-1", "채널이 연결되었습니다.");
     }
 
     @DeleteMapping("/{id}/channel")
-    public RsData<Void> disconnectChannel(@PathVariable Long id) {
-        projectService.disconnectChannel(id);
+    public RsData<Void> disconnectChannel(
+            @PathVariable Long id, @RequestHeader(name = "X-Requester-Id", required = false) String requesterId) {
+        projectService.disconnectChannel(id, requesterId);
         return RsData.of("200-1", "채널 연결이 해제되었습니다.");
     }
 
     @DeleteMapping("/{id}")
-    public RsData<Void> delete(@PathVariable Long id) {
-        projectService.delete(id);
+    public RsData<Void> delete(
+            @PathVariable Long id, @RequestHeader(name = "X-Requester-Id", required = false) String requesterId) {
+        projectService.delete(id, requesterId);
         return RsData.of("200-1", "프로젝트가 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -284,7 +284,8 @@ public class DiscordCommandListener extends ListenerAdapter {
             }
             case BUTTON_MEETING_END -> {
                 event.deferReply(true).queue();
-                MeetingEndResult result = endActiveMeeting(event.getGuild(), event.getUser().getId());
+                MeetingEndResult result =
+                        endActiveMeeting(event.getGuild(), event.getUser().getId());
                 event.getHook()
                         .sendMessage(buildMeetingEndMessage(result))
                         .setEphemeral(true)
@@ -1159,7 +1160,8 @@ public class DiscordCommandListener extends ListenerAdapter {
     }
 
     private void handleMeetingEnd(MessageReceivedEvent event) {
-        MeetingEndResult result = endActiveMeeting(event.getGuild(), event.getAuthor().getId());
+        MeetingEndResult result =
+                endActiveMeeting(event.getGuild(), event.getAuthor().getId());
         sendTemporaryMessage(event.getChannel(), buildMeetingEndMessage(result));
     }
 
@@ -1489,7 +1491,8 @@ public class DiscordCommandListener extends ListenerAdapter {
     }
 
     private void handleLeave(MessageReceivedEvent event) {
-        MeetingEndResult result = endActiveMeeting(event.getGuild(), event.getAuthor().getId());
+        MeetingEndResult result =
+                endActiveMeeting(event.getGuild(), event.getAuthor().getId());
         sendTemporaryMessage(event.getChannel(), buildMeetingEndMessage(result));
     }
 

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -104,16 +106,18 @@ public class DiscordCommandListener extends ListenerAdapter {
     private record MeetingEndResult(Long meetingId, boolean hadVoiceState) {}
 
     private record ProjectEditState(
-            ProjectCreationStep step, String name, String description, long projectId, long createdAt) {}
+            ProjectCreationStep step, String name, String description, long projectId, String userId, long createdAt) {}
 
-    private record ProjectDeletionState(long projectId, long createdAt) {}
+    private record ProjectDeletionState(long projectId, String userId, long createdAt) {}
 
-    private record MeetingDeletionState(long meetingId, long createdAt) {}
+    private record MeetingDeletionState(long meetingId, String userId, long createdAt) {}
 
     // 명령어 접두사. 기본값은 !.
     private final String prefix;
     // 실제 STT 엔진 구현체. 현재 기본값은 OpenAI.
     private final SttProvider sttProvider;
+    // HTTP 호출이 포함된 명령어를 JDA 이벤트 스레드 밖에서 처리하기 위한 스레드 풀
+    private final ExecutorService commandExecutor = Executors.newFixedThreadPool(4);
     private final HttpClient httpClient = HttpClient.newHttpClient();
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final String internalBaseUrl;
@@ -176,19 +180,19 @@ public class DiscordCommandListener extends ListenerAdapter {
 
         // 프로젝트 수정 대화 중인 채널이면 먼저 처리
         if (pendingProjectEdits.containsKey(channelId)) {
-            new Thread(() -> handleProjectEditStep(event, channelId)).start();
+            commandExecutor.submit(() -> handleProjectEditStep(event, channelId));
             return;
         }
 
         // 프로젝트 삭제 확인 대기 중인 채널이면 먼저 처리
         if (pendingProjectDeletions.containsKey(channelId)) {
-            new Thread(() -> handleProjectDeletionStep(event, channelId)).start();
+            commandExecutor.submit(() -> handleProjectDeletionStep(event, channelId));
             return;
         }
 
         // 회의 삭제 확인 대기 중인 채널이면 먼저 처리
         if (pendingMeetingDeletions.containsKey(channelId)) {
-            new Thread(() -> handleMeetingDeletionStep(event, channelId)).start();
+            commandExecutor.submit(() -> handleMeetingDeletionStep(event, channelId));
             return;
         }
 
@@ -204,7 +208,14 @@ public class DiscordCommandListener extends ListenerAdapter {
             case "join" -> handleJoin(event);
             case "leave" -> handleLeave(event);
             case "stats" -> handleStats(event);
+            case "help" -> handleHelp(event);
+            case "project" -> commandExecutor.submit(() -> handleProject(event, channelId));
             case "project start" -> handleProjectStart(event, channelId);
+            case "project list" -> commandExecutor.submit(() -> handleProjectList(event));
+            case "project end" -> commandExecutor.submit(() -> handleProjectEnd(event, channelId));
+            case "project edit" -> commandExecutor.submit(() -> handleProjectEdit(event, channelId));
+            case "project delete" -> handleProjectDelete(event, channelId);
+            case "meeting" -> handleMeeting(event);
             case "meeting start" -> {
                 Member member = event.getMember();
                 if (member == null
@@ -221,17 +232,17 @@ public class DiscordCommandListener extends ListenerAdapter {
                         event.getGuild().getAudioManager(),
                         event.getGuild(),
                         channelId);
-                new Thread(() -> handleMeetingStart(ctx)).start();
+                commandExecutor.submit(() -> handleMeetingStart(ctx));
             }
-            case "meeting list" -> new Thread(() -> handleMeetingList(event, channelId)).start();
+            case "meeting list" -> commandExecutor.submit(() -> handleMeetingList(event, channelId));
             case "meeting end" -> handleMeetingEnd(event);
             default -> {
                 if (command.startsWith("project start ")) {
                     String arg = command.substring("project start ".length()).trim();
-                    new Thread(() -> handleProjectStartWithArg(event, channelId, arg)).start();
+                    commandExecutor.submit(() -> handleProjectStartWithArg(event, channelId, arg));
                 } else if (command.startsWith("meeting delete ")) {
                     String arg = command.substring("meeting delete ".length()).trim();
-                    new Thread(() -> handleMeetingDelete(event, arg)).start();
+                    commandExecutor.submit(() -> handleMeetingDelete(event, arg));
                 }
                 // 그 외 알 수 없는 명령은 조용히 무시
             }
@@ -273,7 +284,7 @@ public class DiscordCommandListener extends ListenerAdapter {
             }
             case BUTTON_MEETING_END -> {
                 event.deferReply(true).queue();
-                MeetingEndResult result = endActiveMeeting(event.getGuild());
+                MeetingEndResult result = endActiveMeeting(event.getGuild(), event.getUser().getId());
                 event.getHook()
                         .sendMessage(buildMeetingEndMessage(result))
                         .setEphemeral(true)
@@ -387,7 +398,7 @@ public class DiscordCommandListener extends ListenerAdapter {
 
         Long projectId = fetchProjectIdByChannel(channelId);
         if (projectId != null) {
-            new Thread(() -> startMeeting(ctx, projectId)).start();
+            commandExecutor.submit(() -> startMeeting(ctx, projectId));
             event.getHook().sendMessage("회의 시작 요청을 처리했어요.").setEphemeral(true).queue();
             return;
         }
@@ -419,7 +430,7 @@ public class DiscordCommandListener extends ListenerAdapter {
             return;
         }
 
-        new Thread(() -> startMeeting(state.ctx(), null)).start();
+        commandExecutor.submit(() -> startMeeting(state.ctx(), null));
         event.getHook().sendMessage("프로젝트 없이 회의를 시작할게요.").setEphemeral(true).queue();
     }
 
@@ -861,6 +872,7 @@ public class DiscordCommandListener extends ListenerAdapter {
                     .uri(URI.create(internalBaseUrl + "/api/v1/projects/" + projectId + "/channel/" + channelId))
                     .PUT(HttpRequest.BodyPublishers.noBody());
             attachInternalApiKey(connectReq);
+            attachRequesterHeader(connectReq, event.getAuthor().getId());
             HttpResponse<String> connectResp =
                     httpClient.send(connectReq.build(), HttpResponse.BodyHandlers.ofString());
             if (connectResp.statusCode() / 100 != 2) {
@@ -890,6 +902,7 @@ public class DiscordCommandListener extends ListenerAdapter {
                     .uri(URI.create(internalBaseUrl + "/api/v1/projects/" + projectId + "/channel"))
                     .DELETE();
             attachInternalApiKey(req);
+            attachRequesterHeader(req, event.getAuthor().getId());
             HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() / 100 != 2) {
                 event.getChannel().sendMessage("❌ 프로젝트 연결 해제에 실패했습니다.").queue();
@@ -914,7 +927,12 @@ public class DiscordCommandListener extends ListenerAdapter {
         pendingProjectEdits.put(
                 channelId,
                 new ProjectEditState(
-                        ProjectCreationStep.WAITING_NAME, null, null, projectId, System.currentTimeMillis()));
+                        ProjectCreationStep.WAITING_NAME,
+                        null,
+                        null,
+                        projectId,
+                        event.getAuthor().getId(),
+                        System.currentTimeMillis()));
         event.getChannel().sendMessage("새 프로젝트 이름을 입력해주세요. (건너뛰려면 '.')").queue();
     }
 
@@ -924,7 +942,8 @@ public class DiscordCommandListener extends ListenerAdapter {
             event.getChannel().sendMessage("이 채널에 연결된 프로젝트가 없어요.").queue();
             return;
         }
-        pendingProjectDeletions.put(channelId, new ProjectDeletionState(projectId, System.currentTimeMillis()));
+        pendingProjectDeletions.put(
+                channelId, new ProjectDeletionState(projectId, event.getAuthor().getId(), System.currentTimeMillis()));
         event.getChannel()
                 .sendMessage("⚠️ 정말로 프로젝트를 삭제하시겠어요? 이 작업은 되돌릴 수 없습니다. (yes / no)")
                 .queue();
@@ -953,6 +972,7 @@ public class DiscordCommandListener extends ListenerAdapter {
                                 value,
                                 null,
                                 state.projectId(),
+                                state.userId(),
                                 state.createdAt()));
                 event.getChannel().sendMessage("설명을 입력해주세요. (건너뛰려면 '.')").queue();
             }
@@ -964,6 +984,7 @@ public class DiscordCommandListener extends ListenerAdapter {
                                 state.name(),
                                 value,
                                 state.projectId(),
+                                state.userId(),
                                 state.createdAt()));
                 event.getChannel().sendMessage("기술 스택을 입력해주세요. (건너뛰려면 '.')").queue();
             }
@@ -980,6 +1001,7 @@ public class DiscordCommandListener extends ListenerAdapter {
                             .header("Content-Type", "application/json")
                             .PUT(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(body)));
                     attachInternalApiKey(req);
+                    attachRequesterHeader(req, state.userId());
                     HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
                     if (response.statusCode() / 100 != 2) {
                         event.getChannel().sendMessage("❌ 프로젝트 수정에 실패했습니다.").queue();
@@ -1014,6 +1036,7 @@ public class DiscordCommandListener extends ListenerAdapter {
                         .uri(URI.create(internalBaseUrl + "/api/v1/projects/" + state.projectId()))
                         .DELETE();
                 attachInternalApiKey(req);
+                attachRequesterHeader(req, state.userId());
                 HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
                 if (response.statusCode() / 100 != 2) {
                     event.getChannel().sendMessage("❌ 프로젝트 삭제에 실패했습니다.").queue();
@@ -1125,7 +1148,7 @@ public class DiscordCommandListener extends ListenerAdapter {
 
         if ("yes".equals(input)) {
             MeetingStartContext ctx = state.ctx();
-            new Thread(() -> startMeeting(ctx, null)).start();
+            commandExecutor.submit(() -> startMeeting(ctx, null));
         } else if ("no".equals(input)) {
             event.getChannel().sendMessage("회의 시작을 취소했습니다.").queue();
         } else {
@@ -1136,11 +1159,11 @@ public class DiscordCommandListener extends ListenerAdapter {
     }
 
     private void handleMeetingEnd(MessageReceivedEvent event) {
-        MeetingEndResult result = endActiveMeeting(event.getGuild());
+        MeetingEndResult result = endActiveMeeting(event.getGuild(), event.getAuthor().getId());
         sendTemporaryMessage(event.getChannel(), buildMeetingEndMessage(result));
     }
 
-    private MeetingEndResult endActiveMeeting(Guild guild) {
+    private MeetingEndResult endActiveMeeting(Guild guild, String requesterId) {
         long guildId = guild.getIdLong();
         AudioManager audioManager = guild.getAudioManager();
         PerUserAudioReceiveHandler handler = receiveHandlers.remove(guildId);
@@ -1156,7 +1179,7 @@ public class DiscordCommandListener extends ListenerAdapter {
         audioManager.setConnectionListener(null);
 
         if (meetingId != null) {
-            endMeeting(guildId, meetingId);
+            endMeeting(guildId, meetingId, requesterId);
         }
         log.info("[미팅/종료명령] guildId={}, meetingId={}, hadVoiceState={}", guildId, meetingId, hadVoiceState);
         return new MeetingEndResult(meetingId, hadVoiceState);
@@ -1214,7 +1237,8 @@ public class DiscordCommandListener extends ListenerAdapter {
         }
 
         long channelId = event.getChannel().getIdLong();
-        pendingMeetingDeletions.put(channelId, new MeetingDeletionState(meetingId, System.currentTimeMillis()));
+        pendingMeetingDeletions.put(
+                channelId, new MeetingDeletionState(meetingId, event.getAuthor().getId(), System.currentTimeMillis()));
         event.getChannel()
                 .sendMessage("⚠️ 회의 (id=" + meetingId + ")를 삭제하시겠어요? 이 작업은 되돌릴 수 없습니다. (yes / no)")
                 .queue();
@@ -1240,6 +1264,7 @@ public class DiscordCommandListener extends ListenerAdapter {
                         .uri(URI.create(internalBaseUrl + "/api/v1/meetings/" + state.meetingId()))
                         .DELETE();
                 attachInternalApiKey(req);
+                attachRequesterHeader(req, state.userId());
                 HttpResponse<String> response = httpClient.send(req.build(), HttpResponse.BodyHandlers.ofString());
                 if (response.statusCode() / 100 != 2) {
                     event.getChannel().sendMessage("❌ 회의 삭제에 실패했습니다.").queue();
@@ -1355,6 +1380,7 @@ public class DiscordCommandListener extends ListenerAdapter {
             else body.putNull("techStack");
             body.putNull("serverId");
             body.put("channelId", String.valueOf(channelId));
+            body.put("ownerDiscordId", event.getAuthor().getId());
 
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(internalBaseUrl + "/api/v1/projects"))
@@ -1463,7 +1489,7 @@ public class DiscordCommandListener extends ListenerAdapter {
     }
 
     private void handleLeave(MessageReceivedEvent event) {
-        MeetingEndResult result = endActiveMeeting(event.getGuild());
+        MeetingEndResult result = endActiveMeeting(event.getGuild(), event.getAuthor().getId());
         sendTemporaryMessage(event.getChannel(), buildMeetingEndMessage(result));
     }
 
@@ -1526,12 +1552,13 @@ public class DiscordCommandListener extends ListenerAdapter {
         }
     }
 
-    private void endMeeting(long guildId, long meetingId) {
+    private void endMeeting(long guildId, long meetingId, String requesterId) {
         try {
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(internalBaseUrl + "/api/v1/meetings/" + meetingId + "/end"))
                     .PUT(HttpRequest.BodyPublishers.noBody());
             attachInternalApiKey(requestBuilder);
+            attachRequesterHeader(requestBuilder, requesterId);
 
             HttpResponse<String> response =
                     httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
@@ -1555,6 +1582,16 @@ public class DiscordCommandListener extends ListenerAdapter {
         if (internalApiKey != null && !internalApiKey.isBlank()) {
             requestBuilder.header("X-Internal-Api-Key", internalApiKey);
         }
+    }
+
+    private void attachRequesterHeader(HttpRequest.Builder builder, String userId) {
+        if (userId != null && !userId.isBlank()) {
+            builder.header("X-Requester-Id", userId);
+        }
+    }
+
+    private void attachGuildHeader(HttpRequest.Builder builder, long guildId) {
+        builder.header("X-Guild-Id", String.valueOf(guildId));
     }
 
     private String normalizeBaseUrl(String baseUrl) {

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -210,12 +210,12 @@ public class DiscordCommandListener extends ListenerAdapter {
             case "stats" -> handleStats(event);
             case "help" -> handleHelp(event);
             case "project" -> commandExecutor.submit(() -> handleProject(event, channelId));
+            case "meeting" -> handleMeeting(event);
             case "project start" -> handleProjectStart(event, channelId);
             case "project list" -> commandExecutor.submit(() -> handleProjectList(event));
             case "project end" -> commandExecutor.submit(() -> handleProjectEnd(event, channelId));
             case "project edit" -> commandExecutor.submit(() -> handleProjectEdit(event, channelId));
-            case "project delete" -> handleProjectDelete(event, channelId);
-            case "meeting" -> handleMeeting(event);
+            case "project delete" -> commandExecutor.submit(() -> handleProjectDelete(event, channelId));
             case "meeting start" -> {
                 Member member = event.getMember();
                 if (member == null

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -15,6 +15,7 @@ import com.flodiback.domain.meeting.meeting.event.MeetingEndedEvent;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -47,9 +48,10 @@ public class MeetingService {
                 project != null);
     }
 
-    public MeetingDetailResponse end(Long id) {
+    public MeetingDetailResponse end(Long id, String requesterId) {
         Meeting meeting =
                 meetingRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회의입니다."));
+        checkWritePermission(meeting, requesterId);
 
         meeting.end();
         meetingRepository.save(meeting);
@@ -59,24 +61,47 @@ public class MeetingService {
     }
 
     @Transactional(readOnly = true)
-    public MeetingDetailResponse getById(Long id) {
+    public MeetingDetailResponse getById(Long id, String guildId) {
         Meeting meeting =
                 meetingRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회의입니다."));
-
+        checkReadPermission(meeting, guildId);
         return toDetailResponse(meeting);
     }
 
     @Transactional(readOnly = true)
-    public List<MeetingDetailResponse> getByProjectId(Long projectId) {
+    public List<MeetingDetailResponse> getByProjectId(Long projectId, String guildId) {
+        Project project =
+                projectRepository.findById(projectId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        checkReadPermission(project, guildId);
         return meetingRepository.findByProjectId(projectId).stream()
                 .map(this::toDetailResponse)
                 .toList();
     }
 
-    public void delete(Long id) {
+    public void delete(Long id, String requesterId) {
         Meeting meeting =
                 meetingRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회의입니다."));
+        checkWritePermission(meeting, requesterId);
         meetingRepository.delete(meeting);
+    }
+
+    private void checkReadPermission(Meeting meeting, String guildId) {
+        checkReadPermission(meeting.getProject(), guildId);
+    }
+
+    private void checkReadPermission(Project project, String guildId) {
+        if (guildId == null || project == null || project.getServer() == null) return;
+        if (!guildId.equals(project.getServer().getGuildId())) {
+            throw new ServiceException("403-1", "권한이 없습니다.");
+        }
+    }
+
+    private void checkWritePermission(Meeting meeting, String requesterId) {
+        Project project = meeting.getProject();
+        if (requesterId == null || project == null || project.getOwnerDiscordId() == null) return;
+        if (!requesterId.equals(project.getOwnerDiscordId())) {
+            throw new ServiceException("403-1", "권한이 없습니다.");
+        }
     }
 
     private MeetingDetailResponse toDetailResponse(Meeting meeting) {

--- a/src/main/java/com/flodiback/domain/project/project/dto/CreateProjectRequest.java
+++ b/src/main/java/com/flodiback/domain/project/project/dto/CreateProjectRequest.java
@@ -3,4 +3,9 @@ package com.flodiback.domain.project.project.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record CreateProjectRequest(
-        @NotBlank String name, String description, String techStack, Long serverId, String channelId) {}
+        @NotBlank String name,
+        String description,
+        String techStack,
+        Long serverId,
+        String channelId,
+        String ownerDiscordId) {}

--- a/src/main/java/com/flodiback/domain/project/project/entity/Project.java
+++ b/src/main/java/com/flodiback/domain/project/project/entity/Project.java
@@ -36,6 +36,9 @@ public class Project {
     @Column(name = "channel_id", length = 50)
     private String channelId;
 
+    @Column(name = "owner_discord_id", length = 50)
+    private String ownerDiscordId;
+
     @Column(name = "name", nullable = false, length = 100)
     private String name;
 
@@ -78,12 +81,14 @@ public class Project {
     public Project(
             DiscordServer server,
             String channelId,
+            String ownerDiscordId,
             String name,
             String description,
             String techStack,
             String metadata) {
         this.server = server;
         this.channelId = channelId;
+        this.ownerDiscordId = ownerDiscordId;
         this.name = name;
         this.description = description;
         this.techStack = techStack;

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -42,6 +42,7 @@ public class ProjectService {
         Project project = Project.builder()
                 .server(server)
                 .channelId(req.channelId())
+                .ownerDiscordId(req.ownerDiscordId())
                 .name(req.name())
                 .description(req.description())
                 .techStack(req.techStack())
@@ -57,43 +58,63 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public ProjectResponse getByChannelId(String channelId) {
-        return projectRepository
+    public ProjectResponse getByChannelId(String channelId, String guildId) {
+        Project project = projectRepository
                 .findByChannelId(channelId)
-                .map(this::toResponse)
-                .orElse(null);
-    }
-
-    @Transactional(readOnly = true)
-    public ProjectResponse getById(Long id) {
-        Project project =
-                projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        checkReadPermission(project, guildId);
         return toResponse(project);
     }
 
-    public ProjectResponse update(Long id, UpdateProjectRequest req) {
+    @Transactional(readOnly = true)
+    public ProjectResponse getById(Long id, String guildId) {
         Project project =
                 projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        checkReadPermission(project, guildId);
+        return toResponse(project);
+    }
+
+    public ProjectResponse update(Long id, UpdateProjectRequest req, String requesterId) {
+        Project project =
+                projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        checkWritePermission(project, requesterId);
         project.update(req.name(), req.description(), req.techStack());
         return toResponse(project);
     }
 
-    public void connectChannel(Long id, String channelId) {
+    public void connectChannel(Long id, String channelId, String requesterId) {
         Project project =
                 projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        checkWritePermission(project, requesterId);
         project.connectChannel(channelId);
     }
 
-    public void disconnectChannel(Long id) {
+    public void disconnectChannel(Long id, String requesterId) {
         Project project =
                 projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        checkWritePermission(project, requesterId);
         project.disconnectChannel();
     }
 
-    public void delete(Long id) {
+    public void delete(Long id, String requesterId) {
         Project project =
                 projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+        checkWritePermission(project, requesterId);
         project.softDelete();
+    }
+
+    private void checkReadPermission(Project project, String guildId) {
+        if (guildId == null || project.getServer() == null) return;
+        if (!guildId.equals(project.getServer().getGuildId())) {
+            throw new ServiceException("403-1", "권한이 없습니다.");
+        }
+    }
+
+    private void checkWritePermission(Project project, String requesterId) {
+        if (requesterId == null || project.getOwnerDiscordId() == null) return;
+        if (!requesterId.equals(project.getOwnerDiscordId())) {
+            throw new ServiceException("403-1", "권한이 없습니다.");
+        }
     }
 
     ProjectResponse toResponse(Project project) {

--- a/src/main/java/com/flodiback/global/config/InternalApiKeyFilterConfig.java
+++ b/src/main/java/com/flodiback/global/config/InternalApiKeyFilterConfig.java
@@ -10,11 +10,14 @@ import com.flodiback.global.filter.InternalApiKeyFilter;
 @Configuration
 public class InternalApiKeyFilterConfig {
 
-    @Value("${internal.api-key:}")
+    @Value("${internal.api-key}")
     private String apiKey;
 
     @Bean
     public FilterRegistrationBean<InternalApiKeyFilter> internalApiKeyFilter() {
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException("INTERNAL_API_KEY가 설정되지 않았습니다. 환경변수를 확인해주세요.");
+        }
         FilterRegistrationBean<InternalApiKeyFilter> bean = new FilterRegistrationBean<>();
         bean.setFilter(new InternalApiKeyFilter(apiKey));
         bean.addUrlPatterns("/api/*");

--- a/src/main/java/com/flodiback/global/config/InternalApiKeyFilterConfig.java
+++ b/src/main/java/com/flodiback/global/config/InternalApiKeyFilterConfig.java
@@ -1,0 +1,24 @@
+package com.flodiback.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.flodiback.global.filter.InternalApiKeyFilter;
+
+@Configuration
+public class InternalApiKeyFilterConfig {
+
+    @Value("${internal.api-key:}")
+    private String apiKey;
+
+    @Bean
+    public FilterRegistrationBean<InternalApiKeyFilter> internalApiKeyFilter() {
+        FilterRegistrationBean<InternalApiKeyFilter> bean = new FilterRegistrationBean<>();
+        bean.setFilter(new InternalApiKeyFilter(apiKey));
+        bean.addUrlPatterns("/api/*");
+        bean.setOrder(1);
+        return bean;
+    }
+}

--- a/src/main/java/com/flodiback/global/filter/InternalApiKeyFilter.java
+++ b/src/main/java/com/flodiback/global/filter/InternalApiKeyFilter.java
@@ -1,0 +1,50 @@
+package com.flodiback.global.filter;
+
+import java.io.IOException;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flodiback.global.rsData.RsData;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * 내부 API 키 검증 필터.
+ *
+ * <p>설정된 키가 없으면 검증을 스킵한다 (로컬 개발 편의 및 웹 확장 대비).
+ * 키가 설정된 경우 X-Internal-Api-Key 헤더가 일치하지 않으면 403을 반환한다.
+ */
+public class InternalApiKeyFilter extends OncePerRequestFilter {
+
+    private static final String HEADER_NAME = "X-Internal-Api-Key";
+
+    private final String apiKey;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public InternalApiKeyFilter(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        if (apiKey == null || apiKey.isBlank()) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String provided = request.getHeader(HEADER_NAME);
+        if (!apiKey.equals(provided)) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write(objectMapper.writeValueAsString(RsData.of("403-1", "접근이 거부되었습니다.")));
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/flodiback/global/filter/InternalApiKeyFilter.java
+++ b/src/main/java/com/flodiback/global/filter/InternalApiKeyFilter.java
@@ -15,8 +15,8 @@ import jakarta.servlet.http.HttpServletResponse;
 /**
  * 내부 API 키 검증 필터.
  *
- * <p>설정된 키가 없으면 검증을 스킵한다 (로컬 개발 편의 및 웹 확장 대비).
- * 키가 설정된 경우 X-Internal-Api-Key 헤더가 일치하지 않으면 403을 반환한다.
+ * <p>X-Internal-Api-Key 헤더가 설정된 키와 일치하지 않으면 403을 반환한다.
+ * 키는 앱 기동 시 반드시 설정되어야 한다 (미설정 시 기동 실패).
  */
 public class InternalApiKeyFilter extends OncePerRequestFilter {
 
@@ -32,11 +32,6 @@ public class InternalApiKeyFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
-        if (apiKey == null || apiKey.isBlank()) {
-            chain.doFilter(request, response);
-            return;
-        }
-
         String provided = request.getHeader(HEADER_NAME);
         if (!apiKey.equals(provided)) {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,9 @@ spring:
     baseline-version: 1
     locations: classpath:db/migration
 
+internal:
+  api-key: ${INTERNAL_API_KEY:}
+
 openai:
   api-key: ${OPENAI_API_KEY}
   embedding:

--- a/src/main/resources/db/migration/V8__project_owner_discord_id.sql
+++ b/src/main/resources/db/migration/V8__project_owner_discord_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD COLUMN owner_discord_id VARCHAR(50);

--- a/src/test/java/com/flodiback/api/decision/DecisionControllerTest.java
+++ b/src/test/java/com/flodiback/api/decision/DecisionControllerTest.java
@@ -38,7 +38,8 @@ import com.flodiback.global.embedding.OpenAiEmbeddingClient;
         properties = {
             "spring.flyway.enabled=false",
             "spring.jpa.hibernate.ddl-auto=create-drop",
-            "openai.api-key=test-key"
+            "openai.api-key=test-key",
+            "internal.api-key=test-internal-key"
         })
 @AutoConfigureMockMvc
 class DecisionControllerTest {

--- a/src/test/java/com/flodiback/api/decision/DecisionControllerTest.java
+++ b/src/test/java/com/flodiback/api/decision/DecisionControllerTest.java
@@ -114,7 +114,8 @@ class DecisionControllerTest {
         saveDecision(project, "배포는 AWS로 한다.");
         saveDecision(otherProject, "다른 프로젝트 결정사항");
 
-        mockMvc.perform(get("/api/v1/projects/{projectId}/decisions", project.getId()))
+        mockMvc.perform(get("/api/v1/projects/{projectId}/decisions", project.getId())
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -132,7 +133,8 @@ class DecisionControllerTest {
 
         mockMvc.perform(post("/api/v1/projects/{projectId}/decisions", project.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .content(requestBody)
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.resultCode").value("201-1"))
                 .andExpect(jsonPath("$.data.projectId").value(project.getId()))
@@ -156,7 +158,8 @@ class DecisionControllerTest {
 
         mockMvc.perform(put("/api/v1/projects/{projectId}/decisions/{decisionId}", project.getId(), decision.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .content(requestBody)
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
                 .andExpect(jsonPath("$.data.content").value("인증 방식은 JWT로 한다."));
@@ -169,8 +172,8 @@ class DecisionControllerTest {
     void deleteDecision_deletesOnlyProjectDecision() throws Exception {
         Decision decision = saveDecision(project, "삭제할 결정사항");
 
-        mockMvc.perform(delete(
-                        "/api/v1/projects/{projectId}/decisions/{decisionId}", project.getId(), decision.getId()))
+        mockMvc.perform(delete("/api/v1/projects/{projectId}/decisions/{decisionId}", project.getId(), decision.getId())
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"));
 
@@ -187,7 +190,8 @@ class DecisionControllerTest {
 
         mockMvc.perform(post("/api/v1/projects/{projectId}/decisions", 999999L)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .content(requestBody)
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.resultCode").value("404-1"));
     }
@@ -204,7 +208,8 @@ class DecisionControllerTest {
 
         mockMvc.perform(put("/api/v1/projects/{projectId}/decisions/{decisionId}", project.getId(), decision.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .content(requestBody)
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.resultCode").value("404-1"));
     }
@@ -213,8 +218,8 @@ class DecisionControllerTest {
     void deleteDecision_returnsNotFound_whenDecisionBelongsToAnotherProject() throws Exception {
         Decision decision = saveDecision(otherProject, "다른 프로젝트 결정사항");
 
-        mockMvc.perform(delete(
-                        "/api/v1/projects/{projectId}/decisions/{decisionId}", project.getId(), decision.getId()))
+        mockMvc.perform(delete("/api/v1/projects/{projectId}/decisions/{decisionId}", project.getId(), decision.getId())
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.resultCode").value("404-1"));
     }
@@ -229,7 +234,8 @@ class DecisionControllerTest {
 
         mockMvc.perform(post("/api/v1/projects/{projectId}/decisions", project.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .content(requestBody)
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.resultCode").value("400-1"));
     }

--- a/src/test/java/com/flodiback/api/meeting/MeetingControllerTest.java
+++ b/src/test/java/com/flodiback/api/meeting/MeetingControllerTest.java
@@ -35,7 +35,8 @@ import com.flodiback.global.embedding.OpenAiEmbeddingClient;
         properties = {
             "spring.flyway.enabled=false",
             "spring.jpa.hibernate.ddl-auto=create-drop",
-            "openai.api-key=test-key"
+            "openai.api-key=test-key",
+            "internal.api-key=test-internal-key"
         })
 @AutoConfigureMockMvc
 class MeetingControllerTest {

--- a/src/test/java/com/flodiback/api/meeting/MeetingControllerTest.java
+++ b/src/test/java/com/flodiback/api/meeting/MeetingControllerTest.java
@@ -100,7 +100,8 @@ class MeetingControllerTest {
         saveMeeting(project, "2차 개발 회의");
 
         mockMvc.perform(get("/api/v1/meetings")
-                        .param("projectId", project.getId().toString()))
+                        .param("projectId", project.getId().toString())
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -112,7 +113,8 @@ class MeetingControllerTest {
     void deleteMeeting_회의를_삭제한다() throws Exception {
         Meeting meeting = saveMeeting(project, "삭제할 회의");
 
-        mockMvc.perform(delete("/api/v1/meetings/{id}", meeting.getId()))
+        mockMvc.perform(delete("/api/v1/meetings/{id}", meeting.getId())
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"));
 

--- a/src/test/java/com/flodiback/api/project/ProjectControllerTest.java
+++ b/src/test/java/com/flodiback/api/project/ProjectControllerTest.java
@@ -34,7 +34,8 @@ import com.flodiback.global.embedding.OpenAiEmbeddingClient;
         properties = {
             "spring.flyway.enabled=false",
             "spring.jpa.hibernate.ddl-auto=create-drop",
-            "openai.api-key=test-key"
+            "openai.api-key=test-key",
+            "internal.api-key=test-internal-key"
         })
 @AutoConfigureMockMvc
 class ProjectControllerTest {

--- a/src/test/java/com/flodiback/api/project/ProjectControllerTest.java
+++ b/src/test/java/com/flodiback/api/project/ProjectControllerTest.java
@@ -86,7 +86,8 @@ class ProjectControllerTest {
 
     @Test
     void connectChannel_채널을_프로젝트에_연결한다() throws Exception {
-        mockMvc.perform(put("/api/v1/projects/{id}/channel/{channelId}", project.getId(), "channel-123"))
+        mockMvc.perform(put("/api/v1/projects/{id}/channel/{channelId}", project.getId(), "channel-123")
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"));
 
@@ -99,7 +100,8 @@ class ProjectControllerTest {
         project.connectChannel("channel-123");
         projectRepository.save(project);
 
-        mockMvc.perform(delete("/api/v1/projects/{id}/channel", project.getId()))
+        mockMvc.perform(delete("/api/v1/projects/{id}/channel", project.getId())
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"));
 
@@ -112,7 +114,8 @@ class ProjectControllerTest {
         project.connectChannel("channel-123");
         projectRepository.save(project);
 
-        mockMvc.perform(get("/api/v1/projects/channel/{channelId}", "channel-123"))
+        mockMvc.perform(get("/api/v1/projects/channel/{channelId}", "channel-123")
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
                 .andExpect(jsonPath("$.data.name").value("플로디"));
@@ -120,7 +123,8 @@ class ProjectControllerTest {
 
     @Test
     void getByChannelId_연결된_프로젝트가_없으면_404를_반환한다() throws Exception {
-        mockMvc.perform(get("/api/v1/projects/channel/{channelId}", "없는채널"))
+        mockMvc.perform(get("/api/v1/projects/channel/{channelId}", "없는채널")
+                        .header("X-Internal-Api-Key", "test-internal-key"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.resultCode").value("404-1"));
     }

--- a/src/test/java/com/flodiback/domain/meeting/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meeting/service/MeetingServiceTest.java
@@ -105,7 +105,7 @@ class MeetingServiceTest {
         given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        MeetingDetailResponse response = meetingService.end(1L);
+        MeetingDetailResponse response = meetingService.end(1L, null);
 
         // then
         verify(meetingRepository).save(meeting);
@@ -122,7 +122,7 @@ class MeetingServiceTest {
         given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        MeetingDetailResponse response = meetingService.end(1L);
+        MeetingDetailResponse response = meetingService.end(1L, null);
 
         // then
         verify(meetingRepository).save(meeting);
@@ -135,7 +135,7 @@ class MeetingServiceTest {
         given(meetingRepository.findById(999L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> meetingService.end(999L))
+        assertThatThrownBy(() -> meetingService.end(999L, null))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("존재하지 않는 회의입니다.");
 
@@ -150,7 +150,7 @@ class MeetingServiceTest {
         given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        meetingService.end(1L);
+        meetingService.end(1L, null);
 
         // then
         verify(eventPublisher).publishEvent(any(MeetingEndedEvent.class));
@@ -162,7 +162,7 @@ class MeetingServiceTest {
         given(meetingRepository.findById(999L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> meetingService.end(999L)).isInstanceOf(NoSuchElementException.class);
+        assertThatThrownBy(() -> meetingService.end(999L, null)).isInstanceOf(NoSuchElementException.class);
 
         verify(eventPublisher, never()).publishEvent(any());
     }
@@ -176,7 +176,7 @@ class MeetingServiceTest {
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
 
         // when
-        MeetingDetailResponse response = meetingService.getById(1L);
+        MeetingDetailResponse response = meetingService.getById(1L, null);
 
         // then
         assertThat(response.title()).isEqualTo("테스트 회의");
@@ -189,7 +189,7 @@ class MeetingServiceTest {
         given(meetingRepository.findById(999L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> meetingService.getById(999L))
+        assertThatThrownBy(() -> meetingService.getById(999L, null))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("존재하지 않는 회의입니다.");
     }

--- a/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
@@ -43,7 +43,7 @@ class ProjectServiceTest {
     @Test
     void create_serverId없으면_server_null로_프로젝트생성() {
         // given
-        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", null, null);
+        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", null, null, null);
         given(projectRepository.save(any(Project.class))).willAnswer(inv -> inv.getArgument(0));
 
         // when
@@ -63,7 +63,7 @@ class ProjectServiceTest {
         // given
         DiscordServer server =
                 DiscordServer.builder().guildId("guild-123").guildName("플로디 서버").build();
-        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", 1L, null);
+        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", 1L, null, null);
         given(discordServerRepository.findById(1L)).willReturn(Optional.of(server));
         given(projectRepository.save(any(Project.class))).willAnswer(inv -> inv.getArgument(0));
 
@@ -79,7 +79,7 @@ class ProjectServiceTest {
     @Test
     void create_존재하지않는_serverId면_예외발생() {
         // given
-        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", 999L, null);
+        CreateProjectRequest req = new CreateProjectRequest("플로디 프로젝트", "설명", "Java", 999L, null, null);
         given(discordServerRepository.findById(999L)).willReturn(Optional.empty());
 
         // when & then
@@ -122,7 +122,7 @@ class ProjectServiceTest {
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
 
         // when
-        ProjectResponse response = projectService.getById(1L);
+        ProjectResponse response = projectService.getById(1L, null);
 
         // then
         assertThat(response.name()).isEqualTo("플로디 프로젝트");
@@ -136,7 +136,7 @@ class ProjectServiceTest {
         given(projectRepository.findById(999L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> projectService.getById(999L))
+        assertThatThrownBy(() -> projectService.getById(999L, null))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("존재하지 않는 프로젝트입니다.");
     }
@@ -155,7 +155,7 @@ class ProjectServiceTest {
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
 
         // when
-        ProjectResponse response = projectService.update(1L, req);
+        ProjectResponse response = projectService.update(1L, req, null);
 
         // then
         assertThat(response.name()).isEqualTo("새 이름");
@@ -169,7 +169,7 @@ class ProjectServiceTest {
         given(projectRepository.findById(999L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> projectService.update(999L, new UpdateProjectRequest("이름", null, null)))
+        assertThatThrownBy(() -> projectService.update(999L, new UpdateProjectRequest("이름", null, null), null))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("존재하지 않는 프로젝트입니다.");
     }
@@ -183,7 +183,7 @@ class ProjectServiceTest {
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
 
         // when
-        projectService.delete(1L);
+        projectService.delete(1L, null);
 
         // then
         assertThat(project.getDeletedAt()).isNotNull();
@@ -195,7 +195,7 @@ class ProjectServiceTest {
         given(projectRepository.findById(999L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> projectService.delete(999L))
+        assertThatThrownBy(() -> projectService.delete(999L, null))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("존재하지 않는 프로젝트입니다.");
     }

--- a/src/test/java/com/flodiback/support/AbstractPostgresIntegrationTest.java
+++ b/src/test/java/com/flodiback/support/AbstractPostgresIntegrationTest.java
@@ -27,5 +27,6 @@ public abstract class AbstractPostgresIntegrationTest {
         // Flyway는 테스트에서 비활성화 (Hibernate create-drop이 스키마를 직접 관리)
         registry.add("spring.flyway.enabled", () -> "false");
         registry.add("openai.api-key", () -> "test-key");
+        registry.add("internal.api-key", () -> "test-internal-key");
     }
 }


### PR DESCRIPTION
## 71번 pr merge이후 dev로 rebase후 merge

## 🔗 연관된 이슈
refs #63
<!-- 완료 이슈가 있으면 아래도 작성 -->
closes #70

---

## 📝 작업 내용

Discord 봇 명령어 기반의 최소한의 인증/인가를 구현했습니다.

로그인 없이 Discord 컨텍스트(guildId, userId)만으로 동작하며,

프로젝트 생성자만 수정·삭제 가능하고 같은 서버 멤버는 읽기 가능합니다.

---

## ✅ 주요 변경 사항

1) `projects` 테이블에 `owner_discord_id` 컬럼 추가 (V8 마이그레이션)

2) 백엔드 읽기 API에 `X-Guild-Id`, 쓰기 API에 `X-Requester-Id` 헤더 기반 권한 검증 추가 (헤더 없으면 스킵 → 웹 확장 대비)

3) 봇이 API 호출 시 요청자 Discord 유저 ID와 서버 ID를 헤더에 포함하도록 수정

4) 회의 수정·삭제 권한은 별도 owner 없이 연결된 프로젝트의 owner를 따르도록 설계

---

## 🧪 테스트 결과

```bash

./gradlew compileTestJava

./gradlew spotlessCheck

- 로컬 테스트 통과

- 관련 시나리오 수동 확인

---

**👀 리뷰 포인트 (선택)**

- checkReadPermission / checkWritePermission — 헤더가 null이면 검증 스킵하는 정책이 의도적입니다. 웹 도입 시 Controller 앞단에 인증 레이어를 추가하면 자연스럽게

확장 가능합니다.

- 회의 owner를 별도로 두지 않고 프로젝트 owner를 따르도록 단순화한 설계 의도가 맞는지 확인 부탁드립니다.

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, 로그, 링크 등 -->
- 예) 스크린샷, 로그, 관련 문서 링크
