### PR TITLE
[fix]: NPM letsencrypt 볼륨 누락 추가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,6 +71,7 @@ services:
       - "127.0.0.1:81:81"
     volumes:
       - npm_data:/data
+      - npm_letsencrypt:/etc/letsencrypt
     depends_on:
       nginx:
         condition: service_healthy
@@ -133,3 +134,4 @@ volumes:
   postgres_data:
   redis_data:
   npm_data:
+  npm_letsencrypt:


### PR DESCRIPTION
## Summary
- NPM(Nginx Proxy Manager) 컨테이너 시작 시 `/etc/letsencrypt` 마운트 누락으로 재시작 루프 발생
- `npm_letsencrypt` named volume 추가로 수정

## Test plan
- [ ] EC2에서 NPM 컨테이너 정상 기동 확인
- [ ] NPM 관리 UI (SSH 터널 경유 `http://localhost:8081`) 접속 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)