### PR TITLE
[refactor]: .env.example 정리 및 DISCORD_DEFAULT_MEETING_ID dead code 제거

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,29 +5,15 @@
 APP_PORT=8000
 
 # ------------------------------------------------------------------------------
+# Nginx
+# ------------------------------------------------------------------------------
+
+NGINX_DOMAIN=백엔드 API 도메인
+
+# ------------------------------------------------------------------------------
 # PostgreSQL
 # ------------------------------------------------------------------------------
 
-# ── Discord OAuth (웹 대시보드 로그인) ────────────────────────────
-# Developer Portal > OAuth2
-DISCORD_CLIENT_ID=your_discord_client_id
-DISCORD_CLIENT_SECRET=your_discord_client_secret
-# 백엔드 콜백 URL (Discord Developer Portal > Redirects에도 동일하게 등록)
-DISCORD_REDIRECT_URI=http://localhost:8080/auth/v1/discord/callback
-
-# ── JWT (웹 대시보드 인증 쿠키) ───────────────────────────────────
-# openssl rand -base64 32 로 생성 (32바이트 이상 필수)
-JWT_SECRET=your_jwt_secret_at_least_32_bytes_long
-JWT_EXPIRE_HOURS=24
-
-# ── CORS / 프론트엔드 URL ─────────────────────────────────────────
-# 여러 origin은 쉼표로 구분 (예: http://localhost:5173,https://app.example.com)
-CORS_ALLOWED_ORIGINS=http://localhost:5173
-# OAuth 로그인 성공 후 리다이렉트 대상 (단일 URL)
-FRONTEND_URL=http://localhost:5173
-
-# ── Database ──────────────────────────────────────────────────────
-# Discord bot token (Developer Portal > Bot > Reset Token)
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=flodiback
@@ -42,15 +28,33 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 
 # ------------------------------------------------------------------------------
+# Discord OAuth (웹 대시보드 로그인)
+# ------------------------------------------------------------------------------
+
+DISCORD_CLIENT_ID=your_discord_client_id
+DISCORD_CLIENT_SECRET=your_discord_client_secret
+DISCORD_REDIRECT_URI=http://localhost:8080/auth/v1/discord/callback
+
+# ------------------------------------------------------------------------------
+# JWT (웹 대시보드 인증 쿠키)
+# ------------------------------------------------------------------------------
+
+JWT_SECRET=your_jwt_secret_at_least_32_bytes_long
+JWT_EXPIRE_HOURS=24
+
+# ------------------------------------------------------------------------------
+# CORS / 프론트엔드 URL
+# ------------------------------------------------------------------------------
+
+CORS_ALLOWED_ORIGINS=http://localhost:5173
+FRONTEND_URL=http://localhost:5173
+
+# ------------------------------------------------------------------------------
 # Discord bot
 # ------------------------------------------------------------------------------
 
 DISCORD_TOKEN=your_discord_bot_token
 DISCORD_BOT_PREFIX=!
-
-# Optional: comma-separated Discord guild IDs this bot instance should handle.
-# 여러 Docker 인스턴스가 같은 DISCORD_TOKEN을 쓰면 각 인스턴스에 담당 서버 ID를 지정하세요.
-# 비워두면 봇이 초대된 모든 서버 이벤트를 처리합니다.
 DISCORD_ALLOWED_GUILD_IDS=
 
 # ------------------------------------------------------------------------------
@@ -58,11 +62,7 @@ DISCORD_ALLOWED_GUILD_IDS=
 # ------------------------------------------------------------------------------
 
 INTERNAL_API_BASE_URL=http://localhost:8080
-
-# Web dashboard base URL
 FRONTEND_BASE_URL=http://localhost:5173
-
-# Optional: internal API key (필요한 경우만)
 INTERNAL_API_KEY=
 
 # ------------------------------------------------------------------------------
@@ -85,9 +85,10 @@ OPENAI_EMBEDDING_API_KEY=your_openai_embedding_api_key
 
 # ------------------------------------------------------------------------------
 # GLM
+# AI_PROVIDER: openai | glm | disabled | (비어있으면 GLM_ENABLED 값으로 결정)
 # ------------------------------------------------------------------------------
 
-AI_PROVIDER=glm
+AI_PROVIDER=
 GLM_ENABLED=false
 GLM_API_KEY=your_glm_api_key
 GLM_MODEL=glm-5.1

--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,6 @@ FRONTEND_URL=http://localhost:5173
 
 DISCORD_TOKEN=your_discord_bot_token
 DISCORD_BOT_PREFIX=!
-DISCORD_ALLOWED_GUILD_IDS=
 
 # ------------------------------------------------------------------------------
 # Internal API

