### PR TITLE
[feat] 회의 종료 분석 저장 안정화 및 WorkLog 담당자 식별 개선

### DIFF
--- a/docs/exec-plans/completed/2026-05/2026-05-11-221721-meeting-analysis-persistence-stability-codex.md
+++ b/docs/exec-plans/completed/2026-05/2026-05-11-221721-meeting-analysis-persistence-stability-codex.md
@@ -1,0 +1,36 @@
+# 2026-05-11-221721-meeting-analysis-persistence-stability-codex
+
+- author: codex
+- status: completed
+- created-at: 2026-05-11 22:17:21
+- completed-at: 2026-05-11 22:28:00
+
+## Background
+
+Meeting end analysis saves summary, decisions, and work logs in one flow. If an AI-generated work log contains invalid data such as a missing assignee, the derived item save can fail and roll back the meeting summary.
+
+## Goal
+
+Ensure `MeetingSummary` survives derived item failures, normalize AI analysis output before persistence, and keep the existing strict internal API context update path unchanged.
+
+## Scope
+
+- Add a meeting analysis persistence service with separate summary, embedding, and derived item save methods.
+- Normalize AI-generated decisions and work logs in `MeetingAnalysisService`.
+- Add tests for normalization and best-effort persistence behavior.
+- Update the meeting analysis prompt with the default assignee rule.
+
+## Verification
+
+- [x] Focused meeting analysis tests
+- [x] Focused meeting context persistence tests
+- [x] Existing context/controller tests
+- [x] `./gradlew test`
+- [x] `./gradlew spotlessCheck`
+- [x] `./gradlew build`
+
+## Decision Log
+
+- 2026-05-11 22:17:21: Keep `ContextService.updateContext()` as the strict API path and add a tolerant persistence path only for meeting end AI analysis.
+- 2026-05-11 22:17:21: Use `"담당자 미정"` for missing work log assignees and skip work logs with blank tasks.
+- 2026-05-11 22:28:00: Completed implementation and verified with focused tests, full tests, spotless, and build.

--- a/docs/exec-plans/completed/2026-05/2026-05-11-221721-meeting-analysis-persistence-stability-codex.md
+++ b/docs/exec-plans/completed/2026-05/2026-05-11-221721-meeting-analysis-persistence-stability-codex.md
@@ -1,7 +1,7 @@
 # 2026-05-11-221721-meeting-analysis-persistence-stability-codex
 
-- author: codex
-- status: completed
+- 작성자: codex
+- 상태: 완료(읽기 전용)
 - created-at: 2026-05-11 22:17:21
 - completed-at: 2026-05-11 22:28:00
 

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -83,6 +83,7 @@
 - `meeting_id` BIGINT FK -> `meetings.id` NOT NULL
 - `project_id` BIGINT FK -> `projects.id` NOT NULL
 - `assignee_name` VARCHAR(100) NOT NULL
+- `assignee_discord_id` VARCHAR(50) NULL
 - `task` TEXT NOT NULL
 - `due_date` DATE NULL
 - `created_at` TIMESTAMP NOT NULL

--- a/docs/impl/codex/0512-worklog-assignee-discord-id.md
+++ b/docs/impl/codex/0512-worklog-assignee-discord-id.md
@@ -1,0 +1,57 @@
+---
+generated-by: ai-draft
+reviewed-by:
+reviewed-at:
+evidence:
+---
+
+# WorkLog 담당자 Discord ID 저장
+
+> 회의 종료 분석에서 GLM이 담당자 이름을 직접 확정하지 않고, 서버가 speaker key를 실제 Discord 사용자 ID로 매핑해 WorkLog에 저장하도록 개선했다.
+
+- 구현 일자: 2026-05-12
+- 작성자: codex
+- 해당 파트: meeting analysis, meeting context, worklog
+- 관련 테이블: work_logs, utterances
+
+---
+
+## 왜 이렇게 구현했나
+
+### 문제 상황
+기존 WorkLog는 `assigneeName`만 저장해 동명이인, 표시 이름 변경, "제가 할게요" 같은 발화자 지시를 안정적으로 추적하기 어려웠다.
+
+### 선택한 방식
+회의 전체 발화자 목록에서 `S1`, `S2` 같은 임시 speaker key를 만들고, prompt에는 이 key만 노출한다. GLM은 `assigneeSpeakerKey`만 반환하고, 서버가 key를 `speakerDiscordId`와 표시 이름으로 매핑해 WorkLog를 저장한다.
+
+### 다른 방법
+| 방식 | 장점 | 단점 | 선택 여부 |
+|------|------|------|----------|
+| prompt에 Discord ID 직접 노출 | 구현 단순 | 외부 모델에 raw 식별자 노출 | 미선택 |
+| GLM이 assigneeName 반환 | 기존 구조 유지 | 이름/id 불일치와 추론 모호성 지속 | 미선택 |
+| 서버 speaker key 매핑 | 식별자 노출 최소화, 서버가 최종 확정 | DTO/스키마 변경 필요 | 선택 |
+
+---
+
+## 핵심 구현 내용
+
+### 구조 설명
+`UtteranceRepository`가 회의 전체 distinct 발화자를 첫 발화 ID 기준으로 조회하고, `MeetingAnalysisService`가 이를 `S1`, `S2`로 매핑한다. WorkLog 저장 DTO와 entity에는 nullable `assigneeDiscordId`를 추가해 기존 API 호환성을 유지했다.
+
+### 설계 결정사항
+- speaker key 순서: `firstUtteranceId ASC` 기준으로 결정한다.
+- unknown speaker: `speakerDiscordId`가 없거나 key 매핑이 실패하면 `담당자 미정`과 `assigneeDiscordId=null`로 저장한다.
+- rolling summary: key가 없는 summary-only 담당자는 ID를 확정하지 않는다.
+
+---
+
+## 다음에 개선할 점
+
+- [ ] WorkLog 담당자 변경/재배정 API가 생기면 `assigneeDiscordId` 갱신 정책도 함께 정의한다.
+- [ ] rolling summary에 speaker key 메타데이터를 포함할지 별도 검토한다.
+
+---
+
+## 히스토리 메모
+
+> WorkLog 담당자를 문자열로만 저장해 실제 사용자 식별이 어려운 문제를 발견했고, prompt용 speaker key를 서버 매핑 테이블로 되돌리는 방식으로 해결했다. 그 결과 GLM은 담당자 key만 선택하고, 서버가 최종 담당자 이름과 Discord ID를 확정한다.

--- a/docs/impl/codex/0512-worklog-assignee-discord-id.md
+++ b/docs/impl/codex/0512-worklog-assignee-discord-id.md
@@ -1,8 +1,8 @@
 ---
 generated-by: ai-draft
-reviewed-by:
-reviewed-at:
-evidence:
+reviewed-by: madupal
+reviewed-at: 2026-05-12
+evidence: PR 81
 ---
 
 # WorkLog 담당자 Discord ID 저장

