### PR TITLE
[refactor] STT 발화 시각 기록

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,21 @@ jobs:
       GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
       GLM_MODEL: ${{ secrets.GLM_MODEL }}
       GLM_API_URL: ${{ secrets.GLM_API_URL }}
+      ORG_GRADLE_OPTS: -Dorg.gradle.java.installations.fromEnv=JAVA_HOME_25_X64
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 25
+      - name: Set up JDK 25 toolchain
         uses: actions/setup-java@v4
         with:
           java-version: '25'
+          distribution: 'temurin'
+
+      - name: Set up JDK 21 for Gradle
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/docker-compose.bot.yml
+++ b/docker-compose.bot.yml
@@ -1,6 +1,6 @@
 services:
   discord-bot:
-    image: eclipse-temurin:21-jdk
+    image: eclipse-temurin:25-jdk
     platform: linux/amd64
     working_dir: /workspace
     volumes:

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandler.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandler.java
@@ -39,8 +39,8 @@ final class OpenAiRealtimeEventHandler {
                         session.speakerId(),
                         cumulative,
                         false,
-                        0L,
-                        0L,
+                        startMs(session),
+                        endMs(session),
                         sentPcmBytes,
                         audioDurationMs(sentPcmBytes),
                         null));
@@ -67,8 +67,8 @@ final class OpenAiRealtimeEventHandler {
                         session.speakerId(),
                         finalText,
                         true,
-                        0L,
-                        0L,
+                        startMs(session),
+                        endMs(session),
                         sentPcmBytes,
                         audioDurationMs(sentPcmBytes),
                         null));
@@ -81,6 +81,16 @@ final class OpenAiRealtimeEventHandler {
             return 0L;
         }
         return sentPcmBytes / REALTIME_PCM_BYTES_PER_MS;