--- a/src/main/java/com/flodiback/bot/DiscordBotMain.java
+++ b/src/main/java/com/flodiback/bot/DiscordBotMain.java
@@ -33,7 +33,6 @@ public final class DiscordBotMain {
         // 1) 토큰/설정값 로드
         String token = resolveToken();
         String prefix = BotEnv.getOrDefault("DISCORD_BOT_PREFIX", "!");
-        long defaultMeetingId = parseMeetingId(BotEnv.getOrDefault("DISCORD_DEFAULT_MEETING_ID", "1"));
 
         // 2) Opus native 로딩 상태 확인
         // canReceiveUser/Opus decode 경로는 native 준비 여부에 영향받는다.
@@ -66,16 +65,15 @@ public final class DiscordBotMain {
                 .disableCache(
                         CacheFlag.EMOJI, CacheFlag.STICKER, CacheFlag.SOUNDBOARD_SOUNDS, CacheFlag.SCHEDULED_EVENTS)
                 .setAudioModuleConfig(audioModuleConfig)
-                .addEventListeners(new DiscordCommandListener(prefix, sttProvider, defaultMeetingId, redisPublisher))
+                .addEventListeners(new DiscordCommandListener(prefix, sttProvider, redisPublisher))
                 .build()
                 .awaitReady();
 
         log.info(
-                "[봇/준비완료] userId={}, username={}, prefix={}, defaultMeetingId={}",
+                "[봇/준비완료] userId={}, username={}, prefix={}",
                 jda.getSelfUser().getId(),
                 jda.getSelfUser().getName(),
-                prefix,
-                defaultMeetingId);
+                prefix);
     }
 
     private static String resolveToken() {
@@ -84,17 +82,6 @@ public final class DiscordBotMain {
             throw new IllegalStateException("DISCORD_TOKEN 환경변수 또는 .env 값이 비어있습니다.");
         }
         return token;
-    }
-
-    /**
-     * 환경변수 문자열을 long meetingId로 안전하게 변환한다.
-     */
-    private static long parseMeetingId(String rawMeetingId) {
-        try {
-            return Long.parseLong(rawMeetingId.trim());
-        } catch (Exception exception) {
-            throw new IllegalStateException("DISCORD_DEFAULT_MEETING_ID 값이 숫자가 아닙니다: " + rawMeetingId, exception);
-        }
     }
 
     /**

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -144,15 +144,10 @@ public class DiscordCommandListener extends ListenerAdapter {
     private final RedisPublisher redisPublisher;
 
     public DiscordCommandListener() {
-        this("!", new OpenAiSttProvider(), 1L, null);
+        this("!", new OpenAiSttProvider(), null);
     }
 
-    public DiscordCommandListener(String prefix, SttProvider sttProvider, long defaultMeetingId) {
-        this(prefix, sttProvider, defaultMeetingId, null);
-    }
-
-    public DiscordCommandListener(
-            String prefix, SttProvider sttProvider, long defaultMeetingId, RedisPublisher redisPublisher) {
+    public DiscordCommandListener(String prefix, SttProvider sttProvider, RedisPublisher redisPublisher) {
         this.prefix = (prefix == null || prefix.isBlank()) ? "!" : prefix.trim();
         this.sttProvider = Objects.requireNonNull(sttProvider);
         this.internalBaseUrl = normalizeBaseUrl(BotEnv.getOrDefault("INTERNAL_API_BASE_URL", "http://localhost:8080"));


### PR DESCRIPTION
## 🔗 연관된 이슈

없음

## 📝 작업 내용

`.env.example` 구조 정리 및 실제로 동작하지 않는 `DISCORD_DEFAULT_MEETING_ID` 관련 코드 제거

## ✅ 주요 변경 사항

- `.env.example`
  - 섹션 구분 형식을 프로젝트 표준(`# ---...---`)으로 통일
  - `NGINX_DOMAIN` 섹션 추가 (도메인 설정 명시)
  - GLM 섹션 주석 오타 수정 (`ture` → `false`) 및 `AI_PROVIDER` 설명 주석 분리
  - `DISCORD_ALLOWED_GUILD_IDS` 항목 복원 (코드에서 사용 중)

- `DiscordBotMain.java` / `DiscordCommandListener.java`
  - `defaultMeetingId` 파라미터가 생성자에서 받기만 하고 필드에 저장하지 않아 실제로 동작하지 않음을 확인
  - `DISCORD_DEFAULT_MEETING_ID` env 읽기, `parseMeetingId()` 메서드, 생성자 파라미터 전부 제거
  - 봇은 항상 `/internal/v1/meetings` API로 새 회의를 생성하므로 fallback ID 자체가 불필요

## 🧪 테스트 결과

- `./gradlew spotlessCheck compileJava` 통과

## 👀 리뷰 포인트

- `DiscordCommandListener` 생성자 시그니처 변경 (`long defaultMeetingId` 파라미터 제거) — 외부 호출 지점은 `DiscordBotMain` 하나뿐임을 확인

## 📎 참고 사항

- `.env` (gitignore, EC2 배포용)는 별도로 로컬에서 관리