### PR TITLE
[fix] 봇 Compose Gradle JDK 조정

### DIFF
--- a/docker-compose.bot.yml
+++ b/docker-compose.bot.yml
@@ -1,6 +1,6 @@
 services:
   discord-bot:
-    image: eclipse-temurin:25-jdk
+    image: eclipse-temurin:21-jdk
     platform: linux/amd64
     working_dir: /workspace
     volumes:


### PR DESCRIPTION
## 요약
- 테스트용 Discord bot Compose 이미지를 JDK 21로 조정해 Gradle Kotlin DSL의 JDK 25.0.x 파싱 실패를 피합니다.
- 프로젝트 컴파일과 runDiscordBot 실행은 build.gradle.kts의 Java 25 toolchain을 계속 사용합니다.

## 검증
- docker compose -f docker-compose.bot.yml up -d --force-recreate
- docker compose -f docker-compose.bot.yml logs discord-bot | rg "Finished Loading|준비완료|BUILD FAILED|Task :runDiscordBot"
- 확인 로그: Task :runDiscordBot, JDA Finished Loading, [봇/준비완료]

Closes #77