### PR TITLE
[fix] nginx 헬스체크 localhost → 127.0.0.1 수정

### DIFF
--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -83,7 +83,7 @@ wait_for_nginx_health() {
 
     log "nginx 경유 health check 대기 중"
     for _ in $(seq 1 "$HEALTH_RETRIES"); do
-        body="$("${COMPOSE[@]}" exec -T nginx wget -q -O - "http://localhost/actuator/health" 2>/dev/null || true)"
+        body="$("${COMPOSE[@]}" exec -T nginx wget -q -O - "http://127.0.0.1/actuator/health" 2>/dev/null || true)"
         if printf '%s' "$body" | grep -q '"status":"UP"'; then
             log "nginx 경유 health check 성공"
             return


### PR DESCRIPTION
## Summary
- Alpine Linux nginx 컨테이너에서 `localhost`가 IPv6(`::1`)로 resolve되어 nginx 헬스체크가 항상 실패하는 버그 수정
- `127.0.0.1`로 명시하여 IPv4로 강제 접속하도록 변경

## 원인
nginx는 `0.0.0.0:80` (IPv4)으로 listening 중이지만, Alpine에서 `wget http://localhost`는 `::1:80` (IPv6)으로 연결 시도 → Connection refused

## Test plan
- [ ] EC2에서 `./scripts/deploy-blue-green.sh` 실행 후 nginx 헬스체크 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)