+    }
+
+    private long startMs(OpenAiSttSessionState session) {
+        long firstAudioAtMs = session.firstAudioAtMs();
+        return firstAudioAtMs > 0 ? firstAudioAtMs : System.currentTimeMillis();
+    }
+
+    private long endMs(OpenAiSttSessionState session) {
+        long lastAudioAtMs = session.lastAudioAtMs();
+        return lastAudioAtMs > 0 ? lastAudioAtMs : startMs(session);
     }
 
     /**

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
@@ -75,8 +75,11 @@ public class OpenAiSttProvider implements SttProvider {
         }
         try {
             byte[] realtimePcm = pcmConverter.toRealtimePcm16(pcm16le);
+            if (realtimePcm.length == 0) {
+                return;
+            }
             pcmDebugDumper.capture(sessionId, pcm16le, realtimePcm);
-            session.addSentPcmBytes(realtimePcm.length);
+            session.recordSentPcm(realtimePcm.length, timestampMs);
             realtimeClient.appendAudio(session, realtimePcm, timestampMs);
         } catch (Exception exception) {
             session.sttListener().onError(sessionId, exception);

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttSessionState.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttSessionState.java
@@ -28,6 +28,9 @@ final class OpenAiSttSessionState {
 
     // 관측용 누적 PCM 바이트(디버깅/메트릭 용도)
     private final AtomicLong sentPcmBytes = new AtomicLong();
+    // 실제 STT로 전송한 첫/마지막 PCM 프레임 시각(ms)
+    private final AtomicLong firstAudioAtMs = new AtomicLong();
+    private final AtomicLong lastAudioAtMs = new AtomicLong();
     // endSession이 호출되었는지 상태 플래그
     private final AtomicBoolean endRequested = new AtomicBoolean(false);
 
@@ -58,12 +61,23 @@ final class OpenAiSttSessionState {
         return listener;
     }
 
-    void addSentPcmBytes(long bytes) {
+    void recordSentPcm(long bytes, long timestampMs) {
         sentPcmBytes.addAndGet(bytes);
+        long normalizedTimestampMs = timestampMs > 0 ? timestampMs : System.currentTimeMillis();
+        firstAudioAtMs.compareAndSet(0L, normalizedTimestampMs);
+        lastAudioAtMs.set(normalizedTimestampMs);
     }
 
     long sentPcmBytes() {
         return sentPcmBytes.get();
+    }
+
+    long firstAudioAtMs() {
+        return firstAudioAtMs.get();
+    }
+
+    long lastAudioAtMs() {
+        return lastAudioAtMs.get();
     }
 
     void markEndRequested() {

--- a/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandlerTest.java
+++ b/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandlerTest.java
@@ -63,7 +63,7 @@ class OpenAiRealtimeEventHandlerTest {
 
         private SttResult onlyResult() {
             assertThat(results).hasSize(1);
-            return results.getFirst();
+            return results.get(0);
         }
     }
 }

--- a/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandlerTest.java
+++ b/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandlerTest.java
@@ -1,0 +1,69 @@
+package com.flodiback.domain.speech.stt.provider.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.flodiback.domain.speech.stt.SttListener;
+import com.flodiback.domain.speech.stt.SttResult;
+
+class OpenAiRealtimeEventHandlerTest {
+
+    private final OpenAiRealtimeEventHandler eventHandler = new OpenAiRealtimeEventHandler();
+
+    @Test
+    void onDelta_usesFirstAndLastAudioTimestamps() {
+        CapturingSttListener listener = new CapturingSttListener();
+        OpenAiSttSessionState session = new OpenAiSttSessionState("session-1", "speaker-1", listener);
+        session.recordSentPcm(4_800L, 1_000L);
+        session.recordSentPcm(4_800L, 1_120L);
+
+        eventHandler.onDelta(session, "item-1", "안녕");
+
+        SttResult result = listener.onlyResult();
+        assertThat(result.isFinal()).isFalse();
+        assertThat(result.startMs()).isEqualTo(1_000L);
+        assertThat(result.endMs()).isEqualTo(1_120L);
+        assertThat(result.sentPcmBytes()).isEqualTo(9_600L);
+        assertThat(result.audioDurationMs()).isEqualTo(200L);
+    }
+
+    @Test
+    void onCompleted_usesFirstAndLastAudioTimestamps() {
+        CapturingSttListener listener = new CapturingSttListener();
+        OpenAiSttSessionState session = new OpenAiSttSessionState("session-1", "speaker-1", listener);
+        session.recordSentPcm(4_800L, 2_000L);
+        session.recordSentPcm(4_800L, 2_180L);
+
+        eventHandler.onCompleted(session, "item-1", "최종 전사");
+
+        SttResult result = listener.onlyResult();
+        assertThat(result.isFinal()).isTrue();
+        assertThat(result.startMs()).isEqualTo(2_000L);
+        assertThat(result.endMs()).isEqualTo(2_180L);
+        assertThat(result.sentPcmBytes()).isEqualTo(9_600L);
+        assertThat(result.audioDurationMs()).isEqualTo(200L);
+    }
+
+    private static final class CapturingSttListener implements SttListener {
+        private final List<SttResult> results = new ArrayList<>();
+
+        @Override
+        public void onResult(SttResult result) {
+            results.add(result);
+        }
+
+        @Override
+        public void onError(String sessionId, Throwable throwable) {
+            throw new AssertionError("Unexpected STT error", throwable);
+        }
+
+        private SttResult onlyResult() {
+            assertThat(results).hasSize(1);
+            return results.getFirst();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항
- OpenAI Realtime STT 세션에서 실제 전송한 첫 번째/마지막 PCM timestamp를 기록합니다.
- `conversation.item.input_audio_transcription.delta/completed` 결과를 `SttResult`로 변환할 때 `startMs/endMs`에 0L 대신 실제 오디오 구간 시각을 넣습니다.
- 변환 결과가 빈 PCM이면 전송/시각 기록을 건너뛰도록 방어했습니다.
- delta/final 결과가 첫/마지막 오디오 timestamp를 사용하는지 단위 테스트를 추가했습니다.

## 배경
기존에는 `OpenAiRealtimeEventHandler`가 `SttResult.startMs/endMs`를 항상 `0L`로 생성했습니다. 이후 `BotSttListener`가 이 값을 내부 speech API의 `speech_started_at/speech_ended_at`으로 변환하면서, 발화 시간이 1970년 기준으로 저장될 수 있었습니다.

이 문제는 전사 텍스트 품질에는 직접 영향이 적지만, 회의록 정렬과 타임라인 분석, 최근 발화 기반 컨텍스트 조회에 영향을 줄 수 있습니다.

## 검증
- `./gradlew test --tests com.flodiback.domain.speech.stt.provider.openai.OpenAiRealtimeEventHandlerTest --tests com.flodiback.bot.stt.BotSttListenerTest --tests com.flodiback.bot.command.DiscordCommandListenerTest`
- `./gradlew spotlessCheck`
- `./gradlew test`