--- a/docs/references/internal-api-contracts.md
+++ b/docs/references/internal-api-contracts.md
@@ -95,6 +95,7 @@ Query:
       {
         "id": 7,
         "assigneeName": "김철수",
+        "assigneeDiscordId": "123456789",
         "task": "로그인 API 작성",
         "dueDate": "2026-05-10",
         "status": "TODO"

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/WorkLogItem.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/WorkLogItem.java
@@ -2,4 +2,4 @@ package com.flodiback.domain.meeting.analysis.dto;
 
 import java.time.LocalDate;
 
-public record WorkLogItem(String assigneeName, String task, LocalDate dueDate) {}
+public record WorkLogItem(String assigneeSpeakerKey, String task, LocalDate dueDate) {}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
@@ -4,8 +4,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -27,9 +30,10 @@ import com.flodiback.domain.meeting.meeting.repository.ContextCacheRepository;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.meeting.meetinglog.dto.ActionItemRequest;
 import com.flodiback.domain.meeting.meetinglog.dto.UpdateContextRequest;
+import com.flodiback.domain.meeting.meetinglog.entity.MeetingSummary;
 import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
 import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
-import com.flodiback.domain.meeting.meetinglog.service.ContextService;
+import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository.SpeakerProjection;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.global.client.GlmClient;
 import com.flodiback.global.exception.ServiceException;
@@ -44,6 +48,9 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class MeetingAnalysisService {
 
+    private static final String UNKNOWN_ASSIGNEE = "담당자 미정";
+    private static final String UNKNOWN_SPEAKER_KEY = "unknown";
+
     @Value("classpath:prompts/meeting-analysis-system.md")
     private Resource systemPromptResource;
 
@@ -57,7 +64,7 @@ public class MeetingAnalysisService {
     private final MeetingRepository meetingRepository;
     private final ContextCacheRepository contextCacheRepository;
     private final UtteranceRepository utteranceRepository;
-    private final ContextService contextService;
+    private final MeetingContextPersistenceService meetingContextPersistenceService;
     private final GlmClient glmClient;
     private final ObjectMapper objectMapper;
 
@@ -79,29 +86,133 @@ public class MeetingAnalysisService {
         if (project == null) {
             throw new ServiceException("400-1", "회의에 연결된 프로젝트가 없습니다.");
         }
-
-        String context = buildContext(meeting);
+        // 회의 종료 분석 - 발화자 key map 생성
+        SpeakerDirectory speakerDirectory = buildSpeakerDirectory(meeting);
+        // GLM prompt context 생성
+        String context = buildContext(meeting, speakerDirectory);
+        // GLM 응답 - GLM은 이름 대신 speaker key 반환
         AnalysisResult result = callGlm(context);
+        UpdateContextRequest request = toUpdateContextRequest(meeting.getId(), result, speakerDirectory);
 
-        contextService.updateContext(project.getId(), toUpdateContextRequest(meeting.getId(), result));
+        /*
+         * saveSummaryRequired()
+         * -> MeetingSummary 먼저 REQUIRES_NEW로 저장
+         *
+         * saveSummaryEmbeddingBestEffort()
+         * -> summary embedding 실패해도 summary는 유지
+         *
+         * saveDerivedItemsBestEffort()
+         * -> decision/worklog 저장 실패해도 summary는 롤백하지 않음
+         */
+        // Keep these as external proxy calls; do not wrap them in a same-bean orchestration method.
+        MeetingSummary savedSummary = meetingContextPersistenceService.saveSummaryRequired(project.getId(), request);
+        meetingContextPersistenceService.saveSummaryEmbeddingBestEffort(savedSummary);
+        meetingContextPersistenceService.saveDerivedItemsBestEffort(project.getId(), request);
     }
 
-    private UpdateContextRequest toUpdateContextRequest(Long meetingId, AnalysisResult result) {
+    private UpdateContextRequest toUpdateContextRequest(
+            Long meetingId, AnalysisResult result, SpeakerDirectory speakerDirectory) {
+        String summary = normalizeRequiredSummary(result.summary());
         List<String> decisions = result.decisions() == null
                 ? null
-                : result.decisions().stream().map(DecisionItem::content).toList();
+                : result.decisions().stream()
+                        .filter(Objects::nonNull)
+                        .map(DecisionItem::content)
+                        .map(this::normalizeOptionalText)
+                        .filter(Objects::nonNull)
+                        .toList();
         List<ActionItemRequest> actionItems = result.worklogs() == null
                 ? null
-                : result.worklogs().stream().map(this::toActionItemRequest).toList();
+                : result.worklogs().stream()
+                        .map(item -> toActionItemRequest(item, speakerDirectory))
+                        .filter(Objects::nonNull)
+                        .toList();
 
-        return new UpdateContextRequest(meetingId, result.summary(), result.unresolvedItems(), decisions, actionItems);
+        return new UpdateContextRequest(
+                meetingId, summary, normalizeOptionalText(result.unresolvedItems()), decisions, actionItems);
     }
 
-    private ActionItemRequest toActionItemRequest(WorkLogItem item) {
-        return new ActionItemRequest(item.assigneeName(), item.task(), item.dueDate());
+    private ActionItemRequest toActionItemRequest(WorkLogItem item, SpeakerDirectory speakerDirectory) {
+        if (item == null) {
+            return null;
+        }
+        String task = normalizeOptionalText(item.task());
+        if (task == null) {
+            return null;
+        }
+
+        SpeakerRef assignee = speakerDirectory.findByKey(normalizeOptionalText(item.assigneeSpeakerKey()));
+        if (assignee == null) {
+            return new ActionItemRequest(null, UNKNOWN_ASSIGNEE, task, item.dueDate());
+        }
+        return new ActionItemRequest(assignee.discordId(), assignee.name(), task, item.dueDate());
     }
 
-    private String buildContext(Meeting meeting) {
+    private String normalizeRequiredSummary(String summary) {
+        String normalized = normalizeOptionalText(summary);
+        if (normalized == null) {
+            throw new ServiceException("422-1", "Meeting analysis summary is blank.");
+        }
+        return normalized;
+    }
+
+    private String normalizeOptionalText(String value) {
+        if (value == null) {
+            return null;
+        }
+        String stripped = value.strip();
+        return stripped.isBlank() ? null : stripped;
+    }
+
+    /**
+     * 회의 전체 발화자 목록을 조회
+     * firstUtteranceId ASC 순서로 speaker key를 붙임
+     * S1 -> Alice / discord-user-1
+     * S2 -> Bob / discord-user-2
+     *
+     * speakerDiscordId가 없거나 blank인 발화자는 key map에서 제외
+     */
+    private SpeakerDirectory buildSpeakerDirectory(Meeting meeting) {
+        Map<String, SpeakerRef> byDiscordId = new LinkedHashMap<>();
+        Map<String, SpeakerRef> byKey = new LinkedHashMap<>();
+
+        List<SpeakerProjection> speakers = utteranceRepository.findDistinctSpeakersByMeeting(meeting);
+
+        int sequence = 1;
+        for (SpeakerProjection speaker : speakers) {
+            String discordId = normalizeOptionalText(speaker.getSpeakerDiscordId());
+            if (byDiscordId.containsKey(discordId)) {
+                continue;
+            }
+            String key = "S" + sequence++;
+            String name = normalizeOptionalText(speaker.getSpeakerName());
+            SpeakerRef ref = new SpeakerRef(key, discordId, name != null ? name : UNKNOWN_ASSIGNEE);
+            byDiscordId.put(discordId, ref);
+            byKey.put(key, ref);
+        }
+
+        return new SpeakerDirectory(byDiscordId, byKey);
+    }
+
+    /**
+     * 분석 prompt에는 raw Discord ID를 넣지 않음
+     * 대신 서버가 만든 speaker key만 넣음
+     *
+     * [회의 전체 내용]
+     * [speaker=S1, name=Alice] API 명세 확정했어요.
+     * [speaker=S2, name=Bob] 제가 금요일까지 구현할게요.
+     *
+     * rolling summary가 있으면:
+     * [현재 회의 rolling summary]
+     * ...
+     *
+     * [rolling summary에 아직 반영되지 않은 발화]
+     * [speaker=S2, name=Bob] 제가 금요일까지 구현할게요.
+     *
+     * rolling summary에는 speaker key가 없다.
+     * 그래서 prompt에서도 summary에서만 추론한 담당자는 assigneeSpeakerKey=null로 반환
+     */
+    private String buildContext(Meeting meeting, SpeakerDirectory speakerDirectory) {
         ContextCache latestCache = contextCacheRepository
                 .findTopByMeetingOrderByVersionDesc(meeting)
                 .orElse(null);
@@ -117,10 +228,17 @@ public class MeetingAnalysisService {
         }
 
         sb.append(latestCache != null ? "[rolling summary에 아직 반영되지 않은 발화]\n" : "[회의 전체 내용]\n");
-        sortForPrompt(utterances)
-                .forEach(u -> sb.append(String.format("%s: %s\n", u.getSpeakerName(), u.getContent())));
+        sortForPrompt(utterances).forEach(u -> sb.append(formatUtterance(u, speakerDirectory)));
 
         return sb.toString();
+    }
+
+    private String formatUtterance(Utterance utterance, SpeakerDirectory speakerDirectory) {
+        SpeakerRef speaker = speakerDirectory.findByDiscordId(normalizeOptionalText(utterance.getSpeakerDiscordId()));
+        String key = speaker != null ? speaker.key() : UNKNOWN_SPEAKER_KEY;
+        String name = normalizeOptionalText(utterance.getSpeakerName());
+        return String.format(
+                "[speaker=%s, name=%s] %s\n", key, name != null ? name : UNKNOWN_ASSIGNEE, utterance.getContent());
     }
 
     private List<Utterance> sortForPrompt(List<Utterance> utterances) {
@@ -145,4 +263,17 @@ public class MeetingAnalysisService {
             throw new RuntimeException("GLM 응답 파싱 실패: " + raw, e);
         }
     }
+
+    private record SpeakerDirectory(Map<String, SpeakerRef> byDiscordId, Map<String, SpeakerRef> byKey) {
+
+        SpeakerRef findByDiscordId(String discordId) {
+            return discordId != null ? byDiscordId.get(discordId) : null;
+        }
+
+        SpeakerRef findByKey(String key) {
+            return key != null ? byKey.get(key) : null;
+        }
+    }
+
+    private record SpeakerRef(String key, String discordId, String name) {}
 }

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceService.java
@@ -1,0 +1,139 @@
+package com.flodiback.domain.meeting.analysis.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.flodiback.domain.decision.decision.entity.Decision;
+import com.flodiback.domain.decision.decision.repository.DecisionRepository;
+import com.flodiback.domain.decision.decision.service.DecisionEmbeddingService;
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.meeting.meetinglog.dto.UpdateContextRequest;
+import com.flodiback.domain.meeting.meetinglog.entity.MeetingSummary;
+import com.flodiback.domain.meeting.meetinglog.repository.MeetingSummaryRepository;
+import com.flodiback.domain.meeting.meetinglog.service.MeetingSummaryEmbeddingService;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.domain.project.worklog.entity.WorkLog;
+import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
+import com.flodiback.global.exception.ServiceException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class MeetingContextPersistenceService {
+
+    private final MeetingRepository meetingRepository;
+    private final MeetingSummaryRepository meetingSummaryRepository;
+    private final ProjectRepository projectRepository;
+    private final WorkLogRepository workLogRepository;
+    private final DecisionRepository decisionRepository;
+    private final DecisionEmbeddingService decisionEmbeddingService;
+    private final MeetingSummaryEmbeddingService meetingSummaryEmbeddingService;
+    private final TransactionTemplate derivedItemsTransactionTemplate;
+
+    public MeetingContextPersistenceService(
+            MeetingRepository meetingRepository,
+            MeetingSummaryRepository meetingSummaryRepository,
+            ProjectRepository projectRepository,
+            WorkLogRepository workLogRepository,
+            DecisionRepository decisionRepository,
+            DecisionEmbeddingService decisionEmbeddingService,
+            MeetingSummaryEmbeddingService meetingSummaryEmbeddingService,
+            PlatformTransactionManager transactionManager) {
+        this.meetingRepository = meetingRepository;
+        this.meetingSummaryRepository = meetingSummaryRepository;
+        this.projectRepository = projectRepository;
+        this.workLogRepository = workLogRepository;
+        this.decisionRepository = decisionRepository;
+        this.decisionEmbeddingService = decisionEmbeddingService;
+        this.meetingSummaryEmbeddingService = meetingSummaryEmbeddingService;
+        this.derivedItemsTransactionTemplate = new TransactionTemplate(transactionManager);
+        this.derivedItemsTransactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public MeetingSummary saveSummaryRequired(Long projectId, UpdateContextRequest req) {
+        projectRepository.findById(projectId).orElseThrow(() -> new ServiceException("404-2", "프로젝트를 찾을 수 없습니다."));
+        Meeting meeting = findMeetingInProject(projectId, req.meetingId());
+
+        return meetingSummaryRepository.save(MeetingSummary.builder()
+                .meeting(meeting)
+                .summary(req.summary())
+                .unresolvedItems(req.unresolvedItems())
+                .build());
+    }
+
+    public void saveSummaryEmbeddingBestEffort(MeetingSummary savedSummary) {
+        try {
+            meetingSummaryEmbeddingService.processEmbedding(savedSummary);
+        } catch (RuntimeException e) {
+            log.warn(
+                    "Meeting summary embedding failed after summary save - summaryId={}: {}",
+                    savedSummary != null ? savedSummary.getId() : null,
+                    e.getMessage());
+        }
+    }
+
+    public void saveDerivedItemsBestEffort(Long projectId, UpdateContextRequest req) {
+        try {
+            derivedItemsTransactionTemplate.executeWithoutResult(status -> saveDerivedItems(projectId, req));
+        } catch (Exception e) {
+            log.warn(
+                    "Meeting derived context save skipped after summary save - projectId={}, meetingId={}, reason={}",
+                    projectId,
+                    req != null ? req.meetingId() : null,
+                    e.getMessage());
+        }
+    }
+
+    private void saveDerivedItems(Long projectId, UpdateContextRequest req) {
+        Project project = projectRepository
+                .findById(projectId)
+                .orElseThrow(() -> new ServiceException("404-2", "프로젝트를 찾을 수 없습니다."));
+        Meeting meeting = findMeetingInProject(projectId, req.meetingId());
+
+        if (req.decisions() != null) {
+            req.decisions().forEach(content -> {
+                Decision saved = decisionRepository.save(Decision.builder()
+                        .project(project)
+                        .meeting(meeting)
+                        .content(content)
+                        .build());
+                // TODO: Move decision embedding outside this DB transaction in a follow-up.
+                decisionEmbeddingService.processEmbedding(saved);
+            });
+        }
+
+        if (req.actionItems() != null) {
+            req.actionItems()
+                    .forEach(item -> workLogRepository.save(WorkLog.builder()
+                            .meeting(meeting)
+                            .project(project)
+                            .assigneeName(item.assigneeName())
+                            .assigneeDiscordId(item.assigneeDiscordId())
+                            .task(item.task())
+                            .dueDate(item.dueDate())
+                            .build()));
+        }
+
+        decisionRepository.flush();
+        workLogRepository.flush();
+    }
+
+    private Meeting findMeetingInProject(Long projectId, Long meetingId) {
+        Meeting meeting = meetingRepository
+                .findById(meetingId)
+                .orElseThrow(() -> new ServiceException("404-1", "회의를 찾을 수 없습니다."));
+        if (meeting.getProject() == null
+                || !projectId.equals(meeting.getProject().getId())) {
+            throw new ServiceException("400-1", "회의가 요청한 프로젝트에 속하지 않습니다.");
+        }
+        return meeting;
+    }
+}

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/dto/ActionItemRequest.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/dto/ActionItemRequest.java
@@ -5,4 +5,12 @@ import java.time.LocalDate;
 import jakarta.validation.constraints.NotBlank;
 
 public record ActionItemRequest(
-        @NotBlank String assigneeName, @NotBlank String task, LocalDate dueDate) {}
+        String assigneeDiscordId,
+        @NotBlank String assigneeName,
+        @NotBlank String task,
+        LocalDate dueDate) {
+
+    public ActionItemRequest(String assigneeName, String task, LocalDate dueDate) {
+        this(null, assigneeName, task, dueDate);
+    }
+}

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/dto/WorkLogSummary.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/dto/WorkLogSummary.java
@@ -4,12 +4,18 @@ import java.time.LocalDate;
 
 import com.flodiback.domain.project.worklog.entity.WorkLog;
 
-public record WorkLogSummary(Long id, String assigneeName, String task, LocalDate dueDate, String status) {
+public record WorkLogSummary(
+        Long id, String assigneeName, String assigneeDiscordId, String task, LocalDate dueDate, String status) {
+
+    public WorkLogSummary(Long id, String assigneeName, String task, LocalDate dueDate, String status) {
+        this(id, assigneeName, null, task, dueDate, status);
+    }
 
     public static WorkLogSummary from(WorkLog workLog) {
         return new WorkLogSummary(
                 workLog.getId(),
                 workLog.getAssigneeName(),
+                workLog.getAssigneeDiscordId(),
                 workLog.getTask(),
                 workLog.getDueDate(),
                 workLog.getStatus());

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
@@ -3,6 +3,8 @@ package com.flodiback.domain.meeting.meetinglog.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
@@ -18,4 +20,30 @@ public interface UtteranceRepository extends JpaRepository<Utterance, Long> {
     List<Utterance> findTop30ByMeetingOrderByIdDesc(Meeting meeting);
 
     List<Utterance> findTop30ByMeetingAndIdGreaterThanOrderByIdDesc(Meeting meeting, Long id);
+
+    @Query("""
+            select u.speakerDiscordId as speakerDiscordId,
+                   u.speakerName as speakerName,
+                   u.id as firstUtteranceId
+            from Utterance u
+            where u.meeting = :meeting
+              and u.speakerDiscordId is not null
+              and trim(u.speakerDiscordId) <> ''
+              and u.id = (
+                  select min(u2.id)
+                  from Utterance u2
+                  where u2.meeting = :meeting
+                    and u2.speakerDiscordId = u.speakerDiscordId
+              )
+            order by u.id asc
+            """)
+    List<SpeakerProjection> findDistinctSpeakersByMeeting(@Param("meeting") Meeting meeting);
+
+    interface SpeakerProjection {
+        String getSpeakerDiscordId();
+
+        String getSpeakerName();
+
+        Long getFirstUtteranceId();
+    }
 }

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/service/ContextService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/service/ContextService.java
@@ -188,6 +188,7 @@ public class ContextService {
                             .meeting(meeting)
                             .project(project)
                             .assigneeName(item.assigneeName())
+                            .assigneeDiscordId(item.assigneeDiscordId())
                             .task(item.task())
                             .dueDate(item.dueDate())
                             .build()));

--- a/src/main/java/com/flodiback/domain/project/worklog/entity/WorkLog.java
+++ b/src/main/java/com/flodiback/domain/project/worklog/entity/WorkLog.java
@@ -35,6 +35,9 @@ public class WorkLog {
     @Column(name = "assignee_name", nullable = false, length = 100)
     private String assigneeName;
 
+    @Column(name = "assignee_discord_id", length = 50)
+    private String assigneeDiscordId;
+
     @Column(name = "task", nullable = false, columnDefinition = "TEXT")
     private String task;
 
@@ -49,10 +52,17 @@ public class WorkLog {
     private LocalDateTime createdAt;
 
     @Builder
-    public WorkLog(Meeting meeting, Project project, String assigneeName, String task, LocalDate dueDate) {
+    public WorkLog(
+            Meeting meeting,
+            Project project,
+            String assigneeName,
+            String assigneeDiscordId,
+            String task,
+            LocalDate dueDate) {
         this.meeting = meeting;
         this.project = project;
         this.assigneeName = assigneeName;
+        this.assigneeDiscordId = assigneeDiscordId;
         this.task = task;
         this.dueDate = dueDate;
         this.status = "TODO";

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -85,6 +85,7 @@ CREATE TABLE IF NOT EXISTS work_logs (
     meeting_id    BIGINT       NOT NULL REFERENCES meetings (id),
     project_id    BIGINT       NOT NULL REFERENCES projects (id),
     assignee_name VARCHAR(100) NOT NULL,
+    assignee_discord_id VARCHAR(50),
     task          TEXT         NOT NULL,
     due_date      DATE,
     status        VARCHAR(20)  NOT NULL DEFAULT 'TODO',

--- a/src/main/resources/db/migration/V9__worklog_assignee_discord_id.sql
+++ b/src/main/resources/db/migration/V9__worklog_assignee_discord_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE work_logs
+    ADD COLUMN IF NOT EXISTS assignee_discord_id VARCHAR(50);

--- a/src/main/resources/prompts/meeting-analysis-system.md
+++ b/src/main/resources/prompts/meeting-analysis-system.md
@@ -11,32 +11,40 @@
     { "content": "회의에서 확정된 결정 사항" }
   ],
   "worklogs": [
-    { "assigneeName": "담당자 이름", "task": "구체적인 작업 내용", "dueDate": "YYYY-MM-DD 또는 null" }
+    { "assigneeSpeakerKey": "S1 또는 null", "task": "구체적인 작업 내용", "dueDate": "YYYY-MM-DD 또는 null" }
   ]
 }
+
+## Worklog 담당자 식별 규칙
+- worklogs에는 assigneeName을 반환하지 마세요.
+- 담당자는 새 발화 섹션의 `[speaker=S1, name=...]` 형식에 있는 speaker key로만 지정하세요.
+- speaker key는 반드시 새 발화 섹션에 실제로 등장한 `S1`, `S2` 형식의 값만 사용하세요.
+- `speaker=unknown` 발화자에게 배정된 작업은 assigneeSpeakerKey를 null로 반환하세요.
+- rolling summary에는 speaker key가 없으므로, rolling summary에서만 추론한 담당자는 assigneeSpeakerKey를 null로 반환하세요.
+- 담당자가 명확하지 않으면 assigneeSpeakerKey를 null로 반환하세요.
 
 ## 날짜 처리 규칙 (중요)
 오늘 날짜: {today}
 
 - 날짜가 "YYYY-MM-DD"로 명시된 경우: 그대로 사용
-- "이번 주 금요일", "다음 주 화요일" 등 상대적 표현: 오늘 날짜 기준으로 계산하여 "YYYY-MM-DD"로 변환
+- "이번 주 금요일", "다음 주 월요일" 등 상대적 표현: 오늘 날짜 기준으로 계산하여 "YYYY-MM-DD"로 변환
 - 날짜 언급이 전혀 없는 경우에만 null
-- 반드시 "YYYY-MM-DD" 형식 또는 null만 반환, 자연어 문자열 절대 금지
+- 반드시 "YYYY-MM-DD" 형식 또는 null만 반환, 자연어 문자열 금지
 
 ## 결정 사항 vs 업무 분배 구분
 - decisions: 팀 전체에 영향을 주는 확정된 결정 (예: 기능 제외, 일정 확정)
-- worklogs: 특정 담당자에게 배정된 작업 (예: "A씨가 B를 구현하기로 함")
+- worklogs: 특정 담당자에게 배정된 작업 (예: "S1이 B를 구현하기로 함")
 
 ## 출력 예시
-입력: "이서연: 로그인 API는 다음 주 화요일까지 완료할게요. 알림 기능은 이번 스프린트에서 제외하기로 했어요."
+입력: "[speaker=S1, name=이서연] 로그인 API는 다음 주 수요일까지 완료할게요. 알림 기능은 이번 스프린트에서 제외하기로 했어요."
 출력:
 {
   "summary": "...",
   "unresolvedItems": null,
   "decisions": [
-    { "content": "알림 기능을 이번 스프린트 스코프에서 제외" }
+    { "content": "알림 기능은 이번 스프린트 스코프에서 제외" }
   ],
   "worklogs": [
-    { "assigneeName": "이서연", "task": "로그인 API 완료", "dueDate": "2026-05-12" }
+    { "assigneeSpeakerKey": "S1", "task": "로그인 API 완료", "dueDate": "2026-05-12" }
   ]
 }

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
@@ -5,10 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -17,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -29,9 +33,10 @@ import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.meeting.meeting.repository.ContextCacheRepository;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.meeting.meetinglog.dto.UpdateContextRequest;
+import com.flodiback.domain.meeting.meetinglog.entity.MeetingSummary;
 import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
 import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
-import com.flodiback.domain.meeting.meetinglog.service.ContextService;
+import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository.SpeakerProjection;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.global.client.GlmClient;
 import com.flodiback.global.exception.ServiceException;
@@ -52,7 +57,7 @@ class MeetingAnalysisServiceTest {
     private UtteranceRepository utteranceRepository;
 
     @Mock
-    private ContextService contextService;
+    private MeetingContextPersistenceService meetingContextPersistenceService;
 
     @Mock
     private GlmClient glmClient;
@@ -68,7 +73,7 @@ class MeetingAnalysisServiceTest {
     }
 
     @Test
-    void analyze_회의없으면_예외발생() {
+    void analyze_throwsWhenMeetingDoesNotExist() {
         given(meetingRepository.findById(999L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.analyze(999L))
@@ -77,50 +82,187 @@ class MeetingAnalysisServiceTest {
     }
 
     @Test
-    void analyze_캐시없고_발화있을때_updateContext_호출() throws Exception {
+    void analyze_withoutCache_persistsSummaryEmbeddingAndDerivedItemsInOrder() throws Exception {
         Project project = mockProject(10L);
-        Meeting meeting = Meeting.builder().project(project).title("테스트 회의").build();
-        Utterance u1 = utterance(meeting, 1L, "장만월", "API 명세 확정했습니다.", 1);
-        Utterance u2 = utterance(meeting, 2L, "김철수", "다음 주 금요일까지 구현 완료 예정입니다.", 2);
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        Utterance u1 = utterance(meeting, 1L, "Alice", "API spec is decided.", 1);
+        Utterance u2 = utterance(meeting, 2L, "Bob", "I will finish implementation by Friday.", 2);
+        MeetingSummary savedSummary =
+                MeetingSummary.builder().meeting(meeting).summary("saved").build();
         String glmResponse = """
                 {
-                  "summary": "API 명세 확정 및 구현 일정 논의",
+                  "summary": "API spec and implementation schedule were discussed.",
                   "unresolvedItems": null,
                   "worklogs": [
-                    { "assigneeName": "김철수", "task": "구현 완료", "dueDate": "2026-05-04" },
-                    { "assigneeName": "이영희", "task": "테스트 작성", "dueDate": null }
+                    { "assigneeSpeakerKey": "S2", "task": "Finish implementation", "dueDate": "2026-05-04" },
+                    { "assigneeSpeakerKey": "S1", "task": "Write tests", "dueDate": null }
                   ],
                   "decisions": [
-                    { "content": "API 명세를 확정한다" }
+                    { "content": "Finalize API spec" }
                   ]
                 }
                 """;
 
+        givenAnalysisInputs(meeting, List.of(u1, u2), glmResponse);
+        given(meetingContextPersistenceService.saveSummaryRequired(any(), any()))
+                .willReturn(savedSummary);
+
+        service.analyze(1L);
+
+        ArgumentCaptor<UpdateContextRequest> captor = ArgumentCaptor.forClass(UpdateContextRequest.class);
+        InOrder ordered = inOrder(meetingContextPersistenceService);
+        ordered.verify(meetingContextPersistenceService)
+                .saveSummaryRequired(org.mockito.ArgumentMatchers.eq(10L), captor.capture());
+        ordered.verify(meetingContextPersistenceService).saveSummaryEmbeddingBestEffort(savedSummary);
+        ordered.verify(meetingContextPersistenceService)
+                .saveDerivedItemsBestEffort(org.mockito.ArgumentMatchers.eq(10L), any(UpdateContextRequest.class));
+
+        UpdateContextRequest saved = captor.getValue();
+        assertThat(saved.summary()).isEqualTo("API spec and implementation schedule were discussed.");
+        assertThat(saved.unresolvedItems()).isNull();
+        assertThat(saved.decisions()).containsExactly("Finalize API spec");
+        assertThat(saved.actionItems()).hasSize(2);
+        assertThat(saved.actionItems().get(0).assigneeName()).isEqualTo("Bob");
+        assertThat(saved.actionItems().get(0).assigneeDiscordId()).isEqualTo("user-2");
+        assertThat(saved.actionItems().get(0).dueDate()).isEqualTo(LocalDate.of(2026, 5, 4));
+        assertThat(saved.actionItems().get(1).assigneeName()).isEqualTo("Alice");
+        assertThat(saved.actionItems().get(1).assigneeDiscordId()).isEqualTo("user-1");
+        assertThat(saved.actionItems().get(1).dueDate()).isNull();
+    }
+
+    @Test
+    void analyze_normalizesAiGeneratedDerivedItems() throws Exception {
+        Project project = mockProject(10L);
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        String glmResponse = """
+                {
+                  "summary": "  summary  ",
+                  "unresolvedItems": "  unresolved  ",
+                  "worklogs": [
+                    { "assigneeSpeakerKey": null, "task": "  keep task  ", "dueDate": null },
+                    { "assigneeSpeakerKey": "S1", "task": "   ", "dueDate": null }
+                  ],
+                  "decisions": [
+                    { "content": "  keep decision  " },
+                    { "content": "   " },
+                    { "content": null }
+                  ]
+                }
+                """;
+
+        givenAnalysisInputs(meeting, List.of(), glmResponse);
+
+        service.analyze(1L);
+
+        ArgumentCaptor<UpdateContextRequest> captor = ArgumentCaptor.forClass(UpdateContextRequest.class);
+        verify(meetingContextPersistenceService)
+                .saveSummaryRequired(org.mockito.ArgumentMatchers.eq(10L), captor.capture());
+        UpdateContextRequest request = captor.getValue();
+        assertThat(request.summary()).isEqualTo("summary");
+        assertThat(request.unresolvedItems()).isEqualTo("unresolved");
+        assertThat(request.decisions()).containsExactly("keep decision");
+        assertThat(request.actionItems()).hasSize(1);
+        assertThat(request.actionItems().get(0).assigneeName()).isEqualTo("담당자 미정");
+        assertThat(request.actionItems().get(0).assigneeDiscordId()).isNull();
+        assertThat(request.actionItems().get(0).task()).isEqualTo("keep task");
+    }
+
+    @Test
+    void analyze_assignsSpeakerKeysByFirstUtteranceIdAndFormatsPrompt() throws Exception {
+        Project project = mockProject(10L);
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        Utterance bobFirst = utterance(meeting, 1L, "Bob", "I can do API.", 1);
+        Utterance aliceSecond = utterance(meeting, 2L, "Alice", "I can test it.", 2);
+
+        givenAnalysisInputs(meeting, List.of(aliceSecond, bobFirst), emptyAnalysisJson());
+
+        service.analyze(1L);
+
+        ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(glmClient).chat(anyString(), userPromptCaptor.capture());
+        assertThat(userPromptCaptor.getValue())
+                .contains("[speaker=S1, name=Bob] I can do API.")
+                .contains("[speaker=S2, name=Alice] I can test it.")
+                .containsSubsequence("I can do API.", "I can test it.");
+    }
+
+    @Test
+    void analyze_unknownSpeakerKeyFallsBackToUnknownAssignee() throws Exception {
+        Project project = mockProject(10L);
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        String glmResponse = """
+                {
+                  "summary": "summary",
+                  "unresolvedItems": null,
+                  "worklogs": [
+                    { "assigneeSpeakerKey": "S99", "task": "keep task", "dueDate": null }
+                  ],
+                  "decisions": []
+                }
+                """;
+
+        givenAnalysisInputs(meeting, List.of(), glmResponse);
+
+        service.analyze(1L);
+
+        ArgumentCaptor<UpdateContextRequest> captor = ArgumentCaptor.forClass(UpdateContextRequest.class);
+        verify(meetingContextPersistenceService)
+                .saveSummaryRequired(org.mockito.ArgumentMatchers.eq(10L), captor.capture());
+        assertThat(captor.getValue().actionItems()).hasSize(1);
+        assertThat(captor.getValue().actionItems().get(0).assigneeName()).isEqualTo("담당자 미정");
+        assertThat(captor.getValue().actionItems().get(0).assigneeDiscordId()).isNull();
+    }
+
+    @Test
+    void analyze_utteranceWithoutSpeakerDiscordIdUsesUnknownSpeakerInPrompt() throws Exception {
+        Project project = mockProject(10L);
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        Utterance utterance = utterance(meeting, 1L, "Guest", "I will check it.", 1);
+        ReflectionTestUtils.setField(utterance, "speakerDiscordId", null);
+
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
                 .willReturn(Optional.empty());
-        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(List.of(u1, u2));
-        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponse);
+        given(utteranceRepository.findDistinctSpeakersByMeeting(meeting)).willReturn(List.of());
+        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(List.of(utterance));
+        given(glmClient.chat(anyString(), anyString())).willReturn(emptyAnalysisJson());
         given(objectMapper.readValue(anyString(), any(Class.class)))
                 .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
 
         service.analyze(1L);
 
-        ArgumentCaptor<UpdateContextRequest> captor = ArgumentCaptor.forClass(UpdateContextRequest.class);
-        verify(contextService).updateContext(org.mockito.ArgumentMatchers.eq(10L), captor.capture());
-        UpdateContextRequest saved = captor.getValue();
-        assertThat(saved.summary()).isEqualTo("API 명세 확정 및 구현 일정 논의");
-        assertThat(saved.unresolvedItems()).isNull();
-        assertThat(saved.decisions()).containsExactly("API 명세를 확정한다");
-        assertThat(saved.actionItems()).hasSize(2);
-        assertThat(saved.actionItems().get(0).dueDate()).isEqualTo(LocalDate.of(2026, 5, 4));
-        assertThat(saved.actionItems().get(1).dueDate()).isNull();
+        ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(glmClient).chat(anyString(), userPromptCaptor.capture());
+        assertThat(userPromptCaptor.getValue()).contains("[speaker=unknown, name=Guest] I will check it.");
     }
 
     @Test
-    void analyze_캐시있을때_latestCache하나와_이후발화만_context에_포함() throws Exception {
+    void analyze_blankSummary_doesNotPersistAnything() throws Exception {
         Project project = mockProject(10L);
-        Meeting meeting = Meeting.builder().project(project).title("테스트 회의").build();
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        String glmResponse = """
+                {
+                  "summary": "   ",
+                  "unresolvedItems": null,
+                  "worklogs": [],
+                  "decisions": []
+                }
+                """;
+
+        givenAnalysisInputs(meeting, List.of(), glmResponse);
+
+        assertThatThrownBy(() -> service.analyze(1L))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("summary is blank");
+        verify(meetingContextPersistenceService, never()).saveSummaryRequired(any(), any());
+        verify(meetingContextPersistenceService, never()).saveSummaryEmbeddingBestEffort(any());
+        verify(meetingContextPersistenceService, never()).saveDerivedItemsBestEffort(any(), any());
+    }
+
+    @Test
+    void analyze_withLatestCache_usesOnlyLatestSummaryAndLaterUtterances() throws Exception {
+        Project project = mockProject(10L);
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
         ContextCache oldCache = ContextCache.builder()
                 .meeting(meeting)
                 .version(1)
@@ -135,11 +277,13 @@ class MeetingAnalysisServiceTest {
                 .tokenCount(100)
                 .compressedUntilUtteranceId(10L)
                 .build();
-        Utterance later = utterance(meeting, 11L, "장만월", "이후 발화", 2);
+        Utterance later = utterance(meeting, 11L, "Alice", "later utterance", 2);
 
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
                 .willReturn(Optional.of(latestCache));
+        given(utteranceRepository.findDistinctSpeakersByMeeting(meeting))
+                .willReturn(List.of(speaker("user-11", "Alice", 11L)));
         given(utteranceRepository.findByMeetingAndIdGreaterThanOrderByIdAsc(meeting, 10L))
                 .willReturn(List.of(later));
         given(glmClient.chat(anyString(), anyString())).willReturn(emptyAnalysisJson());
@@ -151,76 +295,64 @@ class MeetingAnalysisServiceTest {
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
         verify(glmClient).chat(anyString(), userPromptCaptor.capture());
         String userPrompt = userPromptCaptor.getValue();
-        assertThat(userPrompt).contains("[현재 회의 rolling summary]");
         assertThat(userPrompt).contains("latest summary");
         assertThat(userPrompt).doesNotContain("old summary");
-        assertThat(userPrompt).contains("[rolling summary에 아직 반영되지 않은 발화]");
-        assertThat(userPrompt).contains("이후 발화");
+        assertThat(userPrompt).contains("[speaker=S1, name=Alice] later utterance");
         assertThat(oldCache.getVersion()).isEqualTo(1);
     }
 
     @Test
-    void analyze_context발화는_speechStartedAt_asc_id_asc로_정렬() throws Exception {
+    void analyze_sortsContextUtterancesBySpeechStartedAtThenId() throws Exception {
         Project project = mockProject(10L);
-        Meeting meeting = Meeting.builder().project(project).title("테스트 회의").build();
-        Utterance second = utterance(meeting, 2L, "B", "두번째", 20);
-        Utterance first = utterance(meeting, 1L, "A", "첫번째", 10);
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        Utterance second = utterance(meeting, 2L, "B", "second", 20);
+        Utterance first = utterance(meeting, 1L, "A", "first", 10);
 
-        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
-        given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
-                .willReturn(Optional.empty());
-        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(List.of(second, first));
-        given(glmClient.chat(anyString(), anyString())).willReturn(emptyAnalysisJson());
-        given(objectMapper.readValue(anyString(), any(Class.class)))
-                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+        givenAnalysisInputs(meeting, List.of(second, first), emptyAnalysisJson());
 
         service.analyze(1L);
 
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
         verify(glmClient).chat(anyString(), userPromptCaptor.capture());
-        assertThat(userPromptCaptor.getValue()).containsSubsequence("첫번째", "두번째");
+        assertThat(userPromptCaptor.getValue()).containsSubsequence("first", "second");
     }
 
     @Test
-    void analyze_glm응답_마크다운코드블록_제거후_파싱() throws Exception {
+    void analyze_stripsMarkdownJsonCodeBlock() throws Exception {
         Project project = mockProject(10L);
-        Meeting meeting = Meeting.builder().project(project).title("테스트 회의").build();
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
         String glmResponseWithCodeBlock = """
                 ```json
                 {
-                  "summary": "마크다운 포함 응답",
-                  "unresolvedItems": "미결 사항 있음",
+                  "summary": "markdown response",
+                  "unresolvedItems": "open issue",
                   "worklogs": [],
                   "decisions": []
                 }
                 ```""";
 
-        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
-        given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
-                .willReturn(Optional.empty());
-        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(List.of());
-        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponseWithCodeBlock);
-        given(objectMapper.readValue(anyString(), any(Class.class)))
-                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+        givenAnalysisInputs(meeting, List.of(), glmResponseWithCodeBlock);
 
         service.analyze(1L);
 
         ArgumentCaptor<UpdateContextRequest> captor = ArgumentCaptor.forClass(UpdateContextRequest.class);
-        verify(contextService).updateContext(org.mockito.ArgumentMatchers.eq(10L), captor.capture());
-        assertThat(captor.getValue().summary()).isEqualTo("마크다운 포함 응답");
-        assertThat(captor.getValue().unresolvedItems()).isEqualTo("미결 사항 있음");
+        verify(meetingContextPersistenceService)
+                .saveSummaryRequired(org.mockito.ArgumentMatchers.eq(10L), captor.capture());
+        assertThat(captor.getValue().summary()).isEqualTo("markdown response");
+        assertThat(captor.getValue().unresolvedItems()).isEqualTo("open issue");
     }
 
     @Test
-    void analyze_glm응답_파싱실패시_예외발생() throws Exception {
+    void analyze_throwsWhenGlmResponseCannotBeParsed() throws Exception {
         Project project = mockProject(10L);
-        Meeting meeting = Meeting.builder().project(project).title("테스트 회의").build();
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
 
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
                 .willReturn(Optional.empty());
+        given(utteranceRepository.findDistinctSpeakersByMeeting(meeting)).willReturn(List.of());
         given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(List.of());
-        given(glmClient.chat(anyString(), anyString())).willReturn("이건 JSON이 아닙니다");
+        given(glmClient.chat(anyString(), anyString())).willReturn("not json");
         given(objectMapper.readValue(anyString(), any(Class.class)))
                 .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
 
@@ -230,8 +362,8 @@ class MeetingAnalysisServiceTest {
     }
 
     @Test
-    void analyze_프로젝트없는_회의면_ServiceException() {
-        Meeting meeting = Meeting.builder().title("테스트 회의").build();
+    void analyze_throwsWhenMeetingHasNoProject() {
+        Meeting meeting = Meeting.builder().title("meeting").build();
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
 
         assertThatThrownBy(() -> service.analyze(1L))
@@ -239,10 +371,21 @@ class MeetingAnalysisServiceTest {
                 .hasMessageContaining("회의에 연결된 프로젝트가 없습니다.");
     }
 
+    private void givenAnalysisInputs(Meeting meeting, List<Utterance> utterances, String glmResponse) throws Exception {
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
+                .willReturn(Optional.empty());
+        given(utteranceRepository.findDistinctSpeakersByMeeting(meeting)).willReturn(speakersFrom(utterances));
+        given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(utterances);
+        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponse);
+        given(objectMapper.readValue(anyString(), any(Class.class)))
+                .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
+    }
+
     private String emptyAnalysisJson() {
         return """
                 {
-                  "summary": "요약",
+                  "summary": "summary",
                   "unresolvedItems": null,
                   "worklogs": [],
                   "decisions": []
@@ -260,6 +403,39 @@ class MeetingAnalysisServiceTest {
                 .build();
         ReflectionTestUtils.setField(utterance, "id", id);
         return utterance;
+    }
+
+    private List<SpeakerProjection> speakersFrom(List<Utterance> utterances) {
+        return utterances.stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        Utterance::getSpeakerDiscordId,
+                        utterance -> utterance,
+                        (left, right) -> left.getId() <= right.getId() ? left : right))
+                .values()
+                .stream()
+                .sorted(Comparator.comparing(Utterance::getId))
+                .map(utterance ->
+                        speaker(utterance.getSpeakerDiscordId(), utterance.getSpeakerName(), utterance.getId()))
+                .toList();
+    }
+
+    private SpeakerProjection speaker(String discordId, String name, Long firstUtteranceId) {
+        return new SpeakerProjection() {
+            @Override
+            public String getSpeakerDiscordId() {
+                return discordId;
+            }
+
+            @Override
+            public String getSpeakerName() {
+                return name;
+            }
+
+            @Override
+            public Long getFirstUtteranceId() {
+                return firstUtteranceId;
+            }
+        };
     }
 
     private Project mockProject(Long id) {

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceServiceTest.java
@@ -1,0 +1,217 @@
+package com.flodiback.domain.meeting.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import com.flodiback.domain.decision.decision.entity.Decision;
+import com.flodiback.domain.decision.decision.repository.DecisionRepository;
+import com.flodiback.domain.decision.decision.service.DecisionEmbeddingService;
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
+import com.flodiback.domain.meeting.meetinglog.dto.ActionItemRequest;
+import com.flodiback.domain.meeting.meetinglog.dto.UpdateContextRequest;
+import com.flodiback.domain.meeting.meetinglog.entity.MeetingSummary;
+import com.flodiback.domain.meeting.meetinglog.repository.MeetingSummaryRepository;
+import com.flodiback.domain.meeting.meetinglog.service.MeetingSummaryEmbeddingService;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.domain.project.worklog.entity.WorkLog;
+import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
+import com.flodiback.global.exception.ServiceException;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingContextPersistenceServiceTest {
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @Mock
+    private MeetingSummaryRepository meetingSummaryRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private WorkLogRepository workLogRepository;
+
+    @Mock
+    private DecisionRepository decisionRepository;
+
+    @Mock
+    private DecisionEmbeddingService decisionEmbeddingService;
+
+    @Mock
+    private MeetingSummaryEmbeddingService meetingSummaryEmbeddingService;
+
+    @Mock
+    private PlatformTransactionManager transactionManager;
+
+    private MeetingContextPersistenceService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MeetingContextPersistenceService(
+                meetingRepository,
+                meetingSummaryRepository,
+                projectRepository,
+                workLogRepository,
+                decisionRepository,
+                decisionEmbeddingService,
+                meetingSummaryEmbeddingService,
+                transactionManager);
+    }
+
+    @Test
+    void saveSummaryRequired_savesOnlySummaryAndReturnsSavedEntity() {
+        Project project = project(1L);
+        Meeting meeting = meeting(project);
+        UpdateContextRequest req = new UpdateContextRequest(10L, "summary", "open", null, null);
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
+        given(meetingSummaryRepository.save(any(MeetingSummary.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        MeetingSummary saved = service.saveSummaryRequired(1L, req);
+
+        assertThat(saved.getSummary()).isEqualTo("summary");
+        assertThat(saved.getUnresolvedItems()).isEqualTo("open");
+        verify(meetingSummaryRepository).save(any(MeetingSummary.class));
+        verify(decisionRepository, never()).save(any());
+        verify(workLogRepository, never()).save(any());
+    }
+
+    @Test
+    void saveSummaryEmbeddingBestEffort_swallowsEmbeddingFailure() {
+        MeetingSummary summary = MeetingSummary.builder()
+                .meeting(meeting(project(1L)))
+                .summary("summary")
+                .build();
+        doThrow(new RuntimeException("embedding failed"))
+                .when(meetingSummaryEmbeddingService)
+                .processEmbedding(summary);
+
+        assertThatCode(() -> service.saveSummaryEmbeddingBestEffort(summary)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void saveDerivedItemsBestEffort_savesDecisionsAndWorkLogs() {
+        Project project = project(1L);
+        Meeting meeting = meeting(project);
+        UpdateContextRequest req = new UpdateContextRequest(
+                10L,
+                "summary",
+                null,
+                List.of("decision-1", "decision-2"),
+                List.of(
+                        new ActionItemRequest("discord-alice", "Alice", "write API", null),
+                        new ActionItemRequest("Bob", "test API", null)));
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
+        given(decisionRepository.save(any(Decision.class))).willAnswer(invocation -> invocation.getArgument(0));
+        stubNewTransaction();
+
+        service.saveDerivedItemsBestEffort(1L, req);
+
+        ArgumentCaptor<TransactionDefinition> transactionDefinitionCaptor =
+                ArgumentCaptor.forClass(TransactionDefinition.class);
+        verify(transactionManager).getTransaction(transactionDefinitionCaptor.capture());
+        assertThat(transactionDefinitionCaptor.getValue().getPropagationBehavior())
+                .isEqualTo(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        verify(decisionRepository, times(2)).save(any(Decision.class));
+        verify(decisionEmbeddingService, times(2)).processEmbedding(any(Decision.class));
+        ArgumentCaptor<WorkLog> workLogCaptor = ArgumentCaptor.forClass(WorkLog.class);
+        verify(workLogRepository, times(2)).save(workLogCaptor.capture());
+        assertThat(workLogCaptor.getAllValues())
+                .extracting(WorkLog::getAssigneeName)
+                .containsExactly("Alice", "Bob");
+        assertThat(workLogCaptor.getAllValues())
+                .extracting(WorkLog::getAssigneeDiscordId)
+                .containsExactly("discord-alice", null);
+    }
+
+    @Test
+    void saveDerivedItemsBestEffort_swallowsWorkLogFailure() {
+        Project project = project(1L);
+        Meeting meeting = meeting(project);
+        UpdateContextRequest req = new UpdateContextRequest(
+                10L, "summary", null, null, List.of(new ActionItemRequest("Alice", "write API", null)));
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
+        given(workLogRepository.save(any(WorkLog.class))).willThrow(new RuntimeException("worklog failed"));
+        stubNewTransaction();
+
+        assertThatCode(() -> service.saveDerivedItemsBestEffort(1L, req)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void saveDerivedItemsBestEffort_swallowsTransactionFailure() {
+        Project project = project(1L);
+        Meeting meeting = meeting(project);
+        UpdateContextRequest req = new UpdateContextRequest(
+                10L, "summary", null, null, List.of(new ActionItemRequest("Alice", "write API", null)));
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
+        stubNewTransaction();
+        doThrow(new RuntimeException("commit failed")).when(transactionManager).commit(any());
+
+        assertThatCode(() -> service.saveDerivedItemsBestEffort(1L, req)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void saveSummaryRequired_throwsWhenMeetingProjectDoesNotMatch() {
+        Project requestedProject = project(1L);
+        Project otherProject = project(2L);
+        Meeting meeting = meeting(otherProject);
+        UpdateContextRequest req = new UpdateContextRequest(10L, "summary", null, null, null);
+        given(projectRepository.findById(1L)).willReturn(Optional.of(requestedProject));
+        given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
+
+        assertThatThrownBy(() -> service.saveSummaryRequired(1L, req)).isInstanceOf(ServiceException.class);
+    }
+
+    @Test
+    void saveSummaryRequired_throwsWhenMeetingDoesNotExist() {
+        UpdateContextRequest req = new UpdateContextRequest(10L, "summary", null, null, null);
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project(1L)));
+        given(meetingRepository.findById(10L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.saveSummaryRequired(1L, req)).isInstanceOf(ServiceException.class);
+    }
+
+    private Project project(Long id) {
+        Project project = Project.builder().name("project").build();
+        ReflectionTestUtils.setField(project, "id", id);
+        return project;
+    }
+
+    private Meeting meeting(Project project) {
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        ReflectionTestUtils.setField(meeting, "id", 10L);
+        return meeting;
+    }
+
+    private void stubNewTransaction() {
+        given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    }
+}

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
@@ -279,7 +279,7 @@ class ContextServiceTest {
                 null,
                 List.of("decision-1", "decision-2"),
                 List.of(
-                        new ActionItemRequest("Alice", "write API", null),
+                        new ActionItemRequest("discord-alice", "Alice", "write API", null),
                         new ActionItemRequest("Bob", "test API", null)));
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
@@ -291,7 +291,11 @@ class ContextServiceTest {
 
         verify(decisionRepository, times(2)).save(any(Decision.class));
         verify(decisionEmbeddingService, times(2)).processEmbedding(any(Decision.class));
-        verify(workLogRepository, times(2)).save(any(WorkLog.class));
+        org.mockito.ArgumentCaptor<WorkLog> workLogCaptor = org.mockito.ArgumentCaptor.forClass(WorkLog.class);
+        verify(workLogRepository, times(2)).save(workLogCaptor.capture());
+        assertThat(workLogCaptor.getAllValues())
+                .extracting(WorkLog::getAssigneeDiscordId)
+                .containsExactly("discord-alice", null);
     }
 
     @Test


### PR DESCRIPTION
## Summary

회의 종료 분석 저장 안정성과 WorkLog 담당자 식별 정확도를 개선했습니다.

- `meetingSummary`는 decision/worklog 저장 실패와 분리해 먼저 저장되도록 변경
- AI 분석 결과를 저장 전에 정규화해 null/blank 값으로 인한 저장 실패 방지
- WorkLog 담당자를 이름 문자열 추론에만 의존하지 않고, 서버 speaker key 매핑을 통해 `assigneeDiscordId`까지 저장

## Changes

### 회의 종료 분석 저장 안정화

- `MeetingContextPersistenceService` 추가
  - `saveSummaryRequired()`
    - `REQUIRES_NEW`로 `MeetingSummary`만 먼저 저장
    - 저장된 `MeetingSummary` 반환
  - `saveSummaryEmbeddingBestEffort()`
    - summary 커밋 이후 embedding 처리
    - 실패해도 warn 로그만 남기고 전파하지 않음
  - `saveDerivedItemsBestEffort()`
    - decision/worklog 저장을 별도 `TransactionTemplate(REQUIRES_NEW)`으로 처리
    - flush/commit 단계 예외까지 catch해 summary 저장을 롤백하지 않음

- `MeetingAnalysisService.analyze()` 저장 순서 명시
  - summary 저장
  - summary embedding
  - derived items 저장
  - self-invocation으로 `REQUIRES_NEW`가 무시되지 않도록 외부 service 호출 구조 유지

- AI 분석 결과 저장 전 정규화
  - blank/null summary는 분석 실패로 처리
  - blank/null decision content는 제외
  - blank/null worklog task는 제외
  - 담당자 식별 실패 시 `assigneeName="담당자 미정"`으로 저장

### WorkLog 실제 담당자 식별

- `work_logs.assignee_discord_id` nullable 컬럼 추가
  - 기존 데이터와 기존 context update API 하위 호환 유지

- WorkLog 관련 DTO/model 확장
  - `WorkLog.assigneeDiscordId`
  - `ActionItemRequest.assigneeDiscordId`
  - `WorkLogSummary.assigneeDiscordId`

- 회의 분석 응답 DTO 변경
  - `WorkLogItem`에서 `assigneeName` 제거
  - GLM은 `assigneeSpeakerKey`, `task`, `dueDate`만 반환

- speaker key 기반 담당자 매핑 추가
  - 회의 전체 발화자 distinct 목록을 조회
  - `firstUtteranceId ASC` 기준으로 `S1`, `S2` 부여
  - prompt에는 raw Discord ID를 넣지 않고 `[speaker=S1, name=...]` 형식만 사용
  - GLM 응답의 `assigneeSpeakerKey`를 서버가 `assigneeName`/`assigneeDiscordId`로 확정
  - unknown/null key는 `담당자 미정`, `assigneeDiscordId=null`로 저장

- `meeting-analysis-system.md` 갱신
  - worklogs는 `assigneeSpeakerKey`, `task`, `dueDate`만 반환하도록 변경
  - `speaker=unknown` 또는 rolling summary에서만 추론한 담당자는 key를 지어내지 않고 `null` 반환하도록 명시

### Docs

- `docs/generated/db-schema.md` 갱신
- `docs/references/internal-api-contracts.md` 갱신
- 구현 기록 추가
  - `docs/impl/codex/0512-worklog-assignee-discord-id.md`

## Compatibility

- 기존 `/internal/v1/projects/{projectId}/context` 요청은 유지됩니다.
- 기존처럼 `assigneeName`, `task`, `dueDate`만 보내도 저장됩니다.
- `assigneeDiscordId`는 optional이며 없으면 `null`로 저장됩니다.
- `assigneeName`, `task`의 기존 `@NotBlank` 검증은 유지됩니다.

## Verification

- 관련 테스트 통과

```bash
./gradlew test --tests "com.flodiback.domain.meeting.analysis.service.*" --tests "com.flodiback.domain.meeting.meetinglog.service.ContextServiceTest" --tests "com.flodiback.api.project.ProjectContextControllerTest"