### PR TITLE
[feat] 웹앱 실시간 자막 및 비동기 AI 답변 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,10 +10,13 @@ DISCORD_TOKEN=your_discord_bot_token
 
 # Text command prefix
 DISCORD_BOT_PREFIX=!
+
 # Optional: comma-separated Discord guild IDs this bot instance should handle.
 # 여러 Docker 인스턴스가 같은 DISCORD_TOKEN을 쓰면 각 인스턴스에 담당 서버 ID를 지정하세요.
 # 비워두면 봇이 초대된 모든 서버 이벤트를 처리합니다.
 DISCORD_ALLOWED_GUILD_IDS=
+
+AI_PROVIDER=disabled
 GLM_ENABLED=false
 
 # Spring internal API base URL (로컬 실행 기준)
@@ -32,10 +35,18 @@ OPENAI_API_KEY=your_openai_api_key
 OPENAI_REALTIME_WS_URL=wss://api.openai.com/v1/realtime?intent=transcription
 OPENAI_TRANSCRIBE_MODEL=gpt-4o-transcribe
 
+# OpenAI AI answers
+OPENAI_CHAT_MODEL=gpt-4o-mini
+OPENAI_CHAT_BASE_URL=https://api.openai.com/v1
+OPENAI_CHAT_TIMEOUT_MS=30000
+OPENAI_CHAT_MAX_RETRIES=0
+
 # OpenAI Embeddings
 OPENAI_EMBEDDING_API_KEY=your_openai_embedding_api_key
 
 OPENAI_TRANSCRIBE_LANGUAGE=ko
+AI_PROVIDER=glm
+GLM_ENABLED=true
 GLM_API_KEY=your_glm_api_key
 GLM_MODEL=glm-5.1
 GLM_API_URL=grepp_url

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ GLM_ENABLED=false
 # Docker에서 봇을 실행하고 Spring 서버는 호스트 Mac에서 실행하면 http://host.docker.internal:8080
 INTERNAL_API_BASE_URL=http://localhost:8080
 
+# Web dashboard base URL
+FRONTEND_BASE_URL=http://localhost:5173
+
 # Optional: internal API key (필요한 경우만)
 INTERNAL_API_KEY=
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,1 @@
-# CLAUDE.md
 
-@AGENTS.md
-
-## Claude Code 메모
-- 기본 진입점은 `AGENTS.md`입니다.
-- 지속적으로 참고할 프로젝트 맥락은 `docs/README.md`와 연결 문서에서 확인합니다.
-- 팀 공통 지침은 저장소 파일에, 개인 취향은 로컬 설정에 둡니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,8 @@
+# CLAUDE.md
 
+@AGENTS.md
+
+## Claude Code 메모
+- 기본 진입점은 `AGENTS.md`입니다.
+- 지속적으로 참고할 프로젝트 맥락은 `docs/README.md`와 연결 문서에서 확인합니다.
+- 팀 공통 지침은 저장소 파일에, 개인 취향은 로컬 설정에 둡니다.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,6 +104,9 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testAnnotationProcessor("org.projectlombok:lombok")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
+    implementation("redis.clients:jedis:5.1.5")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("com.orctom:vad4j:1.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,6 +124,7 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    systemProperty("spring.profiles.active", "test")
 }
 
 // Spring 서버와 분리된 Discord 봇 실행 태스크

--- a/docker-compose.bot.yml
+++ b/docker-compose.bot.yml
@@ -10,6 +10,7 @@ services:
       - .env
     environment:
       ORG_GRADLE_JAVA_INSTALLATIONS_AUTO_DOWNLOAD: "true"
+      REDIS_HOST: host.docker.internal
     command: ["/bin/bash", "-lc", "./gradlew --no-daemon --console=plain runDiscordBot"]
     restart: "no"
 

--- a/docs/exec-plans/completed/2026-05/2026-05-10-200637-ai-answer-async-websocket-codex.md
+++ b/docs/exec-plans/completed/2026-05/2026-05-10-200637-ai-answer-async-websocket-codex.md
@@ -1,0 +1,50 @@
+# 2026-05-10-200637-ai-answer-async-websocket-codex
+
+- author: codex
+- status: completed
+- created-at: 2026-05-10 20:06:37
+
+## Background
+
+Meeting speech ingest currently waits for AI answer generation when a wake word is present. That couples `/internal/v1/speech`, caption delivery, RAG context assembly, embedding calls, and GLM latency.
+
+## Goal
+
+Decouple speech ingest from AI answer generation, deliver AI answers to the web frontend through WebSocket events, and reduce average GLM latency by trimming prompt/RAG context.
+
+## Scope
+
+- Make AI answer generation asynchronous for wake-word speech only.
+- Add WebSocket AI answer events for `PENDING`, `COMPLETED`, and `FALLBACK`.
+- Add dedicated async executor and pending scheduler.
+- Add embedding/GLM timeout settings and output token limit.
+- Trim short-term context and prompt text sizes.
+- Add latency logs without logging speech text.
+
+## Checkpoints
+
+1. Add async answer event DTO/service/configuration.
+2. Refactor speech ingest to trigger async answers only when a question is extracted.
+3. Trim ContextService prompt/RAG inputs and repository queries.
+4. Add timeout/token settings and latency logs.
+5. Update tests and verify focused Gradle tests.
+
+## Risks
+
+- WebSocket event contract must stay simple enough for frontend consumption.
+- Async rejection must not block `/speech`.
+- Late `PENDING -> COMPLETED/FALLBACK` ordering must be deterministic enough for frontend state updates.
+
+## Verification
+
+- [x] Focused speech service/controller tests
+- [x] Focused context service tests
+- [x] GLM client tests
+- [x] Build or broader test suite when feasible
+
+## Decision Log
+
+- 2026-05-10 20:06:37: Use WebSocket as the first AI answer delivery path; Discord bot delivery is out of scope for this change.
+- 2026-05-10 20:06:37: Keep GLM timeout at 15s with retry 0; use 5s `PENDING` event for visible responsiveness.
+- 2026-05-10 20:06:37: Skip ContextService parallelization until latency logs prove DB/RAG is the main bottleneck.
+- 2026-05-10 20:24:00: Completed implementation and verified with `./gradlew test`, `./gradlew spotlessCheck`, and `./gradlew build`.

--- a/docs/exec-plans/completed/2026-05/2026-05-10-200637-ai-answer-async-websocket-codex.md
+++ b/docs/exec-plans/completed/2026-05/2026-05-10-200637-ai-answer-async-websocket-codex.md
@@ -1,7 +1,7 @@
 # 2026-05-10-200637-ai-answer-async-websocket-codex
 
-- author: codex
-- status: completed
+- 작성자: codex
+- 상태: 완료(읽기 전용)
 - created-at: 2026-05-10 20:06:37
 
 ## Background

--- a/docs/impl/codex/0510-ai-answer-async-websocket.md
+++ b/docs/impl/codex/0510-ai-answer-async-websocket.md
@@ -1,0 +1,26 @@
+# 회의 중 AI 답변 비동기 WebSocket 전달
+
+> `/internal/v1/speech` 저장 응답과 AI 답변 생성을 분리하고, 웹 프론트엔드가 `/topic/meetings/{meetingId}/ai-answer`로 AI 답변 상태를 받을 수 있게 했다.
+
+## 배경
+
+호출어가 포함된 발화는 기존에 발화 저장 요청 안에서 컨텍스트 조립, embedding, GLM 호출까지 기다렸다. 이 구조에서는 GLM 지연이 내부 API 응답과 caption 흐름까지 지연시킬 수 있었다.
+
+## 구현
+
+- 발화 저장 후 question이 추출될 때만 `SpeechAiAnswerAsyncService`를 실행한다.
+- AI 답변은 `PENDING`, `COMPLETED`, `FALLBACK` WebSocket 이벤트로 전달한다.
+- 5초 후에도 답변이 끝나지 않으면 별도 scheduler가 `PENDING`을 발행하고, 이후 GLM 완료/실패에 따라 후속 이벤트를 발행한다.
+- GLM timeout은 15초, retry는 0으로 조정했고, completion token 상한을 256으로 둔다.
+- 최근 발화와 question context 개수를 줄이고 긴 텍스트를 잘라 prompt 크기를 제한한다.
+
+## 검증
+
+- focused speech/context/GLM tests
+- `InternalSpeechControllerTest`
+
+## 리뷰 메타
+
+- reviewed-by:
+- reviewed-at:
+- evidence:

--- a/docs/impl/codex/0510-ai-answer-async-websocket.md
+++ b/docs/impl/codex/0510-ai-answer-async-websocket.md
@@ -1,3 +1,10 @@
+---
+generated-by: ai-draft
+reviewed-by: madupal
+reviewed-at: 2026-05-11
+evidence: PR 94
+---
+
 # 회의 중 AI 답변 비동기 WebSocket 전달
 
 > `/internal/v1/speech` 저장 응답과 AI 답변 생성을 분리하고, 웹 프론트엔드가 `/topic/meetings/{meetingId}/ai-answer`로 AI 답변 상태를 받을 수 있게 했다.

--- a/docs/impl/codex/0511-openai-ai-chat-provider.md
+++ b/docs/impl/codex/0511-openai-ai-chat-provider.md
@@ -1,3 +1,10 @@
+---
+generated-by: ai-draft
+reviewed-by: madupal
+reviewed-at: 2026-05-11
+evidence: PR 94
+---
+
 # OpenAI AI Chat Provider
 
 > 회의 중 AI 질문 경로에서 GLM과 OpenAI를 같은 `AiChatService` 인터페이스로 교체해 테스트할 수 있게 했다.

--- a/docs/impl/codex/0511-openai-ai-chat-provider.md
+++ b/docs/impl/codex/0511-openai-ai-chat-provider.md
@@ -1,0 +1,46 @@
+# OpenAI AI Chat Provider
+
+> 회의 중 AI 질문 경로에서 GLM과 OpenAI를 같은 `AiChatService` 인터페이스로 교체해 테스트할 수 있게 했다.
+
+## 배경
+
+GLM 수동 테스트와 실제 회의 질문 로그에서 짧은 프롬프트도 8~30초가 걸리는 현상이 확인됐다. DB/RAG보다 GLM 게이트웨이 또는 모델 호출 자체의 기본 지연이 커 보이므로, 같은 회의 질문 경로를 OpenAI 모델로 전환해 지연을 비교할 수 있는 설정이 필요했다.
+
+## 구현
+
+- `OpenAiChatClient`를 추가해 OpenAI Chat Completions API를 호출한다.
+- `OpenAiChatService`를 추가해 기존 `AiChatService` 기반 호출부를 그대로 재사용한다.
+- `AI_PROVIDER=openai|glm|disabled` 설정을 추가했다.
+- 기존 `GLM_ENABLED=true` 설정도 `AI_PROVIDER`가 비어 있을 때 계속 GLM 선택으로 동작하게 유지했다.
+- OpenAI 호출 성공/실패 로그는 GLM 로그와 같은 수준의 메타데이터만 남기고, 프롬프트/응답 본문은 남기지 않는다.
+- `OpenAiChatClientManualTest`를 추가해 로컬에서 GLM 수동 테스트와 같은 방식으로 응답 시간을 비교할 수 있게 했다.
+
+## 사용법
+
+OpenAI로 회의 중 AI 답변을 테스트하려면 `.env`에 다음 값을 둔다.
+
+```properties
+AI_PROVIDER=openai
+OPENAI_API_KEY=...
+OPENAI_CHAT_MODEL=gpt-4o-mini
+OPENAI_CHAT_TIMEOUT_MS=30000
+OPENAI_CHAT_MAX_RETRIES=0
+```
+
+GLM으로 되돌리려면 `AI_PROVIDER=glm` 또는 기존처럼 `GLM_ENABLED=true`를 사용한다.
+
+수동 클라이언트 테스트만 실행하려면 `OpenAiChatClientManualTest`의 `@Disabled`를 잠시 제거한 뒤 다음 명령을 실행한다.
+
+```bash
+./gradlew test --tests "com.flodiback.global.client.OpenAiChatClientManualTest"
+```
+
+## 검증
+
+- `./gradlew test --tests "com.flodiback.global.client.OpenAiChatClientTest" --tests "com.flodiback.domain.ai.service.OpenAiChatServiceTest" --tests "com.flodiback.domain.ai.service.GlmAiChatServiceTest" --tests "com.flodiback.domain.ai.service.DisabledAiChatServiceTest"`
+
+## 리뷰 메타
+
+- reviewed-by:
+- reviewed-at:
+- evidence:

--- a/docs/references/internal-api-contracts.md
+++ b/docs/references/internal-api-contracts.md
@@ -28,13 +28,38 @@ Discord 봇 파이프라인에서 STT 변환 결과를 수신합니다.
   "data": {
     "utterance_id": 11,
     "meeting_id": 1,
-    "ai_answer": "네, 기존 결정사항 기준으로 인증 방식은 JWT를 사용하기로 했습니다."
+    "ai_answer": null
   }
 }
 ```
 
-- `ai_answer`는 호출어가 감지되어 AI 답변이 생성된 경우에만 문자열로 내려갑니다.
-- 호출어가 없거나 AI 답변 생성에 실패하면 `ai_answer`는 `null`입니다.
+- `ai_answer`는 하위 호환을 위해 유지하지만, AI 답변 전달 수단으로 사용하지 않습니다. 항상 `null`입니다.
+- 호출어가 감지된 경우 AI 답변은 비동기로 생성되어 WebSocket으로 전달됩니다.
+
+### AI answer delivery change
+
+- `/internal/v1/speech` no longer waits for AI answer generation.
+- Response `data.ai_answer` remains for backward compatibility but is always `null`.
+- If the speech text contains a wake word and question, the backend creates the AI answer asynchronously and publishes it to WebSocket topic `/topic/meetings/{meetingId}/ai-answer`.
+
+WebSocket payload:
+```json
+{
+  "meetingId": 1,
+  "utteranceId": 11,
+  "speakerDiscordId": "123456789",
+  "question": "인증 방식 뭐로 하기로 했어?",
+  "answer": "[회의 기반] 인증 방식은 JWT로 결정했습니다.",
+  "status": "COMPLETED",
+  "elapsedMs": 3200,
+  "createdAt": "2026-05-10T20:30:00"
+}
+```
+
+- `status`: `PENDING`, `COMPLETED`, `FALLBACK`
+- 5초 안에 완료되면 `COMPLETED`만 발행합니다.
+- 5초를 넘기면 먼저 `PENDING`을 발행하고, 이후 성공 시 `COMPLETED`, 실패/timeout 시 `FALLBACK`을 발행합니다.
+- `question`은 프론트엔드 표시와 caption 매핑을 위한 payload입니다. 서버 latency 로그에는 발화 원문을 남기지 않습니다.
 
 ## `GET /internal/v1/meetings/{meetingId}/context`
 회의 중 AI 답변용 컨텍스트를 조회합니다.

--- a/src/main/java/com/flodiback/api/channel/ChannelController.java
+++ b/src/main/java/com/flodiback/api/channel/ChannelController.java
@@ -1,0 +1,28 @@
+package com.flodiback.api.channel;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flodiback.domain.meeting.meeting.dto.ActiveMeetingResponse;
+import com.flodiback.domain.meeting.meeting.service.MeetingService;
+import com.flodiback.global.rsData.RsData;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/v1/channels")
+@RequiredArgsConstructor
+public class ChannelController {
+
+    private final MeetingService meetingService;
+
+    @GetMapping("/{channelId}/active-meeting")
+    public RsData<ActiveMeetingResponse> getActiveMeeting(@PathVariable String channelId) {
+        ActiveMeetingResponse response =
+                meetingService.getActiveMeeting(channelId).orElse(null);
+        String msg = response != null ? "진행 중인 회의를 찾았습니다." : "진행 중인 회의가 없습니다.";
+        return RsData.of("200-1", msg, response);
+    }
+}

--- a/src/main/java/com/flodiback/api/meeting/RollingSummaryController.java
+++ b/src/main/java/com/flodiback/api/meeting/RollingSummaryController.java
@@ -1,0 +1,29 @@
+package com.flodiback.api.meeting;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flodiback.domain.meeting.meetinglog.rolling.RollingSummaryPersistenceService;
+import com.flodiback.domain.meeting.meetinglog.rolling.RollingSummaryPersistenceService.RollingSummarySnapshot;
+import com.flodiback.global.rsData.RsData;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/v1/meetings")
+@RequiredArgsConstructor
+public class RollingSummaryController {
+
+    private final RollingSummaryPersistenceService rollingSummaryPersistenceService;
+
+    @GetMapping("/{id}/rolling-summary")
+    public ResponseEntity<RsData<RollingSummarySnapshot>> getLatestSummary(@PathVariable Long id) {
+        return rollingSummaryPersistenceService
+                .getLatestSummary(id)
+                .map(snapshot -> ResponseEntity.ok(RsData.of("200-1", "롤링 요약 조회 성공.", snapshot)))
+                .orElse(ResponseEntity.noContent().build());
+    }
+}

--- a/src/main/java/com/flodiback/api/speech/InternalSpeechController.java
+++ b/src/main/java/com/flodiback/api/speech/InternalSpeechController.java
@@ -1,10 +1,12 @@
 package com.flodiback.api.speech;
 
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.flodiback.domain.speech.dto.CaptionEvent;
 import com.flodiback.domain.speech.dto.InternalSpeechRequest;
 import com.flodiback.domain.speech.dto.InternalSpeechResponse;
 import com.flodiback.domain.speech.service.InternalSpeechService;
@@ -19,11 +21,15 @@ import lombok.RequiredArgsConstructor;
 public class InternalSpeechController {
 
     private final InternalSpeechService internalSpeechService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     @PostMapping("/speech")
     public RsData<InternalSpeechResponse> receiveSpeech(@Valid @RequestBody InternalSpeechRequest request) {
-        // Discord 봇에서 전달한 STT 결과를 저장 처리로 넘깁니다.
         InternalSpeechResponse response = internalSpeechService.saveSpeech(request);
+
+        CaptionEvent event = CaptionEvent.finalEvent(
+                request.meetingId(), request.speakerDiscordId(), request.speakerName(), request.text());
+        messagingTemplate.convertAndSend("/topic/meetings/" + request.meetingId() + "/captions", event);
 
         return RsData.of("200-1", "발화가 저장되었습니다.", response);
     }

--- a/src/main/java/com/flodiback/bot/DiscordBotMain.java
+++ b/src/main/java/com/flodiback/bot/DiscordBotMain.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.flodiback.bot.command.DiscordCommandListener;
+import com.flodiback.bot.stt.RedisPublisher;
 import com.flodiback.domain.speech.stt.SttProvider;
 import com.flodiback.domain.speech.stt.provider.openai.OpenAiSttProvider;
 
@@ -53,14 +54,19 @@ public final class DiscordBotMain {
         // 5) STT provider 인스턴스 준비
         SttProvider sttProvider = new OpenAiSttProvider();
 
-        // 6) JDA 빌드 + 명령 리스너 등록
+        // 6) Redis publisher 초기화
+        String redisHost = BotEnv.getOrDefault("REDIS_HOST", "localhost");
+        int redisPort = Integer.parseInt(BotEnv.getOrDefault("REDIS_PORT", "6379"));
+        RedisPublisher redisPublisher = new RedisPublisher(redisHost, redisPort);
+
+        // 7) JDA 빌드 + 명령 리스너 등록
         JDA jda = JDABuilder.createDefault(token, intents)
                 .enableCache(CacheFlag.VOICE_STATE)
                 .setMemberCachePolicy(MemberCachePolicy.VOICE)
                 .disableCache(
                         CacheFlag.EMOJI, CacheFlag.STICKER, CacheFlag.SOUNDBOARD_SOUNDS, CacheFlag.SCHEDULED_EVENTS)
                 .setAudioModuleConfig(audioModuleConfig)
-                .addEventListeners(new DiscordCommandListener(prefix, sttProvider, defaultMeetingId))
+                .addEventListeners(new DiscordCommandListener(prefix, sttProvider, defaultMeetingId, redisPublisher))
                 .build()
                 .awaitReady();
 

--- a/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
+++ b/src/main/java/com/flodiback/bot/audio/PerUserAudioReceiveHandler.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.flodiback.bot.stt.BotSttListener;
+import com.flodiback.bot.stt.RedisPublisher;
 import com.flodiback.domain.speech.stt.SttProvider;
 import com.orctom.vad4j.VAD;
 
@@ -73,6 +74,7 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
     private final ScheduledExecutorService silenceWatcher;
     private final ScheduledExecutorService sttIoExecutor;
     private final Guild guild;
+    private final RedisPublisher redisPublisher;
     private volatile MessageChannel captionChannel;
 
     // 사용자 ID별 누적 통계(튜닝/디버깅 지표)
@@ -118,10 +120,16 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
     }
 
     public PerUserAudioReceiveHandler(long guildId, Guild guild, SttProvider sttProvider, long meetingId) {
+        this(guildId, guild, sttProvider, meetingId, null);
+    }
+
+    public PerUserAudioReceiveHandler(
+            long guildId, Guild guild, SttProvider sttProvider, long meetingId, RedisPublisher redisPublisher) {
         this.guildId = guildId;
         this.guild = guild;
         this.sttProvider = Objects.requireNonNull(sttProvider);
         this.meetingId = meetingId;
+        this.redisPublisher = redisPublisher;
         this.silenceWatcher = Executors.newSingleThreadScheduledExecutor(new SilenceWatcherThreadFactory(guildId));
         this.sttIoExecutor = Executors.newSingleThreadScheduledExecutor(new SttIoThreadFactory(guildId));
         // 무음 종료 감시 스케줄러 시작
@@ -497,7 +505,8 @@ public class PerUserAudioReceiveHandler implements AudioReceiveHandler {
                             session.speakerId,
                             speakerName,
                             captionChannel,
-                            () -> buildQualitySnapshot(userId, session));
+                            () -> buildQualitySnapshot(userId, session),
+                            redisPublisher);
                     sttProvider.startSession(session.sessionId, session.speakerId, listener);
                     log.info(
                             "[STT/세션시작] guildId={}, meetingId={}, userId={}, sessionId={}, speakerName={}",

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.flodiback.bot.BotEnv;
 import com.flodiback.bot.audio.PerUserAudioReceiveHandler;
+import com.flodiback.bot.stt.RedisPublisher;
 import com.flodiback.domain.speech.stt.SttProvider;
 import com.flodiback.domain.speech.stt.provider.openai.OpenAiSttProvider;
 
@@ -112,6 +113,7 @@ public class DiscordCommandListener extends ListenerAdapter {
     private final String internalBaseUrl;
     private final String internalApiKey;
     private final Set<Long> allowedGuildIds;
+    private final String frontendBaseUrl;
     // 길드별 오디오 수신 핸들러 캐시
     private final Map<Long, PerUserAudioReceiveHandler> receiveHandlers = new ConcurrentHashMap<>();
     // 길드별 활성 meetingId
@@ -122,17 +124,25 @@ public class DiscordCommandListener extends ListenerAdapter {
     private final Map<Long, ProjectCreationState> pendingProjectCreations = new ConcurrentHashMap<>();
     // 채널별 회의 시작 확인 대기 상태
     private final Map<Long, MeetingConfirmationState> pendingMeetingConfirmations = new ConcurrentHashMap<>();
+    private final RedisPublisher redisPublisher;
 
     public DiscordCommandListener() {
-        this("!", new OpenAiSttProvider(), 1L);
+        this("!", new OpenAiSttProvider(), 1L, null);
     }
 
     public DiscordCommandListener(String prefix, SttProvider sttProvider, long defaultMeetingId) {
+        this(prefix, sttProvider, defaultMeetingId, null);
+    }
+
+    public DiscordCommandListener(
+            String prefix, SttProvider sttProvider, long defaultMeetingId, RedisPublisher redisPublisher) {
         this.prefix = (prefix == null || prefix.isBlank()) ? "!" : prefix.trim();
         this.sttProvider = Objects.requireNonNull(sttProvider);
         this.internalBaseUrl = normalizeBaseUrl(BotEnv.getOrDefault("INTERNAL_API_BASE_URL", "http://localhost:8080"));
         this.internalApiKey = BotEnv.get("INTERNAL_API_KEY");
         this.allowedGuildIds = parseAllowedGuildIds(BotEnv.get(ENV_ALLOWED_GUILD_IDS));
+        this.frontendBaseUrl = normalizeBaseUrl(BotEnv.getOrDefault("FRONTEND_BASE_URL", "http://localhost:5173"));
+        this.redisPublisher = redisPublisher;
     }
 
     @Override
@@ -216,7 +226,8 @@ public class DiscordCommandListener extends ListenerAdapter {
         switch (event.getComponentId()) {
             case BUTTON_PANEL_OPEN -> {
                 event.replyEmbeds(buildFlodiPanelEmbed().build())
-                        .setComponents(buildFlodiPanelComponents())
+                        .setComponents(buildFlodiPanelComponents(
+                                event.getGuild(), event.getChannel().getIdLong()))
                         .setEphemeral(true)
                         .queue();
             }
@@ -317,11 +328,12 @@ public class DiscordCommandListener extends ListenerAdapter {
                 .addField("회의", "음성 채널에 들어간 뒤 회의를 시작하면 STT 기록이 저장돼요.", false);
     }
 
-    private List<ActionRow> buildFlodiPanelComponents() {
+    private List<ActionRow> buildFlodiPanelComponents(Guild guild, long channelId) {
         return List.of(
                 ActionRow.of(
                         Button.secondary(BUTTON_DASHBOARD_VIEW, "대시보드"),
                         Button.secondary(BUTTON_PROJECT_CREATE, "프로젝트 생성")),
+                buildWebDashboardLinkRow(guild, channelId),
                 ActionRow.of(
                         Button.primary(BUTTON_MEETING_START, "회의 시작"), Button.danger(BUTTON_MEETING_END, "회의 종료")));
     }
@@ -395,6 +407,8 @@ public class DiscordCommandListener extends ListenerAdapter {
         JsonNode projects = fetchData("/api/v1/projects", "프로젝트 목록 조회");
         List<ActionRow> components = new ArrayList<>();
         components.add(ActionRow.of(Button.secondary(BUTTON_PROJECT_CREATE, "프로젝트 생성")));
+        components.add(
+                buildWebDashboardLinkRow(event.getGuild(), event.getChannel().getIdLong()));
         if (projects != null && projects.isArray() && !projects.isEmpty()) {
             components.add(ActionRow.of(buildProjectSelectMenu(projects)));
         }
@@ -415,6 +429,8 @@ public class DiscordCommandListener extends ListenerAdapter {
                 .sendMessage(message)
                 .addEmbeds(buildProjectDashboardEmbed(event.getGuild(), project, decisions, connected)
                         .build())
+                .setComponents(buildWebDashboardLinkRow(
+                        event.getGuild(), event.getChannel().getIdLong()))
                 .setEphemeral(true)
                 .queue();
     }
@@ -428,6 +444,8 @@ public class DiscordCommandListener extends ListenerAdapter {
                 .sendMessage(message)
                 .addEmbeds(buildProjectDashboardEmbed(event.getGuild(), project, decisions, connected)
                         .build())
+                .setComponents(buildWebDashboardLinkRow(
+                        event.getGuild(), event.getChannel().getIdLong()))
                 .setEphemeral(true)
                 .queue();
     }
@@ -439,6 +457,8 @@ public class DiscordCommandListener extends ListenerAdapter {
                 .sendMessage(message)
                 .addEmbeds(buildProjectDashboardEmbed(event.getGuild(), project, decisions, true)
                         .build())
+                .setComponents(buildWebDashboardLinkRow(
+                        event.getGuild(), event.getChannel().getIdLong()))
                 .setEphemeral(true)
                 .queue();
     }
@@ -464,6 +484,7 @@ public class DiscordCommandListener extends ListenerAdapter {
         JsonNode projects = fetchData("/api/v1/projects", "프로젝트 목록 조회");
         List<ActionRow> components = new ArrayList<>();
         components.add(ActionRow.of(Button.secondary(BUTTON_PROJECT_CREATE, "프로젝트 생성")));
+        components.add(buildWebDashboardLinkRow(guild, channel.getIdLong()));
         if (projects != null && projects.isArray() && !projects.isEmpty()) {
             components.add(ActionRow.of(buildProjectSelectMenu(projects)));
         }
@@ -484,6 +505,7 @@ public class DiscordCommandListener extends ListenerAdapter {
         boolean connected = connectedProjectId != null && connectedProjectId == projectId;
         channel.sendMessageEmbeds(buildProjectDashboardEmbed(guild, project, decisions, connected)
                         .build())
+                .setComponents(buildWebDashboardLinkRow(guild, channel.getIdLong()))
                 .queue();
     }
 
@@ -797,7 +819,7 @@ public class DiscordCommandListener extends ListenerAdapter {
 
     private void handleMeetingEnd(MessageReceivedEvent event) {
         MeetingEndResult result = endActiveMeeting(event.getGuild());
-        sendTemporaryMessage(event.getChannel(), buildMeetingEndMessage(result));
+        sendMeetingEndMessage(event.getGuild(), event.getChannel(), result);
     }
 
     private MeetingEndResult endActiveMeeting(Guild guild) {
@@ -872,7 +894,7 @@ public class DiscordCommandListener extends ListenerAdapter {
             }
 
             PerUserAudioReceiveHandler handler =
-                    new PerUserAudioReceiveHandler(ctx.guildId(), ctx.guild(), sttProvider, meetingId);
+                    new PerUserAudioReceiveHandler(ctx.guildId(), ctx.guild(), sttProvider, meetingId, redisPublisher);
             receiveHandlers.put(ctx.guildId(), handler);
             activeMeetingIdByGuild.put(ctx.guildId(), meetingId);
             handler.updateCaptionChannel(ctx.textChannel());
@@ -884,10 +906,7 @@ public class DiscordCommandListener extends ListenerAdapter {
             ctx.audioManager().setSelfDeafened(false);
             ctx.audioManager().openAudioConnection(ctx.voiceChannel());
 
-            ctx.textChannel()
-                    .sendMessage(
-                            "회의 시작! 음성 채널 [" + ctx.voiceChannel().getName() + "]에 입장했어요. (meetingId=" + meetingId + ")")
-                    .queue();
+            sendMeetingStartMessage(ctx, meetingId);
             log.info(
                     "[미팅/시작] guildId={}, meetingId={}, projectId={}, channel={}",
                     ctx.guildId(),
@@ -1115,6 +1134,35 @@ public class DiscordCommandListener extends ListenerAdapter {
         if (internalApiKey != null && !internalApiKey.isBlank()) {
             requestBuilder.header("X-Internal-Api-Key", internalApiKey);
         }
+    }
+
+    private void sendMeetingStartMessage(MeetingStartContext ctx, long meetingId) {
+        String content = "회의 시작! 음성 채널 [" + ctx.voiceChannel().getName() + "]에 입장했어요. (meetingId=" + meetingId + ")";
+
+        ctx.textChannel()
+                .sendMessage(content)
+                .setComponents(buildWebDashboardLinkRow(ctx.guild(), ctx.channelId()))
+                .queue();
+    }
+
+    private void sendMeetingEndMessage(Guild guild, MessageChannel channel, MeetingEndResult result) {
+        if (result.meetingId() == null) {
+            sendTemporaryMessage(channel, buildMeetingEndMessage(result));
+            return;
+        }
+
+        channel.sendMessage(buildMeetingEndMessage(result))
+                .setComponents(buildWebDashboardLinkRow(guild, channel.getIdLong()))
+                .queue();
+    }
+
+    private ActionRow buildWebDashboardLinkRow(Guild guild, long channelId) {
+        return ActionRow.of(Button.link(buildWebDashboardUrl(guild, channelId), "웹 대시보드 열기"));
+    }
+
+    private String buildWebDashboardUrl(Guild guild, long channelId) {
+        String guildId = guild.getId();
+        return frontendBaseUrl + "/channels/" + channelId + "/dashboard?server_id=" + guildId + "&guild_id=" + guildId;
     }
 
     private String normalizeBaseUrl(String baseUrl) {

--- a/src/main/java/com/flodiback/bot/stt/BotSttListener.java
+++ b/src/main/java/com/flodiback/bot/stt/BotSttListener.java
@@ -72,6 +72,8 @@ public class BotSttListener implements SttListener {
     private final AtomicReference<ScheduledFuture<?>> pendingPartialTask = new AtomicReference<>();
     private final AtomicReference<String> pendingPartialText = new AtomicReference<>("");
     private final AtomicLong pendingPartialVersion = new AtomicLong();
+    private final AtomicLong partialSequence = new AtomicLong();
+    private final RedisPublisher redisPublisher;
 
     public BotSttListener(long meetingId, String speakerDiscordId, String speakerName) {
         this(meetingId, speakerDiscordId, speakerName, null);
@@ -87,6 +89,16 @@ public class BotSttListener implements SttListener {
             String speakerName,
             MessageChannel captionChannel,
             Supplier<SessionQualitySnapshot> qualitySnapshotSupplier) {
+        this(meetingId, speakerDiscordId, speakerName, captionChannel, qualitySnapshotSupplier, null);
+    }
+
+    public BotSttListener(
+            long meetingId,
+            String speakerDiscordId,
+            String speakerName,
+            MessageChannel captionChannel,
+            Supplier<SessionQualitySnapshot> qualitySnapshotSupplier,
+            RedisPublisher redisPublisher) {
         this.meetingId = meetingId;
         this.speakerDiscordId = speakerDiscordId;
         this.speakerName = normalizeSpeakerName(speakerName, speakerDiscordId);
@@ -95,6 +107,7 @@ public class BotSttListener implements SttListener {
         this.captionChannel = captionChannel;
         this.qualitySnapshotSupplier =
                 qualitySnapshotSupplier == null ? SessionQualitySnapshot::empty : qualitySnapshotSupplier;
+        this.redisPublisher = redisPublisher;
     }
 
     @Override
@@ -260,6 +273,7 @@ public class BotSttListener implements SttListener {
                     String latest = pendingPartialText.getAndSet("");
                     if (latest != null && !latest.isBlank()) {
                         upsertLiveCaption(latest, false);
+                        publishPartialToRedis(latest);
                     }
                     pendingPartialTask.set(null);
                 },
@@ -268,6 +282,19 @@ public class BotSttListener implements SttListener {
 
         if (previous != null) {
             previous.cancel(false);
+        }
+    }
+
+    private void publishPartialToRedis(String text) {
+        if (redisPublisher == null) {
+            return;
+        }
+        try {
+            // TODO: meeting 종료 시 meetingId prefix key 일괄 제거 필요
+            long seq = partialSequence.incrementAndGet();
+            redisPublisher.publishPartial(meetingId, speakerDiscordId, speakerName, text, seq);
+        } catch (Exception e) {
+            log.warn("[Redis/partial전송실패] speakerId={}, meetingId={}, {}", speakerDiscordId, meetingId, e.getMessage());
         }
     }
 

--- a/src/main/java/com/flodiback/bot/stt/RedisPublisher.java
+++ b/src/main/java/com/flodiback/bot/stt/RedisPublisher.java
@@ -1,0 +1,73 @@
+package com.flodiback.bot.stt;
+
+import java.time.Instant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+public class RedisPublisher {
+    private static final Logger log = LoggerFactory.getLogger(RedisPublisher.class);
+
+    private final JedisPool jedisPool;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public RedisPublisher(String host, int port) {
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMaxTotal(8);
+        this.jedisPool = new JedisPool(config, host, port);
+        log.info("[Redis] publisher 초기화 완료: {}:{}", host, port);
+    }
+
+    public void publishPartial(
+            long meetingId, String speakerDiscordId, String speakerName, String text, long sequence) {
+        String payload =
+                buildPayload("caption.partial", meetingId, speakerDiscordId, speakerName, text, false, sequence);
+        if (payload == null) {
+            return;
+        }
+        publish("captions:meetings:" + meetingId, payload);
+    }
+
+    private void publish(String channel, String payload) {
+        try (var jedis = jedisPool.getResource()) {
+            jedis.publish(channel, payload);
+        } catch (Exception e) {
+            log.warn("[Redis] publish 실패: channel={}, {}", channel, e.getMessage());
+        }
+    }
+
+    private String buildPayload(
+            String type,
+            long meetingId,
+            String speakerDiscordId,
+            String speakerName,
+            String text,
+            boolean isFinal,
+            long sequence) {
+        try {
+            ObjectNode node = objectMapper.createObjectNode();
+            node.put("type", type);
+            node.put("meetingId", meetingId);
+            node.put("speakerDiscordId", speakerDiscordId);
+            node.put("speakerName", speakerName);
+            node.put("text", text);
+            node.put("isFinal", isFinal);
+            node.put("sequence", sequence);
+            node.put("sentAt", Instant.now().toString());
+            return objectMapper.writeValueAsString(node);
+        } catch (Exception e) {
+            log.warn("[Redis] payload 직렬화 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public void close() {
+        jedisPool.close();
+    }
+}

--- a/src/main/java/com/flodiback/domain/ai/service/DisabledAiChatService.java
+++ b/src/main/java/com/flodiback/domain/ai/service/DisabledAiChatService.java
@@ -1,12 +1,13 @@
 package com.flodiback.domain.ai.service;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 
+import com.flodiback.global.config.AiProviderCondition.DisabledProviderCondition;
 import com.flodiback.global.exception.ServiceException;
 
 @Service
-@ConditionalOnProperty(prefix = "glm", name = "enabled", havingValue = "false", matchIfMissing = true)
+@Conditional(DisabledProviderCondition.class)
 public class DisabledAiChatService implements AiChatService {
 
     @Override

--- a/src/main/java/com/flodiback/domain/ai/service/GlmAiChatService.java
+++ b/src/main/java/com/flodiback/domain/ai/service/GlmAiChatService.java
@@ -1,15 +1,16 @@
 package com.flodiback.domain.ai.service;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 
 import com.flodiback.global.client.GlmClient;
+import com.flodiback.global.config.AiProviderCondition.GlmProviderCondition;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@ConditionalOnProperty(prefix = "glm", name = "enabled", havingValue = "true")
+@Conditional(GlmProviderCondition.class)
 public class GlmAiChatService implements AiChatService {
 
     private final GlmClient glmClient;

--- a/src/main/java/com/flodiback/domain/ai/service/OpenAiChatService.java
+++ b/src/main/java/com/flodiback/domain/ai/service/OpenAiChatService.java
@@ -1,0 +1,22 @@
+package com.flodiback.domain.ai.service;
+
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Service;
+
+import com.flodiback.global.client.OpenAiChatClient;
+import com.flodiback.global.config.AiProviderCondition.OpenAiProviderCondition;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Conditional(OpenAiProviderCondition.class)
+public class OpenAiChatService implements AiChatService {
+
+    private final OpenAiChatClient openAiChatClient;
+
+    @Override
+    public String generateAnswer(String systemPrompt, String userQuestion) {
+        return openAiChatClient.chat(systemPrompt, userQuestion);
+    }
+}

--- a/src/main/java/com/flodiback/domain/decision/decision/entity/Decision.java
+++ b/src/main/java/com/flodiback/domain/decision/decision/entity/Decision.java
@@ -6,7 +6,6 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.project.project.entity.Project;
-import com.pgvector.PGvector;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -34,9 +33,6 @@ public class Decision {
 
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
-
-    @Column(name = "embedding", columnDefinition = "vector(1536)", insertable = false, updatable = false)
-    private PGvector embedding;
 
     @CreationTimestamp
     @Column(name = "decided_at", nullable = false, updatable = false)

--- a/src/main/java/com/flodiback/domain/decision/decision/repository/DecisionRepository.java
+++ b/src/main/java/com/flodiback/domain/decision/decision/repository/DecisionRepository.java
@@ -41,7 +41,7 @@ public interface DecisionRepository extends JpaRepository<Decision, Long> {
                         FROM semantic s
                         JOIN decisions d ON s.id = d.id
                     )
-                    SELECT d.*
+                    SELECT d.id, d.project_id, d.meeting_id, d.content, d.decided_at
                     FROM decisions d
                     JOIN combined c ON d.id = c.id
                     ORDER BY c.total_score DESC

--- a/src/main/java/com/flodiback/domain/meeting/meeting/dto/ActiveMeetingResponse.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/dto/ActiveMeetingResponse.java
@@ -1,0 +1,3 @@
+package com.flodiback.domain.meeting.meeting.dto;
+
+public record ActiveMeetingResponse(Long meetingId, String title) {}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/repository/MeetingRepository.java
@@ -9,11 +9,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.global.enums.MeetingStatus;
 
 import jakarta.persistence.LockModeType;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+
+    Optional<Meeting> findFirstByProjectAndStatusOrderByStartedAtDesc(Project project, MeetingStatus status);
 
     List<Meeting> findByStatus(MeetingStatus status);
 

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -1,11 +1,13 @@
 package com.flodiback.domain.meeting.meeting.service;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.flodiback.domain.meeting.meeting.dto.ActiveMeetingResponse;
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
 import com.flodiback.domain.meeting.meeting.dto.MeetingDetailResponse;
@@ -14,6 +16,7 @@ import com.flodiback.domain.meeting.meeting.event.MeetingEndedEvent;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.global.enums.MeetingStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -63,6 +66,15 @@ public class MeetingService {
                 meetingRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회의입니다."));
 
         return toDetailResponse(meeting);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ActiveMeetingResponse> getActiveMeeting(String channelId) {
+        return projectRepository
+                .findByChannelId(channelId)
+                .flatMap(project -> meetingRepository.findFirstByProjectAndStatusOrderByStartedAtDesc(
+                        project, MeetingStatus.IN_PROGRESS))
+                .map(meeting -> new ActiveMeetingResponse(meeting.getId(), meeting.getTitle()));
     }
 
     private MeetingDetailResponse toDetailResponse(Meeting meeting) {

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/entity/MeetingSummary.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/entity/MeetingSummary.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import org.hibernate.annotations.CreationTimestamp;
 
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
-import com.pgvector.PGvector;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -32,9 +31,6 @@ public class MeetingSummary {
 
     @Column(name = "unresolved_items", columnDefinition = "TEXT")
     private String unresolvedItems;
-
-    @Column(name = "embedding", columnDefinition = "vector(1536)", insertable = false, updatable = false)
-    private PGvector embedding;
 
     // boolean confirmed → Lombok이 isConfirmed() 생성
     @Column(name = "is_confirmed", nullable = false)

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/MeetingSummaryRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/MeetingSummaryRepository.java
@@ -18,7 +18,7 @@ public interface MeetingSummaryRepository extends JpaRepository<MeetingSummary, 
             @Param("projectId") Long projectId, @Param("currentMeetingId") Long currentMeetingId);
 
     @Query(value = """
-                    SELECT ms.*
+                    SELECT ms.id, ms.meeting_id, ms.summary, ms.unresolved_items, ms.is_confirmed, ms.created_at
                     FROM meeting_summaries ms
                     JOIN meetings m ON ms.meeting_id = m.id
                     WHERE m.project_id = :projectId
@@ -70,7 +70,7 @@ public interface MeetingSummaryRepository extends JpaRepository<MeetingSummary, 
                         FROM semantic s
                         JOIN meeting_summaries ms ON s.id = ms.id
                     )
-                    SELECT ms.*
+                    SELECT ms.id, ms.meeting_id, ms.summary, ms.unresolved_items, ms.is_confirmed, ms.created_at
                     FROM meeting_summaries ms
                     JOIN combined c ON ms.id = c.id
                     ORDER BY c.total_score DESC

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
@@ -14,4 +14,8 @@ public interface UtteranceRepository extends JpaRepository<Utterance, Long> {
     List<Utterance> findByMeetingOrderByIdAsc(Meeting meeting);
 
     List<Utterance> findByMeetingAndIdGreaterThanOrderByIdAsc(Meeting meeting, Long id);
+
+    List<Utterance> findTop30ByMeetingOrderByIdDesc(Meeting meeting);
+
+    List<Utterance> findTop30ByMeetingAndIdGreaterThanOrderByIdDesc(Meeting meeting, Long id);
 }

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryPersistenceService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryPersistenceService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -28,6 +29,7 @@ public class RollingSummaryPersistenceService {
     private final MeetingRepository meetingRepository;
     private final UtteranceRepository utteranceRepository;
     private final ContextCacheRepository contextCacheRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public Optional<CompressionCandidate> prepareCompression(Long meetingId) {
@@ -87,13 +89,24 @@ public class RollingSummaryPersistenceService {
             return;
         }
 
-        contextCacheRepository.save(ContextCache.builder()
+        ContextCache saved = contextCacheRepository.save(ContextCache.builder()
                 .meeting(meeting)
                 .version(candidate.nextVersion())
                 .compressedText(compressedText.strip())
                 .tokenCount(TokenEstimator.estimate(compressedText))
                 .compressedUntilUtteranceId(candidate.compressedUntilUtteranceId())
                 .build());
+
+        eventPublisher.publishEvent(
+                new RollingSummaryUpdatedEvent(candidate.meetingId(), saved.getCompressedText(), saved.getVersion()));
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<RollingSummarySnapshot> getLatestSummary(Long meetingId) {
+        return meetingRepository
+                .findById(meetingId)
+                .flatMap(meeting -> contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
+                .map(cache -> new RollingSummarySnapshot(meetingId, cache.getCompressedText(), cache.getVersion()));
     }
 
     @Transactional(readOnly = true)
@@ -152,6 +165,8 @@ public class RollingSummaryPersistenceService {
                 """);
         return prompt.toString();
     }
+
+    public record RollingSummarySnapshot(Long meetingId, String summary, Integer version) {}
 
     record CompressionCandidate(
             Long meetingId,

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryService.java
@@ -13,8 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RollingSummaryService {
 
-    static final int TOKEN_THRESHOLD = 3000;
-    static final int KEEP_TURNS = 20;
+    static final int TOKEN_THRESHOLD = 1800;
+    static final int KEEP_TURNS = 12;
 
     private static final String SYSTEM_PROMPT = """
             당신은 회의 내용을 압축하는 AI 요약기입니다.

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryUpdatedEvent.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryUpdatedEvent.java
@@ -1,0 +1,3 @@
+package com.flodiback.domain.meeting.meetinglog.rolling;
+
+public record RollingSummaryUpdatedEvent(Long meetingId, String summary, Integer version) {}

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/service/ContextService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/service/ContextService.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,9 +48,9 @@ public class ContextService {
 
     private static final double SEMANTIC_WEIGHT = 0.7;
     private static final double KEYWORD_WEIGHT = 0.3;
-    private static final int TOP_K = 5;
-    private static final int UNCOMPRESSED_TOKEN_BUDGET = 2000;
-    private static final int MIN_RECENT_UTTERANCE_COUNT = 20;
+    private static final int TOP_K = 3;
+    private static final int UNCOMPRESSED_TOKEN_BUDGET = 1200;
+    private static final int MIN_RECENT_UTTERANCE_COUNT = 10;
 
     private final MeetingRepository meetingRepository;
     private final UtteranceRepository utteranceRepository;
@@ -83,18 +84,37 @@ public class ContextService {
     }
 
     private ShortTermParts resolveShortTerm(Meeting meeting) {
+        long startedAtNanos = System.nanoTime();
         ContextCache latestCache = contextCacheRepository
                 .findTopByMeetingOrderByVersionDesc(meeting)
                 .orElse(null);
         if (latestCache == null) {
-            List<Utterance> utterances = utteranceRepository.findByMeetingOrderByIdAsc(meeting);
-            return new ShortTermParts(null, sortForPrompt(fitToTokenBudget(utterances)));
+            List<Utterance> fetched = utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting);
+            List<Utterance> recentUtterances = selectRecentUtterances(fetched);
+            logShortTerm(meeting.getId(), startedAtNanos, false, fetched.size(), recentUtterances.size());
+            return new ShortTermParts(null, recentUtterances);
         }
 
-        List<Utterance> utterancesAfterCache = utteranceRepository.findByMeetingAndIdGreaterThanOrderByIdAsc(
+        List<Utterance> fetched = utteranceRepository.findTop30ByMeetingAndIdGreaterThanOrderByIdDesc(
                 meeting, latestCache.getCompressedUntilUtteranceId());
-        return new ShortTermParts(
-                latestCache.getCompressedText(), sortForPrompt(fitToTokenBudget(utterancesAfterCache)));
+        List<Utterance> recentUtterances = selectRecentUtterances(fetched);
+        logShortTerm(meeting.getId(), startedAtNanos, true, fetched.size(), recentUtterances.size());
+        return new ShortTermParts(latestCache.getCompressedText(), recentUtterances);
+    }
+
+    private List<Utterance> selectRecentUtterances(List<Utterance> utterances) {
+        return fitToTokenBudget(sortForPrompt(utterances));
+    }
+
+    private void logShortTerm(
+            Long meetingId, long startedAtNanos, boolean hasCache, int fetchedUtterances, int selectedUtterances) {
+        log.info(
+                "shortTerm context resolved. meetingId={}, elapsedMs={}, hasCache={}, fetchedUtterances={}, selectedUtterances={}",
+                meetingId,
+                elapsedMillis(startedAtNanos),
+                hasCache,
+                fetchedUtterances,
+                selectedUtterances);
     }
 
     private List<Utterance> fitToTokenBudget(List<Utterance> utterances) {
@@ -182,8 +202,14 @@ public class ContextService {
 
         String embeddingStr;
         try {
+            long embeddingStartedAtNanos = System.nanoTime();
             float[] raw = embeddingClient.embed(question);
             embeddingStr = new PGvector(raw).getValue();
+            log.info(
+                    "questionContext embedding completed. projectId={}, meetingId={}, elapsedMs={}",
+                    projectId,
+                    meetingId,
+                    elapsedMillis(embeddingStartedAtNanos));
         } catch (Exception e) {
             log.warn(
                     "questionContext embedding failed, returning empty context - projectId={}: {}",
@@ -205,38 +231,65 @@ public class ContextService {
 
     private List<Decision> resolveDecisions(
             Long projectId, String question, String embeddingStr, MeetingStartContext startContext) {
+        long startedAtNanos = System.nanoTime();
         try {
             Set<Long> startDecisionIds = startContext.recentDecisions().stream()
-                    .map(decision -> decision.id())
+                    .map(DecisionSummary::id)
                     .filter(Objects::nonNull)
                     .collect(java.util.stream.Collectors.toSet());
-            return decisionRepository
-                    .hybridSearch(projectId, embeddingStr, question, TOP_K, SEMANTIC_WEIGHT, KEYWORD_WEIGHT)
-                    .stream()
-                    .filter(decision -> !startDecisionIds.contains(decision.getId()))
-                    .toList();
+            List<Decision> result =
+                    decisionRepository
+                            .hybridSearch(projectId, embeddingStr, question, TOP_K, SEMANTIC_WEIGHT, KEYWORD_WEIGHT)
+                            .stream()
+                            .filter(decision -> !startDecisionIds.contains(decision.getId()))
+                            .toList();
+            log.info(
+                    "questionContext decision search completed. projectId={}, elapsedMs={}, resultCount={}",
+                    projectId,
+                    elapsedMillis(startedAtNanos),
+                    result.size());
+            return result;
         } catch (Exception e) {
-            log.warn("하이브리드 서치 실패, questionContext 결정사항을 비웁니다 - projectId={}: {}", projectId, e.getMessage());
+            log.warn(
+                    "questionContext decision search failed, returning empty context - projectId={}: {}",
+                    projectId,
+                    e.getMessage());
             return Collections.emptyList();
         }
     }
 
     private List<MeetingSummary> resolvePastSummaries(
             Long projectId, Long meetingId, String question, String embeddingStr, MeetingStartContext startContext) {
+        long startedAtNanos = System.nanoTime();
         try {
             Set<Long> startSummaryIds = startContext.recentSummaries().stream()
-                    .map(summary -> summary.id())
+                    .map(PastSummary::id)
                     .filter(Objects::nonNull)
                     .collect(java.util.stream.Collectors.toSet());
-            return meetingSummaryRepository
+            List<MeetingSummary> result = meetingSummaryRepository
                     .hybridSearch(projectId, meetingId, embeddingStr, question, TOP_K, SEMANTIC_WEIGHT, KEYWORD_WEIGHT)
                     .stream()
                     .filter(summary -> !startSummaryIds.contains(summary.getId()))
                     .toList();
+            log.info(
+                    "questionContext summary search completed. projectId={}, meetingId={}, elapsedMs={}, resultCount={}",
+                    projectId,
+                    meetingId,
+                    elapsedMillis(startedAtNanos),
+                    result.size());
+            return result;
         } catch (Exception e) {
-            log.warn("회의 요약 하이브리드 서치 실패, questionContext 요약을 비웁니다 - projectId={}: {}", projectId, e.getMessage());
+            log.warn(
+                    "questionContext summary search failed, returning empty context - projectId={}, meetingId={}: {}",
+                    projectId,
+                    meetingId,
+                    e.getMessage());
             return Collections.emptyList();
         }
+    }
+
+    private long elapsedMillis(long startedAtNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAtNanos);
     }
 
     private record ShortTermParts(String rollingSummary, List<Utterance> recentUtterances) {}

--- a/src/main/java/com/flodiback/domain/speech/dto/AiAnswerEvent.java
+++ b/src/main/java/com/flodiback/domain/speech/dto/AiAnswerEvent.java
@@ -1,0 +1,26 @@
+package com.flodiback.domain.speech.dto;
+
+import java.time.LocalDateTime;
+
+public record AiAnswerEvent(
+        Long meetingId,
+        Long utteranceId,
+        String speakerDiscordId,
+        String question,
+        String answer,
+        AiAnswerStatus status,
+        long elapsedMs,
+        LocalDateTime createdAt) {
+
+    public static AiAnswerEvent of(
+            Long meetingId,
+            Long utteranceId,
+            String speakerDiscordId,
+            String question,
+            String answer,
+            AiAnswerStatus status,
+            long elapsedMs) {
+        return new AiAnswerEvent(
+                meetingId, utteranceId, speakerDiscordId, question, answer, status, elapsedMs, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/flodiback/domain/speech/dto/AiAnswerStatus.java
+++ b/src/main/java/com/flodiback/domain/speech/dto/AiAnswerStatus.java
@@ -1,0 +1,7 @@
+package com.flodiback.domain.speech.dto;
+
+public enum AiAnswerStatus {
+    PENDING,
+    COMPLETED,
+    FALLBACK
+}

--- a/src/main/java/com/flodiback/domain/speech/dto/CaptionEvent.java
+++ b/src/main/java/com/flodiback/domain/speech/dto/CaptionEvent.java
@@ -1,0 +1,25 @@
+package com.flodiback.domain.speech.dto;
+
+import java.time.Instant;
+
+public record CaptionEvent(
+        String type,
+        Long meetingId,
+        String speakerDiscordId,
+        String speakerName,
+        String text,
+        boolean isFinal,
+        long sequence,
+        Instant sentAt) {
+
+    public static CaptionEvent partial(
+            Long meetingId, String speakerDiscordId, String speakerName, String text, long sequence) {
+        return new CaptionEvent(
+                "caption.partial", meetingId, speakerDiscordId, speakerName, text, false, sequence, Instant.now());
+    }
+
+    public static CaptionEvent finalEvent(Long meetingId, String speakerDiscordId, String speakerName, String text) {
+        return new CaptionEvent(
+                "caption.final", meetingId, speakerDiscordId, speakerName, text, true, 0L, Instant.now());
+    }
+}

--- a/src/main/java/com/flodiback/domain/speech/service/AiAnswerWebSocketPublisher.java
+++ b/src/main/java/com/flodiback/domain/speech/service/AiAnswerWebSocketPublisher.java
@@ -1,0 +1,54 @@
+package com.flodiback.domain.speech.service;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.flodiback.domain.speech.dto.AiAnswerEvent;
+import com.flodiback.domain.speech.dto.AiAnswerStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AiAnswerWebSocketPublisher {
+
+    public static final String PENDING_ANSWER = "답변을 생성 중이에요. 완료되면 여기에 표시됩니다.";
+    public static final String FALLBACK_ANSWER = "지금은 답변 생성이 지연되고 있어요. 회의 내용은 저장해두었고, 잠시 후 다시 질문해 주세요.";
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void publishPending(
+            Long meetingId, Long utteranceId, String speakerDiscordId, String question, long elapsedMs) {
+        publish(meetingId, utteranceId, speakerDiscordId, question, PENDING_ANSWER, AiAnswerStatus.PENDING, elapsedMs);
+    }
+
+    public void publishCompleted(
+            Long meetingId, Long utteranceId, String speakerDiscordId, String question, String answer, long elapsedMs) {
+        publish(meetingId, utteranceId, speakerDiscordId, question, answer, AiAnswerStatus.COMPLETED, elapsedMs);
+    }
+
+    public void publishFallback(
+            Long meetingId, Long utteranceId, String speakerDiscordId, String question, long elapsedMs) {
+        publish(
+                meetingId,
+                utteranceId,
+                speakerDiscordId,
+                question,
+                FALLBACK_ANSWER,
+                AiAnswerStatus.FALLBACK,
+                elapsedMs);
+    }
+
+    private void publish(
+            Long meetingId,
+            Long utteranceId,
+            String speakerDiscordId,
+            String question,
+            String answer,
+            AiAnswerStatus status,
+            long elapsedMs) {
+        messagingTemplate.convertAndSend(
+                "/topic/meetings/" + meetingId + "/ai-answer",
+                AiAnswerEvent.of(meetingId, utteranceId, speakerDiscordId, question, answer, status, elapsedMs));
+    }
+}

--- a/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/InternalSpeechService.java
@@ -1,26 +1,44 @@
 package com.flodiback.domain.speech.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import com.flodiback.domain.speech.dto.InternalSpeechRequest;
 import com.flodiback.domain.speech.dto.InternalSpeechResponse;
 import com.flodiback.domain.speech.dto.SavedSpeechResult;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InternalSpeechService {
 
     private final SpeechPersistenceService speechPersistenceService;
     private final SpeechAiAnswerService speechAiAnswerService;
+    private final SpeechAiAnswerAsyncService speechAiAnswerAsyncService;
+    private final AiAnswerWebSocketPublisher aiAnswerWebSocketPublisher;
 
     public InternalSpeechResponse saveSpeech(InternalSpeechRequest request) {
         SavedSpeechResult savedSpeech = speechPersistenceService.saveUtterance(request);
 
-        // DB 저장 트랜잭션이 끝난 뒤 GLM을 호출해 DB 커넥션을 오래 잡지 않게 합니다.
-        String aiAnswer = speechAiAnswerService.generateAnswerIfCalled(savedSpeech.meetingId(), request.text());
+        String question = speechAiAnswerService.extractQuestion(request.text());
+        if (StringUtils.hasText(question)) {
+            try {
+                speechAiAnswerAsyncService.generateAndPublish(
+                        savedSpeech.meetingId(), savedSpeech.utteranceId(), request.speakerDiscordId(), question);
+            } catch (RuntimeException e) {
+                log.warn(
+                        "AI answer task rejected, fallback published. meetingId={}, utteranceId={}, reason={}",
+                        savedSpeech.meetingId(),
+                        savedSpeech.utteranceId(),
+                        e.getMessage());
+                aiAnswerWebSocketPublisher.publishFallback(
+                        savedSpeech.meetingId(), savedSpeech.utteranceId(), request.speakerDiscordId(), question, 0L);
+            }
+        }
 
-        return new InternalSpeechResponse(savedSpeech.utteranceId(), savedSpeech.meetingId(), aiAnswer);
+        return new InternalSpeechResponse(savedSpeech.utteranceId(), savedSpeech.meetingId(), null);
     }
 }

--- a/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerAsyncService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerAsyncService.java
@@ -1,0 +1,128 @@
+package com.flodiback.domain.speech.service;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class SpeechAiAnswerAsyncService {
+
+    private static final long PENDING_DELAY_SECONDS = 5L;
+
+    private final SpeechAiAnswerService speechAiAnswerService;
+    private final AiAnswerWebSocketPublisher publisher;
+
+    @Qualifier("pendingScheduler") private final ScheduledExecutorService pendingScheduler;
+
+    public SpeechAiAnswerAsyncService(
+            SpeechAiAnswerService speechAiAnswerService,
+            AiAnswerWebSocketPublisher publisher,
+            @Qualifier("pendingScheduler") ScheduledExecutorService pendingScheduler) {
+        this.speechAiAnswerService = speechAiAnswerService;
+        this.publisher = publisher;
+        this.pendingScheduler = pendingScheduler;
+    }
+
+    @Async("aiAnswerExecutor")
+    public void generateAndPublish(Long meetingId, Long utteranceId, String speakerDiscordId, String question) {
+        long startedAtNanos = System.nanoTime();
+        AtomicBoolean completed = new AtomicBoolean(false);
+        AtomicBoolean pendingPublished = new AtomicBoolean(false);
+        Object publishLock = new Object();
+
+        ScheduledFuture<?> pendingTask = pendingScheduler.schedule(
+                () -> publishPendingIfStillRunning(
+                        meetingId,
+                        utteranceId,
+                        speakerDiscordId,
+                        question,
+                        startedAtNanos,
+                        completed,
+                        pendingPublished,
+                        publishLock),
+                PENDING_DELAY_SECONDS,
+                TimeUnit.SECONDS);
+
+        try {
+            String answer = speechAiAnswerService.generateAnswer(meetingId, question);
+            pendingTask.cancel(false);
+            synchronized (publishLock) {
+                if (!completed.compareAndSet(false, true)) {
+                    return;
+                }
+                long elapsedMs = elapsedMillis(startedAtNanos);
+                if (StringUtils.hasText(answer)) {
+                    publisher.publishCompleted(
+                            meetingId, utteranceId, speakerDiscordId, question, answer.strip(), elapsedMs);
+                    log.info(
+                            "AI answer completed. meetingId={}, utteranceId={}, elapsedMs={}, pendingPublished={}",
+                            meetingId,
+                            utteranceId,
+                            elapsedMs,
+                            pendingPublished.get());
+                } else {
+                    publisher.publishFallback(meetingId, utteranceId, speakerDiscordId, question, elapsedMs);
+                    log.warn(
+                            "AI answer blank, fallback published. meetingId={}, utteranceId={}, elapsedMs={}, pendingPublished={}",
+                            meetingId,
+                            utteranceId,
+                            elapsedMs,
+                            pendingPublished.get());
+                }
+            }
+        } catch (RuntimeException e) {
+            pendingTask.cancel(false);
+            synchronized (publishLock) {
+                if (!completed.compareAndSet(false, true)) {
+                    return;
+                }
+                long elapsedMs = elapsedMillis(startedAtNanos);
+                publisher.publishFallback(meetingId, utteranceId, speakerDiscordId, question, elapsedMs);
+                log.warn(
+                        "AI answer failed, fallback published. meetingId={}, utteranceId={}, elapsedMs={}, pendingPublished={}, reason={}",
+                        meetingId,
+                        utteranceId,
+                        elapsedMs,
+                        pendingPublished.get(),
+                        e.getMessage());
+            }
+        }
+    }
+
+    private void publishPendingIfStillRunning(
+            Long meetingId,
+            Long utteranceId,
+            String speakerDiscordId,
+            String question,
+            long startedAtNanos,
+            AtomicBoolean completed,
+            AtomicBoolean pendingPublished,
+            Object publishLock) {
+        synchronized (publishLock) {
+            if (completed.get()) {
+                return;
+            }
+            long elapsedMs = elapsedMillis(startedAtNanos);
+            pendingPublished.set(true);
+            publisher.publishPending(meetingId, utteranceId, speakerDiscordId, question, elapsedMs);
+            log.info(
+                    "AI answer pending published. meetingId={}, utteranceId={}, elapsedMs={}",
+                    meetingId,
+                    utteranceId,
+                    elapsedMs);
+        }
+    }
+
+    private long elapsedMillis(long startedAtNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAtNanos);
+    }
+}

--- a/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
@@ -1,6 +1,7 @@
 package com.flodiback.domain.speech.service;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -23,39 +24,110 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SpeechAiAnswerService {
 
+    private static final int ROLLING_SUMMARY_MAX_CHARS = 800;
+    private static final int UNRESOLVED_ITEMS_MAX_CHARS = 400;
+    private static final int PROJECT_METADATA_MAX_CHARS = 300;
+    private static final int DECISION_CONTENT_MAX_CHARS = 250;
+    private static final int PAST_SUMMARY_MAX_CHARS = 400;
+    private static final int WORK_LOG_TASK_MAX_CHARS = 160;
+
     private static final String SYSTEM_PROMPT = """
             너는 Discord 회의에 참여하는 AI 회의 보조자야.
             항상 회의 컨텍스트를 먼저 확인하고 한국어로 2~3문장만 답해줘.
             회의 컨텍스트에 근거가 있으면 "[회의 기반]"으로 시작해 답해줘.
-            회의 컨텍스트에 답이 없거나 질문이 회의와 무관하면 "회의 내용에서는 해당 내용을 찾지 못했습니다."라고 먼저 말하고, 이어서 "[일반 지식 기반]"으로 네가 알고 있는 범위에서 간결하게 답해줘.
-            실제 웹 검색은 하지 않으므로 "웹에서 찾았다", "검색 결과에 따르면"처럼 외부 검색을 한 것처럼 말하지 마.
+            회의 컨텍스트에 답이 없거나 질문이 회의와 무관하면 "회의 내용에서는 해당 내용을 찾지 못했습니다."라고 먼저 말하고 이어서 "[일반 지식 기반]"으로 네가 알고 있는 범위에서 간결하게 답해줘.
+            실제 웹 검색은 하지 않으므로 "웹에서 찾아보니", "검색 결과에 따르면"처럼 외부 검색을 한 것처럼 말하지 마.
             """;
 
     private final ContextService contextService;
     private final AiChatService aiChatService;
 
-    public String generateAnswerIfCalled(Long meetingId, String speechText) {
-        String question = AssistantCallExtractor.extractQuestion(speechText);
-        if (!StringUtils.hasText(question)) {
-            return null;
-        }
-
+    public String generateAnswer(Long meetingId, String question) {
+        long totalStartedAtNanos = System.nanoTime();
+        long contextElapsedMs = -1L;
+        long promptElapsedMs = -1L;
+        long glmElapsedMs = -1L;
+        int promptChars = -1;
+        int recentUtteranceCount = -1;
+        int questionDecisionCount = -1;
+        int questionSummaryCount = -1;
         try {
-            ContextResponse context = contextService.assemble(meetingId, question);
-            String answer = aiChatService.generateAnswer(SYSTEM_PROMPT, buildUserPrompt(context, question));
+            long contextStartedAtNanos = System.nanoTime();
+            ContextResponse context;
+            try {
+                context = contextService.assemble(meetingId, question);
+            } finally {
+                contextElapsedMs = elapsedMillis(contextStartedAtNanos);
+            }
+
+            long promptStartedAtNanos = System.nanoTime();
+            String userPrompt;
+            try {
+                userPrompt = buildUserPrompt(context, question);
+            } finally {
+                promptElapsedMs = elapsedMillis(promptStartedAtNanos);
+            }
+            promptChars = userPrompt.length();
+            recentUtteranceCount = context.shortTerm().recentUtterances().size();
+            questionDecisionCount = context.questionContext().decisions().size();
+            questionSummaryCount = context.questionContext().pastSummaries().size();
+
+            log.info(
+                    "AI answer GLM call started. meetingId={}, promptChars={}, systemPromptChars={}, recentUtterances={}, questionDecisions={}, questionSummaries={}",
+                    meetingId,
+                    promptChars,
+                    SYSTEM_PROMPT.length(),
+                    recentUtteranceCount,
+                    questionDecisionCount,
+                    questionSummaryCount);
+
+            long glmStartedAtNanos = System.nanoTime();
+            String answer;
+            try {
+                answer = aiChatService.generateAnswer(SYSTEM_PROMPT, userPrompt);
+            } finally {
+                glmElapsedMs = elapsedMillis(glmStartedAtNanos);
+            }
+            long totalElapsedMs = elapsedMillis(totalStartedAtNanos);
+
+            log.info(
+                    "AI answer generated. meetingId={}, totalMs={}, contextMs={}, promptMs={}, glmMs={}, promptChars={}, recentUtterances={}, questionDecisions={}, questionSummaries={}",
+                    meetingId,
+                    totalElapsedMs,
+                    contextElapsedMs,
+                    promptElapsedMs,
+                    glmElapsedMs,
+                    promptChars,
+                    recentUtteranceCount,
+                    questionDecisionCount,
+                    questionSummaryCount);
+
             return StringUtils.hasText(answer) ? answer.strip() : null;
         } catch (RuntimeException e) {
-            // STT 원문 저장이 더 중요하므로 AI 답변 실패는 응답만 비우고 회의록 흐름은 유지합니다.
-            log.warn("AI 답변 생성에 실패했습니다. meetingId={}, reason={}", meetingId, e.getMessage());
+            log.warn(
+                    "AI answer generation failed. meetingId={}, totalMs={}, contextMs={}, promptMs={}, glmMs={}, promptChars={}, recentUtterances={}, questionDecisions={}, questionSummaries={}, exceptionType={}, reason={}",
+                    meetingId,
+                    elapsedMillis(totalStartedAtNanos),
+                    contextElapsedMs,
+                    promptElapsedMs,
+                    glmElapsedMs,
+                    promptChars,
+                    recentUtteranceCount,
+                    questionDecisionCount,
+                    questionSummaryCount,
+                    e.getClass().getSimpleName(),
+                    e.getMessage());
             return null;
         }
     }
 
+    public String extractQuestion(String speechText) {
+        return AssistantCallExtractor.extractQuestion(speechText);
+    }
+
     private String buildUserPrompt(ContextResponse context, String question) {
-        // GLM이 회의 맥락을 함께 읽을 수 있도록 컨텍스트를 섹션별 텍스트로 정리합니다.
         StringBuilder prompt = new StringBuilder();
 
-        // 회의 맥락을 우선하되, 근거가 없으면 일반 지식 답변임을 표시하게 합니다.
         prompt.append("[답변 규칙]\n");
         prompt.append("- 회의 컨텍스트에 답이 있으면 [회의 기반]으로 답변\n");
         prompt.append("- 회의 컨텍스트에 답이 없거나 무관하면 회의 내용에 없다고 밝힌 뒤 [일반 지식 기반]으로 답변\n");
@@ -82,7 +154,9 @@ public class SpeechAiAnswerService {
     private void appendMeetingStartContext(StringBuilder prompt, MeetingStartContext context) {
         prompt.append("프로젝트명: ").append(valueOrNone(context.projectName())).append("\n");
         prompt.append("기술 스택: ").append(valueOrNone(context.techStack())).append("\n");
-        prompt.append("메타데이터: ").append(valueOrNone(context.metadata())).append("\n");
+        prompt.append("메타데이터: ")
+                .append(valueOrNone(truncate(context.metadata(), PROJECT_METADATA_MAX_CHARS)))
+                .append("\n");
 
         prompt.append("\n최근 결정사항:\n");
         appendDecisions(prompt, context.recentDecisions());
@@ -90,8 +164,8 @@ public class SpeechAiAnswerService {
         prompt.append("\n최근 회의 요약:\n");
         appendPastSummaries(prompt, context.recentSummaries());
 
-        prompt.append("\n미결 사항:\n");
-        appendTextBlock(prompt, context.unresolvedItems());
+        prompt.append("\n미해결 사항:\n");
+        appendTextBlock(prompt, truncate(context.unresolvedItems(), UNRESOLVED_ITEMS_MAX_CHARS));
 
         prompt.append("\n진행 중 작업:\n");
         appendWorkLogs(prompt, context.activeWorkLogs());
@@ -106,30 +180,26 @@ public class SpeechAiAnswerService {
     }
 
     private void appendDecisions(StringBuilder prompt, List<DecisionSummary> decisions) {
-        // 기존 결정사항은 프로젝트의 장기 기억으로, 회의 중 재확인 질문에 쓰입니다.
         if (decisions == null || decisions.isEmpty()) {
-            // 섹션을 비워두지 않고 "없음"을 넣어 GLM이 누락으로 오해하지 않게 합니다.
             prompt.append("- 없음\n");
             return;
         }
 
         decisions.forEach(decision -> prompt.append("- ")
-                .append(decision.content())
+                .append(truncate(decision.content(), DECISION_CONTENT_MAX_CHARS))
                 .append(" (")
                 .append(decision.decidedAt())
                 .append(")\n"));
     }
 
     private void appendPastSummaries(StringBuilder prompt, List<PastSummary> pastSummaries) {
-        // 과거 회의 요약은 현재 회의 이전에 정해진 맥락을 보충합니다.
         if (pastSummaries == null || pastSummaries.isEmpty()) {
-            // 과거 요약이 없는 경우에도 프롬프트 구조를 일정하게 유지합니다.
             prompt.append("- 없음\n");
             return;
         }
 
         pastSummaries.forEach(summary -> prompt.append("- ")
-                .append(summary.summary())
+                .append(truncate(summary.summary(), PAST_SUMMARY_MAX_CHARS))
                 .append(" (")
                 .append(summary.createdAt())
                 .append(")\n"));
@@ -140,13 +210,12 @@ public class SpeechAiAnswerService {
             prompt.append("- 없음\n");
             return;
         }
-        prompt.append(rollingSummary.strip()).append("\n");
+        prompt.append(truncate(rollingSummary, ROLLING_SUMMARY_MAX_CHARS).strip())
+                .append("\n");
     }
 
     private void appendRecentUtterances(StringBuilder prompt, List<UtteranceSummary> recentUtterances) {
-        // 최근 발화는 방금 진행 중인 회의의 단기 맥락으로 사용합니다.
         if (recentUtterances == null || recentUtterances.isEmpty()) {
-            // 최근 대화가 없어도 섹션 의미가 드러나도록 "없음"을 명시합니다.
             prompt.append("- 없음\n");
             return;
         }
@@ -173,7 +242,7 @@ public class SpeechAiAnswerService {
         }
 
         workLogs.forEach(workLog -> prompt.append("- ")
-                .append(workLog.task())
+                .append(truncate(workLog.task(), WORK_LOG_TASK_MAX_CHARS))
                 .append(" / 담당자: ")
                 .append(valueOrNone(workLog.assigneeName()))
                 .append(" / 기한: ")
@@ -184,7 +253,18 @@ public class SpeechAiAnswerService {
     }
 
     private String valueOrNone(String value) {
-        // 값이 비어 있으면 프롬프트에 null 대신 "없음"을 넣어 읽기 쉽게 만듭니다.
         return StringUtils.hasText(value) ? value : "없음";
+    }
+
+    private String truncate(String value, int maxChars) {
+        if (!StringUtils.hasText(value)) {
+            return value;
+        }
+        String stripped = value.strip();
+        return stripped.length() <= maxChars ? stripped : stripped.substring(0, maxChars) + "...";
+    }
+
+    private long elapsedMillis(long startedAtNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAtNanos);
     }
 }

--- a/src/main/java/com/flodiback/global/client/OpenAiChatClient.java
+++ b/src/main/java/com/flodiback/global/client/OpenAiChatClient.java
@@ -6,8 +6,10 @@ import java.util.function.Function;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
+import com.flodiback.global.config.AiProviderCondition.OpenAiProviderCondition;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.errors.OpenAIServiceException;
@@ -18,7 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-public class GlmClient {
+@Conditional(OpenAiProviderCondition.class)
+public class OpenAiChatClient {
 
     private final Function<ChatCompletionCreateParams, ChatCompletion> completionRequester;
     private final String model;
@@ -26,20 +29,20 @@ public class GlmClient {
     private final int maxRetries;
 
     @Autowired
-    public GlmClient(
-            @Value("${glm.api.key}") String apiKey,
-            @Value("${glm.api.model}") String model,
-            @Value("${glm.api.url}") String apiUrl,
-            @Value("${glm.api.timeout-ms:30000}") long timeoutMs,
-            @Value("${glm.api.max-retries:1}") int maxRetries) {
-        this(model, timeoutMs, maxRetries, createCompletionRequester(apiKey, apiUrl, timeoutMs, maxRetries));
+    public OpenAiChatClient(
+            @Value("${openai.api-key}") String apiKey,
+            @Value("${openai.chat.model}") String model,
+            @Value("${openai.chat.base-url}") String baseUrl,
+            @Value("${openai.chat.timeout-ms:30000}") long timeoutMs,
+            @Value("${openai.chat.max-retries:0}") int maxRetries) {
+        this(model, timeoutMs, maxRetries, createCompletionRequester(apiKey, baseUrl, timeoutMs, maxRetries));
     }
 
-    GlmClient(String model, Function<ChatCompletionCreateParams, ChatCompletion> completionRequester) {
+    OpenAiChatClient(String model, Function<ChatCompletionCreateParams, ChatCompletion> completionRequester) {
         this(model, -1L, -1, completionRequester);
     }
 
-    GlmClient(
+    OpenAiChatClient(
             String model,
             long timeoutMs,
             int maxRetries,
@@ -51,16 +54,16 @@ public class GlmClient {
     }
 
     private static Function<ChatCompletionCreateParams, ChatCompletion> createCompletionRequester(
-            String apiKey, String apiUrl, long timeoutMs, int maxRetries) {
+            String apiKey, String baseUrl, long timeoutMs, int maxRetries) {
         log.info(
-                "GLM client initialized. url={}, keyLength={}, timeoutMs={}, maxRetries={}",
-                apiUrl,
+                "OpenAI chat client initialized. url={}, keyLength={}, timeoutMs={}, maxRetries={}",
+                baseUrl,
                 apiKey.length(),
                 timeoutMs,
                 maxRetries);
         OpenAIClient client = OpenAIOkHttpClient.builder()
                 .apiKey(apiKey)
-                .baseUrl(apiUrl)
+                .baseUrl(baseUrl)
                 .timeout(Duration.ofMillis(timeoutMs))
                 .maxRetries(maxRetries)
                 .build();
@@ -81,14 +84,14 @@ public class GlmClient {
             int choiceCount = completion.choices().size();
 
             if (choiceCount == 0) {
-                throw new IllegalStateException("GLM response has no choices.");
+                throw new IllegalStateException("OpenAI response has no choices.");
             }
 
             ChatCompletion.Choice firstChoice = completion.choices().get(0);
             String content = firstChoice.message().content().orElse("");
             long latencyMs = elapsedMillis(startedAtNanos);
             log.info(
-                    "GLM call succeeded. model={}, timeoutMs={}, maxRetries={}, latencyMs={}, choiceCount={}, finishReason={}, responseChars={}",
+                    "OpenAI chat call succeeded. model={}, timeoutMs={}, maxRetries={}, latencyMs={}, choiceCount={}, finishReason={}, responseChars={}",
                     model,
                     timeoutMs,
                     maxRetries,
@@ -104,7 +107,7 @@ public class GlmClient {
 
             if (e instanceof OpenAIServiceException serviceException) {
                 log.warn(
-                        "GLM call failed. model={}, timeoutMs={}, maxRetries={}, latencyMs={}, exceptionType={}, message={}, rootCauseType={}, rootCauseMessage={}, statusCode={}, errorType={}, errorCode={}, errorParam={}, errorBodyPreview={}",
+                        "OpenAI chat call failed. model={}, timeoutMs={}, maxRetries={}, latencyMs={}, exceptionType={}, message={}, rootCauseType={}, rootCauseMessage={}, statusCode={}, errorType={}, errorCode={}, errorParam={}, errorBodyPreview={}",
                         model,
                         timeoutMs,
                         maxRetries,
@@ -120,7 +123,7 @@ public class GlmClient {
                         preview(serviceException.body().toString(), 500));
             } else {
                 log.warn(
-                        "GLM call failed. model={}, timeoutMs={}, maxRetries={}, latencyMs={}, exceptionType={}, message={}, rootCauseType={}, rootCauseMessage={}",
+                        "OpenAI chat call failed. model={}, timeoutMs={}, maxRetries={}, latencyMs={}, exceptionType={}, message={}, rootCauseType={}, rootCauseMessage={}",
                         model,
                         timeoutMs,
                         maxRetries,

--- a/src/main/java/com/flodiback/global/config/AiProviderCondition.java
+++ b/src/main/java/com/flodiback/global/config/AiProviderCondition.java
@@ -1,0 +1,53 @@
+package com.flodiback.global.config;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+public final class AiProviderCondition {
+
+    private static final String PROVIDER_PROPERTY = "ai.provider";
+    private static final String GLM_ENABLED_PROPERTY = "glm.enabled";
+    private static final String OPENAI_PROVIDER = "openai";
+    private static final String GLM_PROVIDER = "glm";
+    private static final String DISABLED_PROVIDER = "disabled";
+
+    private AiProviderCondition() {}
+
+    public static final class OpenAiProviderCondition implements Condition {
+
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            return OPENAI_PROVIDER.equalsIgnoreCase(provider(context));
+        }
+    }
+
+    public static final class GlmProviderCondition implements Condition {
+
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            String provider = provider(context);
+            if (StringUtils.hasText(provider)) {
+                return GLM_PROVIDER.equalsIgnoreCase(provider);
+            }
+            return Boolean.parseBoolean(context.getEnvironment().getProperty(GLM_ENABLED_PROPERTY, "false"));
+        }
+    }
+
+    public static final class DisabledProviderCondition implements Condition {
+
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            String provider = provider(context);
+            if (StringUtils.hasText(provider)) {
+                return DISABLED_PROVIDER.equalsIgnoreCase(provider);
+            }
+            return !Boolean.parseBoolean(context.getEnvironment().getProperty(GLM_ENABLED_PROPERTY, "false"));
+        }
+    }
+
+    private static String provider(ConditionContext context) {
+        return context.getEnvironment().getProperty(PROVIDER_PROPERTY, "");
+    }
+}

--- a/src/main/java/com/flodiback/global/config/AsyncConfig.java
+++ b/src/main/java/com/flodiback/global/config/AsyncConfig.java
@@ -1,12 +1,16 @@
 package com.flodiback.global.config;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Configuration
 @EnableAsync
 public class AsyncConfig {
@@ -18,6 +22,25 @@ public class AsyncConfig {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(10);
         executor.setThreadNamePrefix("analysis-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(name = "aiAnswerExecutor")
+    public Executor aiAnswerExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("ai-answer-");
+        executor.setRejectedExecutionHandler((runnable, poolExecutor) -> {
+            ThreadPoolExecutor pool = (ThreadPoolExecutor) poolExecutor;
+            log.warn(
+                    "AI answer task rejected. activeCount={}, queueSize={}",
+                    pool.getActiveCount(),
+                    pool.getQueue().size());
+            throw new java.util.concurrent.RejectedExecutionException("AI answer task rejected");
+        });
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/flodiback/global/config/RedisSubscriberConfig.java
+++ b/src/main/java/com/flodiback/global/config/RedisSubscriberConfig.java
@@ -1,0 +1,22 @@
+package com.flodiback.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import com.flodiback.global.websocket.CaptionRedisSubscriber;
+
+@Configuration
+public class RedisSubscriberConfig {
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory, CaptionRedisSubscriber subscriber) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(subscriber, new PatternTopic("captions:meetings:*"));
+        return container;
+    }
+}

--- a/src/main/java/com/flodiback/global/config/RedisSubscriberConfig.java
+++ b/src/main/java/com/flodiback/global/config/RedisSubscriberConfig.java
@@ -1,5 +1,6 @@
 package com.flodiback.global.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -9,6 +10,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import com.flodiback.global.websocket.CaptionRedisSubscriber;
 
 @Configuration
+@ConditionalOnProperty(name = "app.redis.captions-enabled", havingValue = "true", matchIfMissing = true)
 public class RedisSubscriberConfig {
 
     @Bean

--- a/src/main/java/com/flodiback/global/config/SchedulingConfig.java
+++ b/src/main/java/com/flodiback/global/config/SchedulingConfig.java
@@ -1,10 +1,12 @@
 package com.flodiback.global.config;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -12,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
-@EnableAsync
 @EnableScheduling
 public class SchedulingConfig {
 
@@ -33,5 +34,16 @@ public class SchedulingConfig {
         });
         executor.initialize();
         return executor;
+    }
+
+    @Bean(name = "pendingScheduler", destroyMethod = "shutdown")
+    public ScheduledExecutorService pendingScheduler() {
+        AtomicInteger threadNo = new AtomicInteger(1);
+        return Executors.newScheduledThreadPool(1, runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("ai-pending-" + threadNo.getAndIncrement());
+            thread.setDaemon(true);
+            return thread;
+        });
     }
 }

--- a/src/main/java/com/flodiback/global/config/WebSocketConfig.java
+++ b/src/main/java/com/flodiback/global/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.flodiback.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Value("${app.cors.allowed-origins:http://localhost:5173}")
+    private String[] allowedOrigins;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns(allowedOrigins);
+    }
+}

--- a/src/main/java/com/flodiback/global/embedding/OpenAiEmbeddingClient.java
+++ b/src/main/java/com/flodiback/global/embedding/OpenAiEmbeddingClient.java
@@ -1,9 +1,11 @@
 package com.flodiback.global.embedding;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -17,8 +19,13 @@ public class OpenAiEmbeddingClient {
     private final RestClient restClient;
 
     public OpenAiEmbeddingClient(@Value("${openai.embedding.api-key}") String apiKey) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(3));
+        requestFactory.setReadTimeout(Duration.ofSeconds(5));
+
         this.restClient = RestClient.builder()
                 .baseUrl("https://api.openai.com/v1")
+                .requestFactory(requestFactory)
                 .defaultHeader("Authorization", "Bearer " + apiKey)
                 .defaultHeader("Content-Type", "application/json")
                 .build();

--- a/src/main/java/com/flodiback/global/websocket/CaptionRedisSubscriber.java
+++ b/src/main/java/com/flodiback/global/websocket/CaptionRedisSubscriber.java
@@ -1,0 +1,33 @@
+package com.flodiback.global.websocket;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flodiback.domain.speech.dto.CaptionEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CaptionRedisSubscriber implements MessageListener {
+
+    private static final Logger log = LoggerFactory.getLogger(CaptionRedisSubscriber.class);
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            CaptionEvent event = objectMapper.readValue(message.getBody(), CaptionEvent.class);
+            messagingTemplate.convertAndSend("/topic/meetings/" + event.meetingId() + "/captions", event);
+        } catch (Exception e) {
+            log.warn("caption Redis 메시지 처리 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/flodiback/global/websocket/ContextSummaryWebSocketPublisher.java
+++ b/src/main/java/com/flodiback/global/websocket/ContextSummaryWebSocketPublisher.java
@@ -1,0 +1,26 @@
+package com.flodiback.global.websocket;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.flodiback.domain.meeting.meetinglog.rolling.RollingSummaryUpdatedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ContextSummaryWebSocketPublisher {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onRollingSummaryUpdated(RollingSummaryUpdatedEvent event) {
+        messagingTemplate.convertAndSend(
+                "/topic/meetings/" + event.meetingId() + "/context",
+                new ContextSummaryMessage(event.meetingId(), event.summary(), event.version()));
+    }
+
+    record ContextSummaryMessage(Long meetingId, String summary, Integer version) {}
+}

--- a/src/main/java/com/flodiback/global/websocket/MeetingStatusWebSocketPublisher.java
+++ b/src/main/java/com/flodiback/global/websocket/MeetingStatusWebSocketPublisher.java
@@ -1,0 +1,26 @@
+package com.flodiback.global.websocket;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.flodiback.domain.meeting.meeting.event.MeetingEndedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MeetingStatusWebSocketPublisher {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onMeetingEnded(MeetingEndedEvent event) {
+        messagingTemplate.convertAndSend(
+                "/topic/meetings/" + event.meetingId() + "/status",
+                new MeetingStatusMessage("meeting.ended", event.meetingId()));
+    }
+
+    record MeetingStatusMessage(String type, Long meetingId) {}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,6 +8,7 @@ spring:
     driver-class-name: org.postgresql.Driver
 
   jpa:
+    show-sql: false
     hibernate:
       ddl-auto: validate
     properties:
@@ -15,6 +16,10 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
 
-glm:
-  # 실제 GLM 호출은 .env에서 GLM_ENABLED=true로 켰을 때만 사용합니다.
-  enabled: ${GLM_ENABLED:false}
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: INFO
+    org.hibernate.orm.jdbc.extract: INFO
+    org.springframework.transaction.interceptor: INFO
+    com.back: INFO
+    org.springframework.security: INFO

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,7 @@
+logging:
+  level:
+    org.hibernate.SQL: INFO
+    org.hibernate.orm.jdbc.bind: INFO
+    org.hibernate.orm.jdbc.extract: INFO
+    org.springframework.transaction.interceptor: INFO
+    org.springframework.security: INFO

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -2,6 +2,10 @@ glm:
   # 테스트에서는 외부 GLM 키 없이 컨텍스트가 뜨도록 채팅 기능을 끕니다.
   enabled: false
 
+app:
+  redis:
+    captions-enabled: false
+
 spring:
   jpa:
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,9 +24,8 @@ spring:
     serialization:
       fail-on-empty-beans: false
   jpa:
-    show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
@@ -42,8 +41,16 @@ app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
 
+ai:
+  provider: ${AI_PROVIDER:}
+
 openai:
   api-key: ${OPENAI_API_KEY}
+  chat:
+    model: ${OPENAI_CHAT_MODEL:gpt-4o-mini}
+    base-url: ${OPENAI_CHAT_BASE_URL:https://api.openai.com/v1}
+    timeout-ms: ${OPENAI_CHAT_TIMEOUT_MS:30000}
+    max-retries: ${OPENAI_CHAT_MAX_RETRIES:0}
   embedding:
     api-key: ${OPENAI_EMBEDDING_API_KEY:}
 glm:
@@ -53,14 +60,7 @@ glm:
     model: ${GLM_MODEL:glm-5.1}
     url: ${GLM_API_URL:https://api.z.ai/api}
     timeout-ms: ${GLM_TIMEOUT_MS:30000}
-    max-retries: ${GLM_MAX_RETRIES:1}
+    max-retries: ${GLM_MAX_RETRIES:0}
 
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8
-logging:
-  level:
-    org.hibernate.orm.jdbc.bind: TRACE
-    org.hibernate.orm.jdbc.extract: TRACE
-    org.springframework.transaction.interceptor: TRACE
-    com.back: TRACE
-    org.springframework.security: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,10 @@ spring:
     baseline-version: 1
     locations: classpath:db/migration
 
+app:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
+
 openai:
   api-key: ${OPENAI_API_KEY}
   embedding:

--- a/src/test/java/com/flodiback/api/speech/InternalSpeechControllerTest.java
+++ b/src/test/java/com/flodiback/api/speech/InternalSpeechControllerTest.java
@@ -2,9 +2,8 @@ package com.flodiback.api.speech;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -27,6 +26,8 @@ import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
 import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
 import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.speech.service.AiAnswerWebSocketPublisher;
+import com.flodiback.domain.speech.service.SpeechAiAnswerAsyncService;
 import com.flodiback.domain.speech.service.SpeechAiAnswerService;
 import com.flodiback.global.enums.MeetingStatus;
 import com.flodiback.support.AbstractPostgresIntegrationTest;
@@ -50,11 +51,16 @@ class InternalSpeechControllerTest extends AbstractPostgresIntegrationTest {
     @MockitoBean
     private SpeechAiAnswerService speechAiAnswerService;
 
+    @MockitoBean
+    private SpeechAiAnswerAsyncService speechAiAnswerAsyncService;
+
+    @MockitoBean
+    private AiAnswerWebSocketPublisher aiAnswerWebSocketPublisher;
+
     private Meeting meeting;
 
     @BeforeEach
     void setUp() {
-        // 발화 저장 테스트를 위해 최소 프로젝트와 회의를 먼저 만든다.
         Project project = Project.builder()
                 .name("Flodi")
                 .description("Discord AI 회의 에이전트")
@@ -73,16 +79,7 @@ class InternalSpeechControllerTest extends AbstractPostgresIntegrationTest {
 
     @Test
     void receiveSpeech_savesUtteranceFromSnakeCaseRequest() throws Exception {
-        String requestBody = """
-                {
-                  "meeting_id": %d,
-                  "speaker_discord_id": "123456789",
-                  "speaker_name": "김철수",
-                  "text": "이번 스프린트 목표를 어떻게 잡을까요?",
-                  "speech_started_at": "2026-04-23T10:30:00",
-                  "speech_ended_at": "2026-04-23T10:30:05"
-                }
-                """.formatted(meeting.getId());
+        String requestBody = requestBody("이번 스프린트 목표를 어떻게 잡을까요?");
 
         mockMvc.perform(post("/internal/v1/speech")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -125,16 +122,7 @@ class InternalSpeechControllerTest extends AbstractPostgresIntegrationTest {
 
     @Test
     void receiveSpeech_returnsBadRequest_whenRequiredTextIsBlank() throws Exception {
-        String requestBody = """
-                {
-                  "meeting_id": %d,
-                  "speaker_discord_id": "123456789",
-                  "speaker_name": "김철수",
-                  "text": "",
-                  "speech_started_at": "2026-04-23T10:30:00",
-                  "speech_ended_at": "2026-04-23T10:30:05"
-                }
-                """.formatted(meeting.getId());
+        String requestBody = requestBody("");
 
         mockMvc.perform(post("/internal/v1/speech")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -144,82 +132,55 @@ class InternalSpeechControllerTest extends AbstractPostgresIntegrationTest {
     }
 
     @Test
-    void receiveSpeech_returnsAiAnswer_whenWakeWordIsIncluded() throws Exception {
-        given(speechAiAnswerService.generateAnswerIfCalled(anyLong(), anyString()))
-                .willReturn("인증 방식은 JWT로 결정했습니다.");
-
-        String requestBody = """
-                {
-                  "meeting_id": %d,
-                  "speaker_discord_id": "123456789",
-                  "speaker_name": "김철수",
-                  "text": "AI야, 인증 방식 뭐로 하기로 했지?",
-                  "speech_started_at": "2026-04-23T10:30:00",
-                  "speech_ended_at": "2026-04-23T10:30:05"
-                }
-                """.formatted(meeting.getId());
+    void receiveSpeech_triggersAsyncAiAnswer_whenWakeWordIsIncluded() throws Exception {
+        given(speechAiAnswerService.extractQuestion("AI야 인증 방식 뭐로 하기로 했어?")).willReturn("인증 방식 뭐로 하기로 했어?");
 
         mockMvc.perform(post("/internal/v1/speech")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .content(requestBody("AI야 인증 방식 뭐로 하기로 했어?")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
-                .andExpect(jsonPath("$.data.ai_answer").value("인증 방식은 JWT로 결정했습니다."));
+                .andExpect(jsonPath("$.data.ai_answer").value(nullValue()));
 
         List<Utterance> utterances = utteranceRepository.findAll();
         assertThat(utterances).hasSize(1);
-        assertThat(utterances.get(0).getContent()).isEqualTo("AI야, 인증 방식 뭐로 하기로 했지?");
-        verify(speechAiAnswerService).generateAnswerIfCalled(meeting.getId(), "AI야, 인증 방식 뭐로 하기로 했지?");
+        assertThat(utterances.get(0).getContent()).isEqualTo("AI야 인증 방식 뭐로 하기로 했어?");
+        verify(speechAiAnswerAsyncService)
+                .generateAndPublish(meeting.getId(), utterances.get(0).getId(), "123456789", "인증 방식 뭐로 하기로 했어?");
     }
 
     @Test
     void receiveSpeech_savesOnly_whenWakeWordHasNoQuestion() throws Exception {
-        String requestBody = """
-                {
-                  "meeting_id": %d,
-                  "speaker_discord_id": "123456789",
-                  "speaker_name": "김철수",
-                  "text": "AI야",
-                  "speech_started_at": "2026-04-23T10:30:00",
-                  "speech_ended_at": "2026-04-23T10:30:05"
-                }
-                """.formatted(meeting.getId());
+        given(speechAiAnswerService.extractQuestion("AI야!")).willReturn(null);
 
         mockMvc.perform(post("/internal/v1/speech")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
+                        .content(requestBody("AI야!")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
                 .andExpect(jsonPath("$.data.ai_answer").value(nullValue()));
 
         List<Utterance> utterances = utteranceRepository.findAll();
         assertThat(utterances).hasSize(1);
-        assertThat(utterances.get(0).getContent()).isEqualTo("AI야");
+        assertThat(utterances.get(0).getContent()).isEqualTo("AI야!");
+        verify(speechAiAnswerAsyncService, never())
+                .generateAndPublish(
+                        org.mockito.ArgumentMatchers.anyLong(),
+                        org.mockito.ArgumentMatchers.anyLong(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString());
     }
 
-    @Test
-    void receiveSpeech_savesSpeech_whenAiAnswerIsNull() throws Exception {
-        String requestBody = """
+    private String requestBody(String text) {
+        return """
                 {
                   "meeting_id": %d,
                   "speaker_discord_id": "123456789",
                   "speaker_name": "김철수",
-                  "text": "봇아, 토큰 만료 시간 정했어?",
+                  "text": "%s",
                   "speech_started_at": "2026-04-23T10:30:00",
                   "speech_ended_at": "2026-04-23T10:30:05"
                 }
-                """.formatted(meeting.getId());
-
-        mockMvc.perform(post("/internal/v1/speech")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value("200-1"))
-                .andExpect(jsonPath("$.data.ai_answer").value(nullValue()));
-
-        List<Utterance> utterances = utteranceRepository.findAll();
-        assertThat(utterances).hasSize(1);
-        assertThat(utterances.get(0).getContent()).isEqualTo("봇아, 토큰 만료 시간 정했어?");
-        verify(speechAiAnswerService).generateAnswerIfCalled(meeting.getId(), "봇아, 토큰 만료 시간 정했어?");
+                """.formatted(meeting.getId(), text);
     }
 }

--- a/src/test/java/com/flodiback/domain/ai/service/OpenAiChatServiceTest.java
+++ b/src/test/java/com/flodiback/domain/ai/service/OpenAiChatServiceTest.java
@@ -1,0 +1,33 @@
+package com.flodiback.domain.ai.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.flodiback.global.client.OpenAiChatClient;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAiChatServiceTest {
+
+    @Mock
+    private OpenAiChatClient openAiChatClient;
+
+    @InjectMocks
+    private OpenAiChatService openAiChatService;
+
+    @Test
+    void generateAnswer_delegatesToOpenAiChatClient() {
+        given(openAiChatClient.chat("system", "user")).willReturn("answer");
+
+        String result = openAiChatService.generateAnswer("system", "user");
+
+        assertThat(result).isEqualTo("answer");
+        verify(openAiChatClient).chat("system", "user");
+    }
+}

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryPersistenceServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryPersistenceServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.flodiback.domain.meeting.meeting.entity.ContextCache;
@@ -40,11 +41,15 @@ class RollingSummaryPersistenceServiceTest {
     @Mock
     private ContextCacheRepository contextCacheRepository;
 
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     private RollingSummaryPersistenceService service;
 
     @BeforeEach
     void setUp() {
-        service = new RollingSummaryPersistenceService(meetingRepository, utteranceRepository, contextCacheRepository);
+        service = new RollingSummaryPersistenceService(
+                meetingRepository, utteranceRepository, contextCacheRepository, eventPublisher);
     }
 
     @Test
@@ -65,7 +70,7 @@ class RollingSummaryPersistenceServiceTest {
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
                 .willReturn(Optional.empty());
-        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(utterances(meeting, 1, 20, 200));
+        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(utterances(meeting, 1, 12, 200));
 
         assertThat(service.prepareCompression(1L)).isEmpty();
     }
@@ -83,7 +88,7 @@ class RollingSummaryPersistenceServiceTest {
 
         assertThat(candidate.expectedVersion()).isNull();
         assertThat(candidate.expectedCompressedUntilUtteranceId()).isNull();
-        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(11L);
+        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(19L);
         assertThat(candidate.userPrompt()).contains("content-1").doesNotContain("content-31");
         assertThat(candidate.userPrompt())
                 .contains("[출력]")
@@ -117,7 +122,7 @@ class RollingSummaryPersistenceServiceTest {
 
         assertThat(candidate.expectedVersion()).isEqualTo(3);
         assertThat(candidate.expectedCompressedUntilUtteranceId()).isEqualTo(5L);
-        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(16L);
+        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(24L);
         assertThat(candidate.userPrompt()).contains("previous summary");
         assertThat(candidate.nextVersion()).isEqualTo(4);
     }
@@ -141,10 +146,10 @@ class RollingSummaryPersistenceServiceTest {
         RollingSummaryPersistenceService.CompressionCandidate candidate =
                 service.prepareCompression(1L).orElseThrow();
 
-        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(13L);
+        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(21L);
         assertThat(candidate.userPrompt())
                 .contains("content-3")
-                .contains("content-13")
+                .contains("content-21")
                 .doesNotContain("content-33");
     }
 
@@ -173,6 +178,7 @@ class RollingSummaryPersistenceServiceTest {
         given(meetingRepository.findByIdForUpdate(1L)).willReturn(Optional.of(meeting));
         given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
                 .willReturn(Optional.empty());
+        given(contextCacheRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
         service.saveCompression(candidate(null, null), "summary");
 
@@ -182,6 +188,7 @@ class RollingSummaryPersistenceServiceTest {
         assertThat(saved.getVersion()).isEqualTo(1);
         assertThat(saved.getCompressedText()).isEqualTo("summary");
         assertThat(saved.getCompressedUntilUtteranceId()).isEqualTo(11L);
+        verify(eventPublisher).publishEvent(new RollingSummaryUpdatedEvent(1L, "summary", 1));
     }
 
     private RollingSummaryPersistenceService.CompressionCandidate candidate(

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
@@ -110,7 +110,7 @@ class ContextServiceTest {
         Meeting meeting = Meeting.builder().title("standalone").build();
         ReflectionTestUtils.setField(meeting, "id", 1L);
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
-        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(Collections.emptyList());
+        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(Collections.emptyList());
 
         ContextResponse result = contextService.assemble(1L, null);
 
@@ -121,23 +121,23 @@ class ContextServiceTest {
     }
 
     @Test
-    void assemble_noCache_usesTokenBudgetButKeepsAtLeastTwentyUtterances() {
+    void assemble_noCache_usesTokenBudgetButKeepsAtLeastTenUtterances() {
         Meeting meeting = Meeting.builder().title("meeting").build();
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
-        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(utterances(meeting, 1, 30, 100));
+        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(utterances(meeting, 1, 30, 100));
 
         ContextResponse result = contextService.assemble(1L, null);
 
-        assertThat(result.shortTerm().recentUtterances()).hasSize(20);
-        assertThat(result.shortTerm().recentUtterances().get(0).content()).isEqualTo("content-11");
-        assertThat(result.shortTerm().recentUtterances().get(19).content()).isEqualTo("content-30");
+        assertThat(result.shortTerm().recentUtterances()).hasSize(12);
+        assertThat(result.shortTerm().recentUtterances().get(0).content()).isEqualTo("content-19");
+        assertThat(result.shortTerm().recentUtterances().get(11).content()).isEqualTo("content-30");
     }
 
     @Test
     void assemble_noCache_returnsMoreThanTwenty_whenTokensFitBudget() {
         Meeting meeting = Meeting.builder().title("meeting").build();
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
-        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(utterances(meeting, 1, 30, 10));
+        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(utterances(meeting, 1, 30, 10));
 
         ContextResponse result = contextService.assemble(1L, null);
 
@@ -157,7 +157,7 @@ class ContextServiceTest {
                 .build();
         given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
                 .willReturn(Optional.of(cache));
-        given(utteranceRepository.findByMeetingAndIdGreaterThanOrderByIdAsc(meeting, 10L))
+        given(utteranceRepository.findTop30ByMeetingAndIdGreaterThanOrderByIdDesc(meeting, 10L))
                 .willReturn(utterances(meeting, 11, 31, 10));
 
         ContextResponse result = contextService.assemble(1L, null);
@@ -174,7 +174,7 @@ class ContextServiceTest {
         MeetingStartContext startContext = startContext(1L, 10L);
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(meetingStartContextProvider.getOrCreate(1L)).willReturn(startContext);
-        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(Collections.emptyList());
+        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(Collections.emptyList());
 
         ContextResponse result = contextService.assemble(1L, null);
 
@@ -205,13 +205,13 @@ class ContextServiceTest {
         MeetingSummary newSummary = meetingSummary(meeting, 12L, "new related summary");
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(meetingStartContextProvider.getOrCreate(1L)).willReturn(startContext);
-        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(Collections.emptyList());
+        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(Collections.emptyList());
         given(embeddingClient.embed("what did we decide?")).willReturn(new float[] {0.1f, 0.2f});
         given(decisionRepository.hybridSearch(
                         org.mockito.ArgumentMatchers.eq(10L),
                         org.mockito.ArgumentMatchers.anyString(),
                         org.mockito.ArgumentMatchers.eq("what did we decide?"),
-                        org.mockito.ArgumentMatchers.eq(5),
+                        org.mockito.ArgumentMatchers.eq(3),
                         org.mockito.ArgumentMatchers.eq(0.7),
                         org.mockito.ArgumentMatchers.eq(0.3)))
                 .willReturn(List.of(duplicateDecision, newDecision));
@@ -220,7 +220,7 @@ class ContextServiceTest {
                         org.mockito.ArgumentMatchers.eq(1L),
                         org.mockito.ArgumentMatchers.anyString(),
                         org.mockito.ArgumentMatchers.eq("what did we decide?"),
-                        org.mockito.ArgumentMatchers.eq(5),
+                        org.mockito.ArgumentMatchers.eq(3),
                         org.mockito.ArgumentMatchers.eq(0.7),
                         org.mockito.ArgumentMatchers.eq(0.3)))
                 .willReturn(List.of(duplicateSummary, newSummary));
@@ -242,7 +242,7 @@ class ContextServiceTest {
         Meeting meeting = Meeting.builder().project(project).title("meeting").build();
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(meetingStartContextProvider.getOrCreate(1L)).willReturn(startContext(1L, 10L));
-        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(Collections.emptyList());
+        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(Collections.emptyList());
         given(embeddingClient.embed("find summary")).willThrow(new RuntimeException("embedding failed"));
 
         ContextResponse result = contextService.assemble(1L, "find summary");

--- a/src/test/java/com/flodiback/domain/speech/service/InternalSpeechServiceTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/InternalSpeechServiceTest.java
@@ -3,6 +3,7 @@ package com.flodiback.domain.speech.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
@@ -30,37 +31,64 @@ class InternalSpeechServiceTest {
     @Mock
     private SpeechAiAnswerService speechAiAnswerService;
 
+    @Mock
+    private SpeechAiAnswerAsyncService speechAiAnswerAsyncService;
+
+    @Mock
+    private AiAnswerWebSocketPublisher aiAnswerWebSocketPublisher;
+
     @InjectMocks
     private InternalSpeechService internalSpeechService;
 
     @Test
-    void saveSpeech_returnsAiAnswerAfterSpeechIsPersisted() {
-        InternalSpeechRequest request = request("AI야, 인증 방식 뭐로 정했어?");
+    void saveSpeech_triggersAsyncAnswerAfterSpeechIsPersisted_whenWakeWordHasQuestion() {
+        InternalSpeechRequest request = request("AI야 인증 방식 뭐로 정했어?");
         given(speechPersistenceService.saveUtterance(request)).willReturn(new SavedSpeechResult(100L, 1L));
-        given(speechAiAnswerService.generateAnswerIfCalled(1L, request.text())).willReturn("인증 방식은 JWT로 정했습니다.");
+        given(speechAiAnswerService.extractQuestion(request.text())).willReturn("인증 방식 뭐로 정했어?");
 
         InternalSpeechResponse response = internalSpeechService.saveSpeech(request);
 
         assertThat(response.utteranceId()).isEqualTo(100L);
         assertThat(response.meetingId()).isEqualTo(1L);
-        assertThat(response.aiAnswer()).isEqualTo("인증 방식은 JWT로 정했습니다.");
+        assertThat(response.aiAnswer()).isNull();
 
-        InOrder inOrder = inOrder(speechPersistenceService, speechAiAnswerService);
+        InOrder inOrder = inOrder(speechPersistenceService, speechAiAnswerAsyncService);
         inOrder.verify(speechPersistenceService).saveUtterance(request);
-        inOrder.verify(speechAiAnswerService).generateAnswerIfCalled(1L, request.text());
+        inOrder.verify(speechAiAnswerAsyncService).generateAndPublish(1L, 100L, "discord-1", "인증 방식 뭐로 정했어?");
     }
 
     @Test
-    void saveSpeech_keepsSavedSpeechResponseWhenAiAnswerIsNull() {
+    void saveSpeech_doesNotTriggerAsyncAnswer_whenQuestionIsBlank() {
         InternalSpeechRequest request = request("이번 회의 목표를 정해봅시다.");
         given(speechPersistenceService.saveUtterance(request)).willReturn(new SavedSpeechResult(101L, 1L));
+        given(speechAiAnswerService.extractQuestion(request.text())).willReturn(null);
 
         InternalSpeechResponse response = internalSpeechService.saveSpeech(request);
 
         assertThat(response.utteranceId()).isEqualTo(101L);
         assertThat(response.meetingId()).isEqualTo(1L);
         assertThat(response.aiAnswer()).isNull();
-        verify(speechAiAnswerService).generateAnswerIfCalled(1L, request.text());
+        verify(speechAiAnswerAsyncService, never())
+                .generateAndPublish(
+                        org.mockito.ArgumentMatchers.anyLong(),
+                        org.mockito.ArgumentMatchers.anyLong(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void saveSpeech_publishesFallback_whenAsyncTaskIsRejected() {
+        InternalSpeechRequest request = request("플로디야 토큰 만료 시간 정했어?");
+        given(speechPersistenceService.saveUtterance(request)).willReturn(new SavedSpeechResult(102L, 1L));
+        given(speechAiAnswerService.extractQuestion(request.text())).willReturn("토큰 만료 시간 정했어?");
+        org.mockito.Mockito.doThrow(new java.util.concurrent.RejectedExecutionException("full"))
+                .when(speechAiAnswerAsyncService)
+                .generateAndPublish(1L, 102L, "discord-1", "토큰 만료 시간 정했어?");
+
+        InternalSpeechResponse response = internalSpeechService.saveSpeech(request);
+
+        assertThat(response.aiAnswer()).isNull();
+        verify(aiAnswerWebSocketPublisher).publishFallback(1L, 102L, "discord-1", "토큰 만료 시간 정했어?", 0L);
     }
 
     @Test

--- a/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerAsyncServiceTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerAsyncServiceTest.java
@@ -1,0 +1,84 @@
+package com.flodiback.domain.speech.service;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class SpeechAiAnswerAsyncServiceTest {
+
+    private SpeechAiAnswerService speechAiAnswerService;
+    private AiAnswerWebSocketPublisher publisher;
+    private ScheduledExecutorService pendingScheduler;
+    private ScheduledFuture<?> pendingTask;
+    private AtomicReference<Runnable> pendingRunnable;
+    private SpeechAiAnswerAsyncService service;
+
+    @BeforeEach
+    void setUp() {
+        speechAiAnswerService = mock(SpeechAiAnswerService.class);
+        publisher = mock(AiAnswerWebSocketPublisher.class);
+        pendingScheduler = mock(ScheduledExecutorService.class);
+        pendingTask = mock(ScheduledFuture.class);
+        pendingRunnable = new AtomicReference<>();
+        given(pendingScheduler.schedule(org.mockito.ArgumentMatchers.any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS)))
+                .willAnswer(invocation -> {
+                    pendingRunnable.set(invocation.getArgument(0));
+                    return pendingTask;
+                });
+        service = new SpeechAiAnswerAsyncService(speechAiAnswerService, publisher, pendingScheduler);
+    }
+
+    @Test
+    void generateAndPublish_publishesCompletedOnly_whenAnswerCompletesBeforePending() {
+        given(speechAiAnswerService.generateAnswer(1L, "question")).willReturn("answer");
+
+        service.generateAndPublish(1L, 100L, "discord-1", "question");
+
+        verify(pendingTask).cancel(false);
+        verify(publisher).publishCompleted(eq(1L), eq(100L), eq("discord-1"), eq("question"), eq("answer"), anyLong());
+        org.mockito.Mockito.verify(publisher, org.mockito.Mockito.never())
+                .publishPending(
+                        anyLong(),
+                        anyLong(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        anyLong());
+    }
+
+    @Test
+    void generateAndPublish_publishesPendingThenCompleted_whenPendingTimerRunsFirst() {
+        given(speechAiAnswerService.generateAnswer(1L, "question")).willAnswer(invocation -> {
+            pendingRunnable.get().run();
+            return "answer";
+        });
+
+        service.generateAndPublish(1L, 100L, "discord-1", "question");
+
+        InOrder inOrder = inOrder(publisher);
+        inOrder.verify(publisher).publishPending(eq(1L), eq(100L), eq("discord-1"), eq("question"), anyLong());
+        inOrder.verify(publisher)
+                .publishCompleted(eq(1L), eq(100L), eq("discord-1"), eq("question"), eq("answer"), anyLong());
+    }
+
+    @Test
+    void generateAndPublish_publishesFallback_whenAnswerFails() {
+        given(speechAiAnswerService.generateAnswer(1L, "question")).willThrow(new RuntimeException("GLM failed"));
+
+        service.generateAndPublish(1L, 100L, "discord-1", "question");
+
+        verify(pendingTask).cancel(false);
+        verify(publisher).publishFallback(eq(1L), eq(100L), eq("discord-1"), eq("question"), anyLong());
+    }
+}

--- a/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
@@ -39,23 +39,37 @@ class SpeechAiAnswerServiceTest {
     private SpeechAiAnswerService speechAiAnswerService;
 
     @Test
-    void generateAnswerIfCalled_returnsNull_whenWakeWordDoesNotExist() {
-        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "이번 스프린트 목표를 정해봅시다");
+    void extractQuestion_returnsNull_whenWakeWordDoesNotExist() {
+        String result = speechAiAnswerService.extractQuestion("이번 스프린트 목표를 정해봅시다.");
 
         assertThat(result).isNull();
-        verify(contextService, never()).assemble(1L, "이번 스프린트 목표를 정해봅시다");
+    }
+
+    @Test
+    void extractQuestion_returnsQuestionAfterWakeWord() {
+        String result = speechAiAnswerService.extractQuestion("플로디야, 인증 방식 뭐로 정했어?");
+
+        assertThat(result).isEqualTo("인증 방식 뭐로 정했어?");
+    }
+
+    @Test
+    void extractQuestion_doesNotCallDependencies_whenWakeWordDoesNotExist() {
+        String result = speechAiAnswerService.extractQuestion("이번 스프린트 목표를 정해봅시다.");
+
+        assertThat(result).isNull();
+        verify(contextService, never()).assemble(1L, "이번 스프린트 목표를 정해봅시다.");
         verify(aiChatService, never()).generateAnswer(anyString(), anyString());
     }
 
     @Test
-    void generateAnswerIfCalled_usesContextAndAiChat_whenWakeWordExists() {
+    void generateAnswer_usesContextAndAiChat() {
         ContextResponse context = new ContextResponse(
                 new MeetingStartContext(
                         1L,
                         10L,
                         "Flodi",
                         "Spring Boot",
-                        null,
+                        "metadata",
                         List.of(new DecisionSummary(1L, "인증 방식은 JWT로 한다.", null)),
                         List.of(new PastSummary(1L, "로그인 기능 담당자를 정했다.", null)),
                         "API 응답 형식 미정",
@@ -63,13 +77,13 @@ class SpeechAiAnswerServiceTest {
                 new ShortTermContext(null, List.of(new UtteranceSummary("김철수", "인증은 JWT로 하자.", null))),
                 QuestionContext.empty());
 
-        given(contextService.assemble(1L, "인증 방식 뭘로 하기로 했지?")).willReturn(context);
-        given(aiChatService.generateAnswer(anyString(), anyString())).willReturn("인증 방식은 JWT로 결정했습니다.");
+        given(contextService.assemble(1L, "인증 방식 뭐로 하기로 했어?")).willReturn(context);
+        given(aiChatService.generateAnswer(anyString(), anyString())).willReturn("[회의 기반] 인증 방식은 JWT로 결정했습니다.");
 
-        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "AI야 인증 방식 뭘로 하기로 했지?");
+        String result = speechAiAnswerService.generateAnswer(1L, "인증 방식 뭐로 하기로 했어?");
 
-        assertThat(result).isEqualTo("인증 방식은 JWT로 결정했습니다.");
-        verify(contextService).assemble(1L, "인증 방식 뭘로 하기로 했지?");
+        assertThat(result).isEqualTo("[회의 기반] 인증 방식은 JWT로 결정했습니다.");
+        verify(contextService).assemble(1L, "인증 방식 뭐로 하기로 했어?");
 
         ArgumentCaptor<String> systemPromptCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
@@ -77,60 +91,67 @@ class SpeechAiAnswerServiceTest {
         assertThat(systemPromptCaptor.getValue())
                 .contains("[회의 기반]")
                 .contains("[일반 지식 기반]")
-                .contains("실제 웹 검색은 하지 않으므로");
+                .contains("2~3문장");
         assertThat(userPromptCaptor.getValue())
                 .contains("[답변 규칙]")
-                .contains("[회의 기반]")
-                .contains("[일반 지식 기반]")
+                .contains("[회의 시작 컨텍스트]")
+                .contains("[현재 회의 컨텍스트]")
+                .contains("[질문 관련 추가 기억]")
+                .contains("[질문]")
                 .contains("Flodi")
                 .contains("인증 방식은 JWT로 한다.")
                 .contains("로그인 기능 담당자를 정했다.")
                 .contains("API 응답 형식 미정")
                 .contains("로그인 API 작성")
-                .contains("[회의 시작 컨텍스트]")
-                .contains("[현재 회의 컨텍스트]")
-                .contains("[질문 관련 추가 기억]")
-                .contains("[질문]")
-                .contains("인증 방식 뭘로 하기로 했지?");
+                .contains("인증 방식 뭐로 하기로 했어?");
     }
 
     @Test
-    void generateAnswerIfCalled_allowsGeneralKnowledgeFallback_whenContextDoesNotContainAnswer() {
-        ContextResponse context = ContextResponse.noProject(null, List.of());
-        given(contextService.assemble(1L, "코끼리 나이는 몇 살이야?")).willReturn(context);
-        given(aiChatService.generateAnswer(anyString(), anyString()))
-                .willReturn("회의 내용에서는 해당 내용을 찾지 못했습니다. [일반 지식 기반] 코끼리는 보통 60~70년 정도 살 수 있습니다.");
+    void generateAnswer_truncatesLongContextText() {
+        String longMetadata = "m".repeat(350);
+        String longDecision = "d".repeat(300);
+        String longSummary = "s".repeat(450);
+        ContextResponse context = new ContextResponse(
+                new MeetingStartContext(
+                        1L,
+                        10L,
+                        "Flodi",
+                        "Spring Boot",
+                        longMetadata,
+                        List.of(new DecisionSummary(1L, longDecision, null)),
+                        List.of(new PastSummary(1L, longSummary, null)),
+                        "u".repeat(450),
+                        List.of(new WorkLogSummary(1L, "김철수", "w".repeat(200), null, "TODO"))),
+                new ShortTermContext("r".repeat(900), List.of()),
+                QuestionContext.empty());
+        given(contextService.assemble(1L, "요약해줘")).willReturn(context);
+        given(aiChatService.generateAnswer(anyString(), anyString())).willReturn("done");
 
-        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "클로드야, 코끼리 나이는 몇 살이야?");
-
-        assertThat(result).isEqualTo("회의 내용에서는 해당 내용을 찾지 못했습니다. [일반 지식 기반] 코끼리는 보통 60~70년 정도 살 수 있습니다.");
-        verify(contextService).assemble(1L, "코끼리 나이는 몇 살이야?");
+        speechAiAnswerService.generateAnswer(1L, "요약해줘");
 
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
         verify(aiChatService).generateAnswer(anyString(), userPromptCaptor.capture());
-        assertThat(userPromptCaptor.getValue())
-                .contains("회의 컨텍스트에 답이 없거나 무관하면")
-                .contains("회의 내용에 없다고 밝힌 뒤")
-                .contains("[일반 지식 기반]")
-                .contains("실제 웹 검색은 하지 않았으므로")
-                .contains("코끼리 나이는 몇 살이야?");
+        String prompt = userPromptCaptor.getValue();
+        assertThat(prompt).contains("m".repeat(300) + "...");
+        assertThat(prompt).contains("d".repeat(250) + "...");
+        assertThat(prompt).contains("s".repeat(400) + "...");
+        assertThat(prompt).contains("u".repeat(400) + "...");
+        assertThat(prompt).contains("w".repeat(160) + "...");
+        assertThat(prompt).contains("r".repeat(800) + "...");
     }
 
     @Test
-    void generateAnswerIfCalled_acceptsMisrecognizedFlodiWakeWord() {
-        ContextResponse context = ContextResponse.noProject(null, List.of());
-        given(contextService.assemble(1L, "아까 말랑이 관련 이야기 요약 좀 해줄래?")).willReturn(context);
-        given(aiChatService.generateAnswer(anyString(), anyString())).willReturn("말랑이 관련 이야기를 요약했습니다.");
+    void extractQuestion_acceptsMisrecognizedFlodiWakeWord() {
+        String result = speechAiAnswerService.extractQuestion("플로디아 아까 말랑이 관련 이야기 요약 좀 해줄래?");
 
-        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "플로디아 아까 말랑이 관련 이야기 요약 좀 해줄래?");
-
-        assertThat(result).isEqualTo("말랑이 관련 이야기를 요약했습니다.");
-        verify(contextService).assemble(1L, "아까 말랑이 관련 이야기 요약 좀 해줄래?");
+        assertThat(result).isEqualTo("아까 말랑이 관련 이야기 요약 좀 해줄래?");
+        verify(contextService, never()).assemble(1L, "아까 말랑이 관련 이야기 요약 좀 해줄래?");
+        verify(aiChatService, never()).generateAnswer(anyString(), anyString());
     }
 
     @Test
-    void generateAnswerIfCalled_returnsNull_whenQuestionIsBlank() {
-        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "플로디야!");
+    void extractQuestion_returnsNull_whenQuestionIsBlank() {
+        String result = speechAiAnswerService.extractQuestion("플로디야!");
 
         assertThat(result).isNull();
         verify(contextService, never()).assemble(1L, "");
@@ -138,12 +159,12 @@ class SpeechAiAnswerServiceTest {
     }
 
     @Test
-    void generateAnswerIfCalled_returnsNull_whenAiChatFails() {
+    void generateAnswer_returnsNull_whenAiChatFails() {
         ContextResponse context = ContextResponse.noProject(null, List.of());
         given(contextService.assemble(1L, "토큰 만료 시간 정했어?")).willReturn(context);
         given(aiChatService.generateAnswer(anyString(), anyString())).willThrow(new RuntimeException("GLM error"));
 
-        String result = speechAiAnswerService.generateAnswerIfCalled(1L, "플로디야 토큰 만료 시간 정했어?");
+        String result = speechAiAnswerService.generateAnswer(1L, "토큰 만료 시간 정했어?");
 
         assertThat(result).isNull();
         verify(contextService).assemble(1L, "토큰 만료 시간 정했어?");

--- a/src/test/java/com/flodiback/global/client/OpenAiChatClientManualTest.java
+++ b/src/test/java/com/flodiback/global/client/OpenAiChatClientManualTest.java
@@ -1,0 +1,41 @@
+package com.flodiback.global.client;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * $env:OPENAI_API_KEY='your_openai_api_key'
+ * $env:OPENAI_CHAT_MODEL='gpt-4o-mini'
+ * ./gradlew test --tests "com.flodiback.global.client.OpenAiChatClientManualTest"
+ */
+@Disabled("수동 실행 전용 — 토큰 소모 주의. 실행 시 @Disabled 제거")
+class OpenAiChatClientManualTest {
+
+    @Test
+    void chat_responseCheck() {
+        OpenAiChatClient openAiChatClient = new OpenAiChatClient(
+                env("OPENAI_API_KEY", null),
+                env("OPENAI_CHAT_MODEL", "gpt-4o-mini"),
+                env("OPENAI_CHAT_BASE_URL", "https://api.openai.com/v1"),
+                Long.parseLong(env("OPENAI_CHAT_TIMEOUT_MS", "30000")),
+                Integer.parseInt(env("OPENAI_CHAT_MAX_RETRIES", "0")));
+        String systemPrompt = "You are a concise Korean assistant.";
+        String userPrompt = "1 + 1은 뭐야?";
+
+        String response = openAiChatClient.chat(systemPrompt, userPrompt);
+
+        System.out.println("=== OpenAI chat() response ===");
+        System.out.println(response);
+    }
+
+    private String env(String name, String defaultValue) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            if (defaultValue == null) {
+                throw new IllegalStateException(name + " is required.");
+            }
+            return defaultValue;
+        }
+        return value;
+    }
+}

--- a/src/test/java/com/flodiback/global/client/OpenAiChatClientTest.java
+++ b/src/test/java/com/flodiback/global/client/OpenAiChatClientTest.java
@@ -16,54 +16,54 @@ import com.openai.models.ErrorObject;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionMessage;
 
-class GlmClientTest {
+class OpenAiChatClientTest {
 
     @Test
     void chat_returnsFirstChoiceContent() {
-        GlmClient glmClient = new GlmClient("glm-test", params -> completion("안녕하세요."));
+        OpenAiChatClient openAiChatClient = new OpenAiChatClient("openai-test", params -> completion("answer"));
 
-        String result = glmClient.chat("system", "user");
+        String result = openAiChatClient.chat("system", "user");
 
-        assertThat(result).isEqualTo("안녕하세요.");
+        assertThat(result).isEqualTo("answer");
     }
 
     @Test
     void chat_throwsException_whenChoicesIsEmpty() {
-        GlmClient glmClient = new GlmClient("glm-test", params -> emptyCompletion());
+        OpenAiChatClient openAiChatClient = new OpenAiChatClient("openai-test", params -> emptyCompletion());
 
-        assertThatThrownBy(() -> glmClient.chat("system", "user"))
+        assertThatThrownBy(() -> openAiChatClient.chat("system", "user"))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("choices");
     }
 
     @Test
-    void chat_rethrowsException_whenGlmCallFails() {
-        GlmClient glmClient = new GlmClient("glm-test", params -> {
+    void chat_rethrowsException_whenOpenAiCallFails() {
+        OpenAiChatClient openAiChatClient = new OpenAiChatClient("openai-test", params -> {
             throw new IllegalStateException("network error");
         });
 
-        assertThatThrownBy(() -> glmClient.chat("system", "user"))
+        assertThatThrownBy(() -> openAiChatClient.chat("system", "user"))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("network error");
     }
 
     @Test
-    void chat_rethrowsIoException_whenGlmCallFails() {
-        GlmClient glmClient = new GlmClient("glm-test", 15000L, 0, params -> {
+    void chat_rethrowsIoException_whenOpenAiCallFails() {
+        OpenAiChatClient openAiChatClient = new OpenAiChatClient("openai-test", 30000L, 0, params -> {
             throw new OpenAIIoException("Request failed", new java.net.SocketTimeoutException("Read timed out"));
         });
 
-        assertThatThrownBy(() -> glmClient.chat("system", "user"))
+        assertThatThrownBy(() -> openAiChatClient.chat("system", "user"))
                 .isInstanceOf(OpenAIIoException.class)
                 .hasMessageContaining("Request failed");
     }
 
     @Test
-    void chat_rethrowsServiceException_whenGlmReturnsErrorStatus() {
+    void chat_rethrowsServiceException_whenOpenAiReturnsErrorStatus() {
         ErrorObject error = ErrorObject.builder()
                 .code("bad_request")
-                .message("unsupported parameter")
-                .param(Optional.of("max_completion_tokens"))
+                .message("invalid request")
+                .param(Optional.of("messages"))
                 .type("invalid_request_error")
                 .build();
         UnexpectedStatusCodeException exception = UnexpectedStatusCodeException.builder()
@@ -71,11 +71,11 @@ class GlmClientTest {
                 .headers(Headers.builder().build())
                 .error(error)
                 .build();
-        GlmClient glmClient = new GlmClient("glm-test", 15000L, 0, params -> {
+        OpenAiChatClient openAiChatClient = new OpenAiChatClient("openai-test", 30000L, 0, params -> {
             throw exception;
         });
 
-        assertThatThrownBy(() -> glmClient.chat("system", "user"))
+        assertThatThrownBy(() -> openAiChatClient.chat("system", "user"))
                 .isInstanceOf(UnexpectedStatusCodeException.class)
                 .hasMessageContaining("400");
     }
@@ -84,7 +84,7 @@ class GlmClientTest {
         return ChatCompletion.builder()
                 .id("chatcmpl-test")
                 .created(0L)
-                .model("glm-test")
+                .model("openai-test")
                 .addChoice(ChatCompletion.Choice.builder()
                         .index(0)
                         .finishReason(ChatCompletion.Choice.FinishReason.STOP)
@@ -102,7 +102,7 @@ class GlmClientTest {
         return ChatCompletion.builder()
                 .id("chatcmpl-test")
                 .created(0L)
-                .model("glm-test")
+                .model("openai-test")
                 .choices(List.of())
                 .build();
     }


### PR DESCRIPTION
> 변경 범위가 넓지만 목적은 하나입니다: Discord 회의 내용을 웹앱으로 실시간 전달하고, AI 답변 생성이 STT 저장/자막 흐름을 막지 않도록 분리했습니다.


## Summary

웹앱에서 회의 진행 상태를 실시간으로 볼 수 있도록 Discord 봇, WebSocket, AI 답변 흐름을 연결했습니다.

- Discord 봇의 STT partial 자막을 Redis Pub/Sub → WebSocket으로 전달
- `/internal/v1/speech` 저장 응답과 AI 답변 생성을 분리
- AI 답변을 `/topic/meetings/{meetingId}/ai-answer` WebSocket 이벤트로 발행
- contextCache/rolling summary 상태를 웹에서 확인할 수 있는 이벤트와 조회 경로 추가
- AI provider를 `AI_PROVIDER=openai|glm|disabled`로 선택할 수 있도록 OpenAI chat provider 추가
- AI 답변 prompt/RAG 컨텍스트를 경량화하고 latency 로그 추가

## Changes

### 실시간 자막

- Discord 봇에서 STT partial 결과를 Redis 채널 `captions:meetings:{meetingId}`로 publish
- 서버에서 Redis 메시지를 구독해 `/topic/meetings/{meetingId}/captions`로 WebSocket broadcast
- final 자막은 기존 `/internal/v1/speech` 저장 후 WebSocket `caption.final`로 전송

### AI 답변 비동기화

- `/internal/v1/speech`는 발화 저장 후 즉시 응답
- 호출어가 있는 발화만 `SpeechAiAnswerAsyncService`에서 비동기 답변 생성
- AI 답변 상태 이벤트 추가
  - `PENDING`
  - `COMPLETED`
  - `FALLBACK`
- 5초 초과 시 pending 이벤트를 먼저 보내고, 완료/실패 시 후속 이벤트 발행

### AI provider / timeout

- `AiChatService` 구현체로 OpenAI chat provider 추가
- `AI_PROVIDER` 설정으로 OpenAI/GLM/disabled 선택 가능
- GLM/OpenAI client timeout/retry/latency 로그 정리
- embedding client timeout 추가

### Context / RAG 경량화

- question context topK 축소
- 최근 발화 조회 limit 및 token budget 축소
- rolling summary trigger/tail 조정
  - token threshold `3000 → 1800`
  - keep turns `20 → 12`
- prompt에 들어가는 summary/decision/worklog 텍스트 길이 제한

### WebSocket / API

- caption event payload 추가
- AI answer event payload 추가
- meeting/context 상태 WebSocket publisher 추가
- internal API contract 문서 갱신

## Test

- [x] `./gradlew test --tests "com.flodiback.domain.meeting.meetinglog.rolling.*"`
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew build`

## Notes

- `/internal/v1/speech`의 `data.ai_answer`는 하위 호환을 위해 유지하지만, 이제 항상 `null`입니다.
- Discord로 AI 답변을 다시 보내는 경로는 이번 변경 범위에서 제외했고, 웹 WebSocket 전달을 기준으로 구현했습니다.
- 회의 종료 후 최종 meeting summary는 아직 `MeetingAnalysisService`에서 `GlmClient`를 직접 사용합니다. `AiChatService` 통합은 후속 작업으로 분리하는 것이 좋습니다.