### PR TITLE
[feat] AI 응답 품질 회복 및 OpenAI 전용 출력 제어

### DIFF
--- a/src/main/java/com/flodiback/domain/ai/service/AiChatService.java
+++ b/src/main/java/com/flodiback/domain/ai/service/AiChatService.java
@@ -2,6 +2,7 @@ package com.flodiback.domain.ai.service;
 
 public interface AiChatService {
 
-    // 호출어/RAG 흐름이 실제 GLM SDK 구현체에 직접 의존하지 않도록 분리합니다.
-    String generateAnswer(String systemPrompt, String userQuestion);
+    String generateShortAnswer(String systemPrompt, String userQuestion);
+
+    String generateSummary(String systemPrompt, String userQuestion);
 }

--- a/src/main/java/com/flodiback/domain/ai/service/DisabledAiChatService.java
+++ b/src/main/java/com/flodiback/domain/ai/service/DisabledAiChatService.java
@@ -11,8 +11,16 @@ import com.flodiback.global.exception.ServiceException;
 public class DisabledAiChatService implements AiChatService {
 
     @Override
-    public String generateAnswer(String systemPrompt, String userQuestion) {
-        // 로컬/테스트 환경에서 GLM 키 없이 실행할 수 있도록 명확히 비활성 상태를 알립니다.
-        throw new ServiceException("503-1", "GLM 채팅 서비스가 비활성화되어 있습니다.");
+    public String generateShortAnswer(String systemPrompt, String userQuestion) {
+        throw disabledException();
+    }
+
+    @Override
+    public String generateSummary(String systemPrompt, String userQuestion) {
+        throw disabledException();
+    }
+
+    private ServiceException disabledException() {
+        return new ServiceException("503-1", "AI chat service is disabled.");
     }
 }

--- a/src/main/java/com/flodiback/domain/ai/service/GlmAiChatService.java
+++ b/src/main/java/com/flodiback/domain/ai/service/GlmAiChatService.java
@@ -16,8 +16,12 @@ public class GlmAiChatService implements AiChatService {
     private final GlmClient glmClient;
 
     @Override
-    public String generateAnswer(String systemPrompt, String userQuestion) {
-        // 실제 GLM 호출은 공용 GlmClient에 위임해 호출부가 SDK 세부 구현을 몰라도 되게 합니다.
+    public String generateShortAnswer(String systemPrompt, String userQuestion) {
+        return glmClient.chat(systemPrompt, userQuestion);
+    }
+
+    @Override
+    public String generateSummary(String systemPrompt, String userQuestion) {
         return glmClient.chat(systemPrompt, userQuestion);
     }
 }

--- a/src/main/java/com/flodiback/domain/ai/service/OpenAiChatService.java
+++ b/src/main/java/com/flodiback/domain/ai/service/OpenAiChatService.java
@@ -13,10 +13,17 @@ import lombok.RequiredArgsConstructor;
 @Conditional(OpenAiProviderCondition.class)
 public class OpenAiChatService implements AiChatService {
 
+    private static final int SHORT_ANSWER_MAX_COMPLETION_TOKENS = 256;
+
     private final OpenAiChatClient openAiChatClient;
 
     @Override
-    public String generateAnswer(String systemPrompt, String userQuestion) {
+    public String generateShortAnswer(String systemPrompt, String userQuestion) {
+        return openAiChatClient.chat(systemPrompt, userQuestion, SHORT_ANSWER_MAX_COMPLETION_TOKENS);
+    }
+
+    @Override
+    public String generateSummary(String systemPrompt, String userQuestion) {
         return openAiChatClient.chat(systemPrompt, userQuestion);
     }
 }

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepository.java
@@ -2,6 +2,7 @@ package com.flodiback.domain.meeting.meetinglog.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,9 +18,9 @@ public interface UtteranceRepository extends JpaRepository<Utterance, Long> {
 
     List<Utterance> findByMeetingAndIdGreaterThanOrderByIdAsc(Meeting meeting, Long id);
 
-    List<Utterance> findTop30ByMeetingOrderByIdDesc(Meeting meeting);
+    List<Utterance> findByMeetingOrderByIdDesc(Meeting meeting, Pageable pageable);
 
-    List<Utterance> findTop30ByMeetingAndIdGreaterThanOrderByIdDesc(Meeting meeting, Long id);
+    List<Utterance> findByMeetingAndIdGreaterThanOrderByIdDesc(Meeting meeting, Long id, Pageable pageable);
 
     @Query("""
             select u.speakerDiscordId as speakerDiscordId,

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryService.java
@@ -13,8 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RollingSummaryService {
 
-    static final int TOKEN_THRESHOLD = 1800;
-    static final int KEEP_TURNS = 12;
+    static final int TOKEN_THRESHOLD = 2600;
+    static final int KEEP_TURNS = 18;
 
     private static final String SYSTEM_PROMPT = """
             당신은 회의 내용을 압축하는 AI 요약기입니다.
@@ -43,7 +43,7 @@ public class RollingSummaryService {
     public void compressIfNeeded(Long meetingId) {
         try {
             rollingSummaryPersistenceService.prepareCompression(meetingId).ifPresent(candidate -> {
-                String compressedText = aiChatService.generateAnswer(SYSTEM_PROMPT, candidate.userPrompt());
+                String compressedText = aiChatService.generateSummary(SYSTEM_PROMPT, candidate.userPrompt());
                 if (!StringUtils.hasText(compressedText)) {
                     log.warn("Rolling summary GLM returned blank result. meetingId={}", meetingId);
                     return;

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/service/ContextService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/service/ContextService.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,9 +49,10 @@ public class ContextService {
 
     private static final double SEMANTIC_WEIGHT = 0.7;
     private static final double KEYWORD_WEIGHT = 0.3;
-    private static final int TOP_K = 3;
-    private static final int UNCOMPRESSED_TOKEN_BUDGET = 1200;
-    private static final int MIN_RECENT_UTTERANCE_COUNT = 10;
+    private static final int TOP_K = 5;
+    private static final int RECENT_DB_LIMIT = 60;
+    private static final int UNCOMPRESSED_TOKEN_BUDGET = 2200;
+    private static final int MIN_RECENT_UTTERANCE_COUNT = 16;
 
     private final MeetingRepository meetingRepository;
     private final UtteranceRepository utteranceRepository;
@@ -89,14 +91,15 @@ public class ContextService {
                 .findTopByMeetingOrderByVersionDesc(meeting)
                 .orElse(null);
         if (latestCache == null) {
-            List<Utterance> fetched = utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting);
+            List<Utterance> fetched =
+                    utteranceRepository.findByMeetingOrderByIdDesc(meeting, PageRequest.of(0, RECENT_DB_LIMIT));
             List<Utterance> recentUtterances = selectRecentUtterances(fetched);
             logShortTerm(meeting.getId(), startedAtNanos, false, fetched.size(), recentUtterances.size());
             return new ShortTermParts(null, recentUtterances);
         }
 
-        List<Utterance> fetched = utteranceRepository.findTop30ByMeetingAndIdGreaterThanOrderByIdDesc(
-                meeting, latestCache.getCompressedUntilUtteranceId());
+        List<Utterance> fetched = utteranceRepository.findByMeetingAndIdGreaterThanOrderByIdDesc(
+                meeting, latestCache.getCompressedUntilUtteranceId(), PageRequest.of(0, RECENT_DB_LIMIT));
         List<Utterance> recentUtterances = selectRecentUtterances(fetched);
         logShortTerm(meeting.getId(), startedAtNanos, true, fetched.size(), recentUtterances.size());
         return new ShortTermParts(latestCache.getCompressedText(), recentUtterances);

--- a/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
+++ b/src/main/java/com/flodiback/domain/speech/service/SpeechAiAnswerService.java
@@ -24,12 +24,12 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SpeechAiAnswerService {
 
-    private static final int ROLLING_SUMMARY_MAX_CHARS = 800;
-    private static final int UNRESOLVED_ITEMS_MAX_CHARS = 400;
-    private static final int PROJECT_METADATA_MAX_CHARS = 300;
-    private static final int DECISION_CONTENT_MAX_CHARS = 250;
-    private static final int PAST_SUMMARY_MAX_CHARS = 400;
-    private static final int WORK_LOG_TASK_MAX_CHARS = 160;
+    private static final int ROLLING_SUMMARY_MAX_CHARS = 1400;
+    private static final int UNRESOLVED_ITEMS_MAX_CHARS = 700;
+    private static final int PROJECT_METADATA_MAX_CHARS = 600;
+    private static final int DECISION_CONTENT_MAX_CHARS = 500;
+    private static final int PAST_SUMMARY_MAX_CHARS = 800;
+    private static final int WORK_LOG_TASK_MAX_CHARS = 240;
 
     private static final String SYSTEM_PROMPT = """
             너는 Discord 회의에 참여하는 AI 회의 보조자야.
@@ -46,7 +46,7 @@ public class SpeechAiAnswerService {
         long totalStartedAtNanos = System.nanoTime();
         long contextElapsedMs = -1L;
         long promptElapsedMs = -1L;
-        long glmElapsedMs = -1L;
+        long chatElapsedMs = -1L;
         int promptChars = -1;
         int recentUtteranceCount = -1;
         int questionDecisionCount = -1;
@@ -73,7 +73,7 @@ public class SpeechAiAnswerService {
             questionSummaryCount = context.questionContext().pastSummaries().size();
 
             log.info(
-                    "AI answer GLM call started. meetingId={}, promptChars={}, systemPromptChars={}, recentUtterances={}, questionDecisions={}, questionSummaries={}",
+                    "AI answer chat call started. meetingId={}, promptChars={}, systemPromptChars={}, recentUtterances={}, questionDecisions={}, questionSummaries={}",
                     meetingId,
                     promptChars,
                     SYSTEM_PROMPT.length(),
@@ -81,22 +81,22 @@ public class SpeechAiAnswerService {
                     questionDecisionCount,
                     questionSummaryCount);
 
-            long glmStartedAtNanos = System.nanoTime();
+            long chatStartedAtNanos = System.nanoTime();
             String answer;
             try {
-                answer = aiChatService.generateAnswer(SYSTEM_PROMPT, userPrompt);
+                answer = aiChatService.generateShortAnswer(SYSTEM_PROMPT, userPrompt);
             } finally {
-                glmElapsedMs = elapsedMillis(glmStartedAtNanos);
+                chatElapsedMs = elapsedMillis(chatStartedAtNanos);
             }
             long totalElapsedMs = elapsedMillis(totalStartedAtNanos);
 
             log.info(
-                    "AI answer generated. meetingId={}, totalMs={}, contextMs={}, promptMs={}, glmMs={}, promptChars={}, recentUtterances={}, questionDecisions={}, questionSummaries={}",
+                    "AI answer generated. meetingId={}, totalMs={}, contextMs={}, promptMs={}, chatMs={}, promptChars={}, recentUtterances={}, questionDecisions={}, questionSummaries={}",
                     meetingId,
                     totalElapsedMs,
                     contextElapsedMs,
                     promptElapsedMs,
-                    glmElapsedMs,
+                    chatElapsedMs,
                     promptChars,
                     recentUtteranceCount,
                     questionDecisionCount,
@@ -105,12 +105,12 @@ public class SpeechAiAnswerService {
             return StringUtils.hasText(answer) ? answer.strip() : null;
         } catch (RuntimeException e) {
             log.warn(
-                    "AI answer generation failed. meetingId={}, totalMs={}, contextMs={}, promptMs={}, glmMs={}, promptChars={}, recentUtterances={}, questionDecisions={}, questionSummaries={}, exceptionType={}, reason={}",
+                    "AI answer generation failed. meetingId={}, totalMs={}, contextMs={}, promptMs={}, chatMs={}, promptChars={}, recentUtterances={}, questionDecisions={}, questionSummaries={}, exceptionType={}, reason={}",
                     meetingId,
                     elapsedMillis(totalStartedAtNanos),
                     contextElapsedMs,
                     promptElapsedMs,
-                    glmElapsedMs,
+                    chatElapsedMs,
                     promptChars,
                     recentUtteranceCount,
                     questionDecisionCount,

--- a/src/main/java/com/flodiback/global/client/OpenAiChatClient.java
+++ b/src/main/java/com/flodiback/global/client/OpenAiChatClient.java
@@ -72,11 +72,22 @@ public class OpenAiChatClient {
     }
 
     public String chat(String systemPrompt, String userPrompt) {
-        ChatCompletionCreateParams params = ChatCompletionCreateParams.builder()
+        return chat(systemPrompt, userPrompt, null);
+    }
+
+    public String chat(String systemPrompt, String userPrompt, int maxCompletionTokens) {
+        return chat(systemPrompt, userPrompt, Long.valueOf(maxCompletionTokens));
+    }
+
+    private String chat(String systemPrompt, String userPrompt, Long maxCompletionTokens) {
+        ChatCompletionCreateParams.Builder builder = ChatCompletionCreateParams.builder()
                 .addSystemMessage(systemPrompt)
                 .addUserMessage(userPrompt)
-                .model(model)
-                .build();
+                .model(model);
+        if (maxCompletionTokens != null) {
+            builder.maxCompletionTokens(maxCompletionTokens);
+        }
+        ChatCompletionCreateParams params = builder.build();
 
         long startedAtNanos = System.nanoTime();
         try {
@@ -91,10 +102,11 @@ public class OpenAiChatClient {
             String content = firstChoice.message().content().orElse("");
             long latencyMs = elapsedMillis(startedAtNanos);
             log.info(
-                    "OpenAI chat call succeeded. model={}, timeoutMs={}, maxRetries={}, latencyMs={}, choiceCount={}, finishReason={}, responseChars={}",
+                    "OpenAI chat call succeeded. model={}, timeoutMs={}, maxRetries={}, maxCompletionTokens={}, latencyMs={}, choiceCount={}, finishReason={}, responseChars={}",
                     model,
                     timeoutMs,
                     maxRetries,
+                    maxCompletionTokens,
                     latencyMs,
                     choiceCount,
                     firstChoice.finishReason(),
@@ -107,10 +119,11 @@ public class OpenAiChatClient {
 
             if (e instanceof OpenAIServiceException serviceException) {
                 log.warn(
-                        "OpenAI chat call failed. model={}, timeoutMs={}, maxRetries={}, latencyMs={}, exceptionType={}, message={}, rootCauseType={}, rootCauseMessage={}, statusCode={}, errorType={}, errorCode={}, errorParam={}, errorBodyPreview={}",
+                        "OpenAI chat call failed. model={}, timeoutMs={}, maxRetries={}, maxCompletionTokens={}, latencyMs={}, exceptionType={}, message={}, rootCauseType={}, rootCauseMessage={}, statusCode={}, errorType={}, errorCode={}, errorParam={}, errorBodyPreview={}",
                         model,
                         timeoutMs,
                         maxRetries,
+                        maxCompletionTokens,
                         latencyMs,
                         e.getClass().getSimpleName(),
                         e.getMessage(),
@@ -123,10 +136,11 @@ public class OpenAiChatClient {
                         preview(serviceException.body().toString(), 500));
             } else {
                 log.warn(
-                        "OpenAI chat call failed. model={}, timeoutMs={}, maxRetries={}, latencyMs={}, exceptionType={}, message={}, rootCauseType={}, rootCauseMessage={}",
+                        "OpenAI chat call failed. model={}, timeoutMs={}, maxRetries={}, maxCompletionTokens={}, latencyMs={}, exceptionType={}, message={}, rootCauseType={}, rootCauseMessage={}",
                         model,
                         timeoutMs,
                         maxRetries,
+                        maxCompletionTokens,
                         latencyMs,
                         e.getClass().getSimpleName(),
                         e.getMessage(),

--- a/src/test/java/com/flodiback/domain/ai/service/DisabledAiChatServiceTest.java
+++ b/src/test/java/com/flodiback/domain/ai/service/DisabledAiChatServiceTest.java
@@ -11,10 +11,18 @@ class DisabledAiChatServiceTest {
     private final AiChatService aiChatService = new DisabledAiChatService();
 
     @Test
-    void generateAnswer_throwsServiceException_whenAiChatIsDisabled() {
-        assertThatThrownBy(() -> aiChatService.generateAnswer("system prompt", "user question"))
+    void generateShortAnswer_throwsServiceException_whenAiChatIsDisabled() {
+        assertThatThrownBy(() -> aiChatService.generateShortAnswer("system prompt", "user question"))
                 .isInstanceOf(ServiceException.class)
                 .hasMessageContaining("503-1")
-                .hasMessageContaining("GLM 채팅 서비스가 비활성화되어 있습니다.");
+                .hasMessageContaining("AI chat service is disabled.");
+    }
+
+    @Test
+    void generateSummary_throwsServiceException_whenAiChatIsDisabled() {
+        assertThatThrownBy(() -> aiChatService.generateSummary("system prompt", "user question"))
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("503-1")
+                .hasMessageContaining("AI chat service is disabled.");
     }
 }

--- a/src/test/java/com/flodiback/domain/ai/service/GlmAiChatServiceTest.java
+++ b/src/test/java/com/flodiback/domain/ai/service/GlmAiChatServiceTest.java
@@ -22,12 +22,22 @@ class GlmAiChatServiceTest {
     private GlmAiChatService glmAiChatService;
 
     @Test
-    void generateAnswer_delegatesToGlmClient() {
+    void generateShortAnswer_delegatesToGlmClient() {
         given(glmClient.chat("system", "user")).willReturn("answer");
 
-        String result = glmAiChatService.generateAnswer("system", "user");
+        String result = glmAiChatService.generateShortAnswer("system", "user");
 
         assertThat(result).isEqualTo("answer");
+        verify(glmClient).chat("system", "user");
+    }
+
+    @Test
+    void generateSummary_delegatesToGlmClient() {
+        given(glmClient.chat("system", "user")).willReturn("summary");
+
+        String result = glmAiChatService.generateSummary("system", "user");
+
+        assertThat(result).isEqualTo("summary");
         verify(glmClient).chat("system", "user");
     }
 }

--- a/src/test/java/com/flodiback/domain/ai/service/OpenAiChatServiceTest.java
+++ b/src/test/java/com/flodiback/domain/ai/service/OpenAiChatServiceTest.java
@@ -22,12 +22,22 @@ class OpenAiChatServiceTest {
     private OpenAiChatService openAiChatService;
 
     @Test
-    void generateAnswer_delegatesToOpenAiChatClient() {
-        given(openAiChatClient.chat("system", "user")).willReturn("answer");
+    void generateShortAnswer_delegatesToOpenAiChatClientWithTokenCap() {
+        given(openAiChatClient.chat("system", "user", 256)).willReturn("answer");
 
-        String result = openAiChatService.generateAnswer("system", "user");
+        String result = openAiChatService.generateShortAnswer("system", "user");
 
         assertThat(result).isEqualTo("answer");
+        verify(openAiChatClient).chat("system", "user", 256);
+    }
+
+    @Test
+    void generateSummary_delegatesToOpenAiChatClientWithoutTokenCap() {
+        given(openAiChatClient.chat("system", "user")).willReturn("summary");
+
+        String result = openAiChatService.generateSummary("system", "user");
+
+        assertThat(result).isEqualTo("summary");
         verify(openAiChatClient).chat("system", "user");
     }
 }

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepositoryTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/repository/UtteranceRepositoryTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.PageRequest;
 
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
@@ -58,6 +59,19 @@ class UtteranceRepositoryTest extends AbstractPostgresIntegrationTest {
         List<Utterance> result = utteranceRepository.findTop20ByMeetingIdOrderBySpeechStartedAtDesc(meeting.getId());
 
         assertThat(result).hasSize(20);
+    }
+
+    @Test
+    void findByMeetingOrderByIdDesc_usesPageableLimit() {
+        for (int i = 0; i < 65; i++) {
+            em.persist(utterance(meeting, "user" + i, "discord" + i, "content " + i));
+        }
+        em.flush();
+
+        List<Utterance> result = utteranceRepository.findByMeetingOrderByIdDesc(meeting, PageRequest.of(0, 60));
+
+        assertThat(result).hasSize(60);
+        assertThat(result.get(0).getId()).isGreaterThan(result.get(59).getId());
     }
 
     private Utterance utterance(Meeting m, String name, String discordId, String content) {

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryPersistenceServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryPersistenceServiceTest.java
@@ -88,7 +88,7 @@ class RollingSummaryPersistenceServiceTest {
 
         assertThat(candidate.expectedVersion()).isNull();
         assertThat(candidate.expectedCompressedUntilUtteranceId()).isNull();
-        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(19L);
+        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(13L);
         assertThat(candidate.userPrompt()).contains("content-1").doesNotContain("content-31");
         assertThat(candidate.userPrompt())
                 .contains("[출력]")
@@ -122,7 +122,7 @@ class RollingSummaryPersistenceServiceTest {
 
         assertThat(candidate.expectedVersion()).isEqualTo(3);
         assertThat(candidate.expectedCompressedUntilUtteranceId()).isEqualTo(5L);
-        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(24L);
+        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(18L);
         assertThat(candidate.userPrompt()).contains("previous summary");
         assertThat(candidate.nextVersion()).isEqualTo(4);
     }
@@ -146,10 +146,10 @@ class RollingSummaryPersistenceServiceTest {
         RollingSummaryPersistenceService.CompressionCandidate candidate =
                 service.prepareCompression(1L).orElseThrow();
 
-        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(21L);
+        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(15L);
         assertThat(candidate.userPrompt())
                 .contains("content-3")
-                .contains("content-21")
+                .contains("content-15")
                 .doesNotContain("content-33");
     }
 

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryServiceTest.java
@@ -61,7 +61,7 @@ class RollingSummaryServiceTest {
         service.compressIfNeeded(1L);
 
         verify(aiChatService, never())
-                .generateAnswer(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+                .generateSummary(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
     }
 
     @Test
@@ -69,7 +69,7 @@ class RollingSummaryServiceTest {
         RollingSummaryService service = new RollingSummaryService(rollingSummaryPersistenceService, aiChatService);
         RollingSummaryPersistenceService.CompressionCandidate candidate = candidate();
         given(rollingSummaryPersistenceService.prepareCompression(1L)).willReturn(Optional.of(candidate));
-        given(aiChatService.generateAnswer(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+        given(aiChatService.generateSummary(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
                 .willReturn(" ");
 
         service.compressIfNeeded(1L);
@@ -83,7 +83,7 @@ class RollingSummaryServiceTest {
         RollingSummaryService service = new RollingSummaryService(rollingSummaryPersistenceService, aiChatService);
         RollingSummaryPersistenceService.CompressionCandidate candidate = candidate();
         given(rollingSummaryPersistenceService.prepareCompression(1L)).willReturn(Optional.of(candidate));
-        given(aiChatService.generateAnswer(
+        given(aiChatService.generateSummary(
                         org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq("prompt")))
                 .willReturn("summary");
 
@@ -97,7 +97,7 @@ class RollingSummaryServiceTest {
         RollingSummaryService service = new RollingSummaryService(rollingSummaryPersistenceService, aiChatService);
         RollingSummaryPersistenceService.CompressionCandidate candidate = candidate();
         given(rollingSummaryPersistenceService.prepareCompression(1L)).willReturn(Optional.of(candidate));
-        given(aiChatService.generateAnswer(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+        given(aiChatService.generateSummary(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
                 .willThrow(new RuntimeException("glm failed"));
 
         assertThatCode(() -> service.compressIfNeeded(1L)).doesNotThrowAnyException();

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
@@ -110,7 +110,8 @@ class ContextServiceTest {
         Meeting meeting = Meeting.builder().title("standalone").build();
         ReflectionTestUtils.setField(meeting, "id", 1L);
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
-        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(Collections.emptyList());
+        given(utteranceRepository.findByMeetingOrderByIdDesc(org.mockito.ArgumentMatchers.eq(meeting), any()))
+                .willReturn(Collections.emptyList());
 
         ContextResponse result = contextService.assemble(1L, null);
 
@@ -124,20 +125,22 @@ class ContextServiceTest {
     void assemble_noCache_usesTokenBudgetButKeepsAtLeastTenUtterances() {
         Meeting meeting = Meeting.builder().title("meeting").build();
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
-        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(utterances(meeting, 1, 30, 100));
+        given(utteranceRepository.findByMeetingOrderByIdDesc(org.mockito.ArgumentMatchers.eq(meeting), any()))
+                .willReturn(utterances(meeting, 1, 30, 100));
 
         ContextResponse result = contextService.assemble(1L, null);
 
-        assertThat(result.shortTerm().recentUtterances()).hasSize(12);
-        assertThat(result.shortTerm().recentUtterances().get(0).content()).isEqualTo("content-19");
-        assertThat(result.shortTerm().recentUtterances().get(11).content()).isEqualTo("content-30");
+        assertThat(result.shortTerm().recentUtterances()).hasSize(22);
+        assertThat(result.shortTerm().recentUtterances().get(0).content()).isEqualTo("content-9");
+        assertThat(result.shortTerm().recentUtterances().get(21).content()).isEqualTo("content-30");
     }
 
     @Test
     void assemble_noCache_returnsMoreThanTwenty_whenTokensFitBudget() {
         Meeting meeting = Meeting.builder().title("meeting").build();
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
-        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(utterances(meeting, 1, 30, 10));
+        given(utteranceRepository.findByMeetingOrderByIdDesc(org.mockito.ArgumentMatchers.eq(meeting), any()))
+                .willReturn(utterances(meeting, 1, 30, 10));
 
         ContextResponse result = contextService.assemble(1L, null);
 
@@ -157,7 +160,8 @@ class ContextServiceTest {
                 .build();
         given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
                 .willReturn(Optional.of(cache));
-        given(utteranceRepository.findTop30ByMeetingAndIdGreaterThanOrderByIdDesc(meeting, 10L))
+        given(utteranceRepository.findByMeetingAndIdGreaterThanOrderByIdDesc(
+                        org.mockito.ArgumentMatchers.eq(meeting), org.mockito.ArgumentMatchers.eq(10L), any()))
                 .willReturn(utterances(meeting, 11, 31, 10));
 
         ContextResponse result = contextService.assemble(1L, null);
@@ -174,7 +178,8 @@ class ContextServiceTest {
         MeetingStartContext startContext = startContext(1L, 10L);
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(meetingStartContextProvider.getOrCreate(1L)).willReturn(startContext);
-        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(Collections.emptyList());
+        given(utteranceRepository.findByMeetingOrderByIdDesc(org.mockito.ArgumentMatchers.eq(meeting), any()))
+                .willReturn(Collections.emptyList());
 
         ContextResponse result = contextService.assemble(1L, null);
 
@@ -205,13 +210,14 @@ class ContextServiceTest {
         MeetingSummary newSummary = meetingSummary(meeting, 12L, "new related summary");
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(meetingStartContextProvider.getOrCreate(1L)).willReturn(startContext);
-        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(Collections.emptyList());
+        given(utteranceRepository.findByMeetingOrderByIdDesc(org.mockito.ArgumentMatchers.eq(meeting), any()))
+                .willReturn(Collections.emptyList());
         given(embeddingClient.embed("what did we decide?")).willReturn(new float[] {0.1f, 0.2f});
         given(decisionRepository.hybridSearch(
                         org.mockito.ArgumentMatchers.eq(10L),
                         org.mockito.ArgumentMatchers.anyString(),
                         org.mockito.ArgumentMatchers.eq("what did we decide?"),
-                        org.mockito.ArgumentMatchers.eq(3),
+                        org.mockito.ArgumentMatchers.eq(5),
                         org.mockito.ArgumentMatchers.eq(0.7),
                         org.mockito.ArgumentMatchers.eq(0.3)))
                 .willReturn(List.of(duplicateDecision, newDecision));
@@ -220,7 +226,7 @@ class ContextServiceTest {
                         org.mockito.ArgumentMatchers.eq(1L),
                         org.mockito.ArgumentMatchers.anyString(),
                         org.mockito.ArgumentMatchers.eq("what did we decide?"),
-                        org.mockito.ArgumentMatchers.eq(3),
+                        org.mockito.ArgumentMatchers.eq(5),
                         org.mockito.ArgumentMatchers.eq(0.7),
                         org.mockito.ArgumentMatchers.eq(0.3)))
                 .willReturn(List.of(duplicateSummary, newSummary));
@@ -242,7 +248,8 @@ class ContextServiceTest {
         Meeting meeting = Meeting.builder().project(project).title("meeting").build();
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(meetingStartContextProvider.getOrCreate(1L)).willReturn(startContext(1L, 10L));
-        given(utteranceRepository.findTop30ByMeetingOrderByIdDesc(meeting)).willReturn(Collections.emptyList());
+        given(utteranceRepository.findByMeetingOrderByIdDesc(org.mockito.ArgumentMatchers.eq(meeting), any()))
+                .willReturn(Collections.emptyList());
         given(embeddingClient.embed("find summary")).willThrow(new RuntimeException("embedding failed"));
 
         ContextResponse result = contextService.assemble(1L, "find summary");

--- a/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
+++ b/src/test/java/com/flodiback/domain/speech/service/SpeechAiAnswerServiceTest.java
@@ -40,7 +40,7 @@ class SpeechAiAnswerServiceTest {
 
     @Test
     void extractQuestion_returnsNull_whenWakeWordDoesNotExist() {
-        String result = speechAiAnswerService.extractQuestion("이번 스프린트 목표를 정해봅시다.");
+        String result = speechAiAnswerService.extractQuestion("이번 스프린트 목표를 정해봅시다");
 
         assertThat(result).isNull();
     }
@@ -54,11 +54,11 @@ class SpeechAiAnswerServiceTest {
 
     @Test
     void extractQuestion_doesNotCallDependencies_whenWakeWordDoesNotExist() {
-        String result = speechAiAnswerService.extractQuestion("이번 스프린트 목표를 정해봅시다.");
+        String result = speechAiAnswerService.extractQuestion("이번 스프린트 목표를 정해봅시다");
 
         assertThat(result).isNull();
-        verify(contextService, never()).assemble(1L, "이번 스프린트 목표를 정해봅시다.");
-        verify(aiChatService, never()).generateAnswer(anyString(), anyString());
+        verify(contextService, never()).assemble(1L, "이번 스프린트 목표를 정해봅시다");
+        verify(aiChatService, never()).generateShortAnswer(anyString(), anyString());
     }
 
     @Test
@@ -70,47 +70,39 @@ class SpeechAiAnswerServiceTest {
                         "Flodi",
                         "Spring Boot",
                         "metadata",
-                        List.of(new DecisionSummary(1L, "인증 방식은 JWT로 한다.", null)),
-                        List.of(new PastSummary(1L, "로그인 기능 담당자를 정했다.", null)),
-                        "API 응답 형식 미정",
-                        List.of(new WorkLogSummary(1L, "김철수", "로그인 API 작성", null, "TODO"))),
-                new ShortTermContext(null, List.of(new UtteranceSummary("김철수", "인증은 JWT로 하자.", null))),
+                        List.of(new DecisionSummary(1L, "auth uses JWT", null)),
+                        List.of(new PastSummary(1L, "assigned login feature", null)),
+                        "API response format undecided",
+                        List.of(new WorkLogSummary(1L, "Alice", "write login API", null, "TODO"))),
+                new ShortTermContext(null, List.of(new UtteranceSummary("Alice", "Let's use JWT.", null))),
                 QuestionContext.empty());
 
-        given(contextService.assemble(1L, "인증 방식 뭐로 하기로 했어?")).willReturn(context);
-        given(aiChatService.generateAnswer(anyString(), anyString())).willReturn("[회의 기반] 인증 방식은 JWT로 결정했습니다.");
+        given(contextService.assemble(1L, "what auth did we choose?")).willReturn(context);
+        given(aiChatService.generateShortAnswer(anyString(), anyString())).willReturn("[meeting] auth uses JWT.");
 
-        String result = speechAiAnswerService.generateAnswer(1L, "인증 방식 뭐로 하기로 했어?");
+        String result = speechAiAnswerService.generateAnswer(1L, "what auth did we choose?");
 
-        assertThat(result).isEqualTo("[회의 기반] 인증 방식은 JWT로 결정했습니다.");
-        verify(contextService).assemble(1L, "인증 방식 뭐로 하기로 했어?");
+        assertThat(result).isEqualTo("[meeting] auth uses JWT.");
+        verify(contextService).assemble(1L, "what auth did we choose?");
 
         ArgumentCaptor<String> systemPromptCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(aiChatService).generateAnswer(systemPromptCaptor.capture(), userPromptCaptor.capture());
-        assertThat(systemPromptCaptor.getValue())
-                .contains("[회의 기반]")
-                .contains("[일반 지식 기반]")
-                .contains("2~3문장");
+        verify(aiChatService).generateShortAnswer(systemPromptCaptor.capture(), userPromptCaptor.capture());
+        assertThat(systemPromptCaptor.getValue()).contains("2~3");
         assertThat(userPromptCaptor.getValue())
-                .contains("[답변 규칙]")
-                .contains("[회의 시작 컨텍스트]")
-                .contains("[현재 회의 컨텍스트]")
-                .contains("[질문 관련 추가 기억]")
-                .contains("[질문]")
                 .contains("Flodi")
-                .contains("인증 방식은 JWT로 한다.")
-                .contains("로그인 기능 담당자를 정했다.")
-                .contains("API 응답 형식 미정")
-                .contains("로그인 API 작성")
-                .contains("인증 방식 뭐로 하기로 했어?");
+                .contains("auth uses JWT")
+                .contains("assigned login feature")
+                .contains("API response format undecided")
+                .contains("write login API")
+                .contains("what auth did we choose?");
     }
 
     @Test
     void generateAnswer_truncatesLongContextText() {
-        String longMetadata = "m".repeat(350);
-        String longDecision = "d".repeat(300);
-        String longSummary = "s".repeat(450);
+        String longMetadata = "m".repeat(650);
+        String longDecision = "d".repeat(550);
+        String longSummary = "s".repeat(850);
         ContextResponse context = new ContextResponse(
                 new MeetingStartContext(
                         1L,
@@ -120,33 +112,33 @@ class SpeechAiAnswerServiceTest {
                         longMetadata,
                         List.of(new DecisionSummary(1L, longDecision, null)),
                         List.of(new PastSummary(1L, longSummary, null)),
-                        "u".repeat(450),
-                        List.of(new WorkLogSummary(1L, "김철수", "w".repeat(200), null, "TODO"))),
-                new ShortTermContext("r".repeat(900), List.of()),
+                        "u".repeat(750),
+                        List.of(new WorkLogSummary(1L, "Alice", "w".repeat(260), null, "TODO"))),
+                new ShortTermContext("r".repeat(1500), List.of()),
                 QuestionContext.empty());
-        given(contextService.assemble(1L, "요약해줘")).willReturn(context);
-        given(aiChatService.generateAnswer(anyString(), anyString())).willReturn("done");
+        given(contextService.assemble(1L, "summarize")).willReturn(context);
+        given(aiChatService.generateShortAnswer(anyString(), anyString())).willReturn("done");
 
-        speechAiAnswerService.generateAnswer(1L, "요약해줘");
+        speechAiAnswerService.generateAnswer(1L, "summarize");
 
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(aiChatService).generateAnswer(anyString(), userPromptCaptor.capture());
+        verify(aiChatService).generateShortAnswer(anyString(), userPromptCaptor.capture());
         String prompt = userPromptCaptor.getValue();
-        assertThat(prompt).contains("m".repeat(300) + "...");
-        assertThat(prompt).contains("d".repeat(250) + "...");
-        assertThat(prompt).contains("s".repeat(400) + "...");
-        assertThat(prompt).contains("u".repeat(400) + "...");
-        assertThat(prompt).contains("w".repeat(160) + "...");
-        assertThat(prompt).contains("r".repeat(800) + "...");
+        assertThat(prompt).contains("m".repeat(600) + "...");
+        assertThat(prompt).contains("d".repeat(500) + "...");
+        assertThat(prompt).contains("s".repeat(800) + "...");
+        assertThat(prompt).contains("u".repeat(700) + "...");
+        assertThat(prompt).contains("w".repeat(240) + "...");
+        assertThat(prompt).contains("r".repeat(1400) + "...");
     }
 
     @Test
     void extractQuestion_acceptsMisrecognizedFlodiWakeWord() {
-        String result = speechAiAnswerService.extractQuestion("플로디아 아까 말랑이 관련 이야기 요약 좀 해줄래?");
+        String result = speechAiAnswerService.extractQuestion("플로디아 아까 말한 내용 요약해줘");
 
-        assertThat(result).isEqualTo("아까 말랑이 관련 이야기 요약 좀 해줄래?");
-        verify(contextService, never()).assemble(1L, "아까 말랑이 관련 이야기 요약 좀 해줄래?");
-        verify(aiChatService, never()).generateAnswer(anyString(), anyString());
+        assertThat(result).isEqualTo("아까 말한 내용 요약해줘");
+        verify(contextService, never()).assemble(1L, "아까 말한 내용 요약해줘");
+        verify(aiChatService, never()).generateShortAnswer(anyString(), anyString());
     }
 
     @Test
@@ -155,19 +147,19 @@ class SpeechAiAnswerServiceTest {
 
         assertThat(result).isNull();
         verify(contextService, never()).assemble(1L, "");
-        verify(aiChatService, never()).generateAnswer(anyString(), anyString());
+        verify(aiChatService, never()).generateShortAnswer(anyString(), anyString());
     }
 
     @Test
     void generateAnswer_returnsNull_whenAiChatFails() {
         ContextResponse context = ContextResponse.noProject(null, List.of());
-        given(contextService.assemble(1L, "토큰 만료 시간 정했어?")).willReturn(context);
-        given(aiChatService.generateAnswer(anyString(), anyString())).willThrow(new RuntimeException("GLM error"));
+        given(contextService.assemble(1L, "token expiry?")).willReturn(context);
+        given(aiChatService.generateShortAnswer(anyString(), anyString())).willThrow(new RuntimeException("AI error"));
 
-        String result = speechAiAnswerService.generateAnswer(1L, "토큰 만료 시간 정했어?");
+        String result = speechAiAnswerService.generateAnswer(1L, "token expiry?");
 
         assertThat(result).isNull();
-        verify(contextService).assemble(1L, "토큰 만료 시간 정했어?");
-        verify(aiChatService).generateAnswer(anyString(), anyString());
+        verify(contextService).assemble(1L, "token expiry?");
+        verify(aiChatService).generateShortAnswer(anyString(), anyString());
     }
 }

--- a/src/test/java/com/flodiback/global/client/OpenAiChatClientTest.java
+++ b/src/test/java/com/flodiback/global/client/OpenAiChatClientTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +15,7 @@ import com.openai.errors.OpenAIIoException;
 import com.openai.errors.UnexpectedStatusCodeException;
 import com.openai.models.ErrorObject;
 import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessage;
 
 class OpenAiChatClientTest {
@@ -25,6 +27,34 @@ class OpenAiChatClientTest {
         String result = openAiChatClient.chat("system", "user");
 
         assertThat(result).isEqualTo("answer");
+    }
+
+    @Test
+    void chat_setsMaxCompletionTokens_whenProvided() {
+        AtomicReference<ChatCompletionCreateParams> capturedParams = new AtomicReference<>();
+        OpenAiChatClient openAiChatClient = new OpenAiChatClient("openai-test", params -> {
+            capturedParams.set(params);
+            return completion("answer");
+        });
+
+        String result = openAiChatClient.chat("system", "user", 256);
+
+        assertThat(result).isEqualTo("answer");
+        assertThat(capturedParams.get().maxCompletionTokens()).contains(256L);
+    }
+
+    @Test
+    void chat_doesNotSetMaxCompletionTokens_whenNotProvided() {
+        AtomicReference<ChatCompletionCreateParams> capturedParams = new AtomicReference<>();
+        OpenAiChatClient openAiChatClient = new OpenAiChatClient("openai-test", params -> {
+            capturedParams.set(params);
+            return completion("answer");
+        });
+
+        String result = openAiChatClient.chat("system", "user");
+
+        assertThat(result).isEqualTo("answer");
+        assertThat(capturedParams.get().maxCompletionTokens()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- 플로디야 AI 답변 품질 회복을 위해 Prompt/RAG/contextCache 경량화 수치를 완화했습니다.
- AI 호출 목적을 `short answer`와 `summary`로 분리하고, OpenAI 플로디야 답변에만 출력 토큰 상한을 적용했습니다.
- 최근 발화 조회를 `Top30` 고정 메서드에서 `Pageable` 기반 조회로 변경했습니다.

## Changes

- `AiChatService`의 기존 `generateAnswer`를 제거하고 `generateShortAnswer`, `generateSummary`로 분리
- OpenAI `generateShortAnswer` 경로에만 `maxCompletionTokens=256` 적용
- rolling summary는 `generateSummary` 경로를 사용해 출력 토큰 제한 없이 생성
- GLM provider는 두 경로 모두 기존 `glmClient.chat()` 호출 유지
- Prompt/RAG 품질 수치 완화
  - `TOP_K`: `3 → 5`
  - 최근 발화 후보: `30 → 60`
  - 최근 발화 token budget: `1200 → 2200`
  - 최소 최근 발화 수: `10 → 16`
  - context text truncate 제한 전반 완화
- rolling summary 압축 정책 완화
  - trigger tokens: `1800 → 2600`
  - tail utterances: `12 → 18`
- `UtteranceRepository` 최근 발화 조회를 `Pageable` 기반으로 전환
- AI 답변 latency 로그의 `GLM`/`glmMs` 표현을 provider-neutral한 `chat`/`chatMs`로 변경
- Disabled provider 메시지를 `AI chat service is disabled.`로 정리

## Test

- [x] `./gradlew compileTestJava --no-daemon --no-watch-fs`
- [x] Related unit tests
  - `AiChatService` implementations
  - `OpenAiChatClientTest`
  - `SpeechAiAnswerServiceTest`
  - `ContextServiceTest`
  - `RollingSummaryServiceTest`
  - `RollingSummaryPersistenceServiceTest`

## Note

- 전체 `./gradlew test`는 로컬 Docker/Testcontainers 초기화 실패로 일부 통합 테스트가 실패했습니다.
- 실패 지점은 `DockerClientProviderStrategy` 초기화이며, 이번 변경 영역의 단위 테스트는 통과했습니다.
