### PR TITLE
fix: OpenAI Realtime rate limit 방어 및 append 배치 전송

### DIFF
--- a/docs/references/discord-bot-jda-dave.md
+++ b/docs/references/discord-bot-jda-dave.md
@@ -18,6 +18,7 @@ export OPENAI_API_KEY=...
 export OPENAI_REALTIME_WS_URL='wss://api.openai.com/v1/realtime?intent=transcription'
 export OPENAI_TRANSCRIBE_MODEL=gpt-realtime-whisper
 export OPENAI_TRANSCRIBE_LANGUAGE=ko
+export OPENAI_REALTIME_APPEND_FLUSH_MS=500
 ```
 
 Docker에서 봇을 실행하고 Spring 서버를 호스트 Mac에서 실행한다면 `INTERNAL_API_BASE_URL`은

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandler.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandler.java
@@ -10,9 +10,20 @@ import com.flodiback.domain.speech.stt.SttResult;
  */
 final class OpenAiRealtimeEventHandler {
     private static final Logger log = LoggerFactory.getLogger(OpenAiRealtimeEventHandler.class);
+    private static final OpenAiRealtimeRateLimitGate SHARED_RATE_LIMIT_GATE = new OpenAiRealtimeRateLimitGate();
     // OpenAI Realtime에는 24kHz mono PCM16LE를 보낸다.
     // 24,000 samples/sec * 2 bytes = 48 bytes/ms 이므로 전송 바이트로 길이를 역산할 수 있다.
     private static final long REALTIME_PCM_BYTES_PER_MS = 48L;
+
+    private final OpenAiRealtimeRateLimitGate rateLimitGate;
+
+    OpenAiRealtimeEventHandler() {
+        this(SHARED_RATE_LIMIT_GATE);
+    }
+
+    OpenAiRealtimeEventHandler(OpenAiRealtimeRateLimitGate rateLimitGate) {
+        this.rateLimitGate = rateLimitGate;
+    }
 
     /**
      * 중간 결과(delta) 이벤트 처리.
@@ -99,8 +110,13 @@ final class OpenAiRealtimeEventHandler {
      * - commit 대기 future를 실패로 종료
      */
     void onError(OpenAiSttSessionState session, Throwable throwable) {
+        rateLimitGate.recordIfRateLimited(throwable);
         log.warn("[OPENAI/이벤트오류] sessionId={}", session.sessionId(), throwable);
         session.sttListener().onError(session.sessionId(), throwable);
         session.markFailed(throwable);
+    }
+
+    OpenAiRealtimeRateLimitGate rateLimitGate() {
+        return rateLimitGate;
     }
 }

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeRateLimitGate.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeRateLimitGate.java
@@ -1,0 +1,73 @@
+package com.flodiback.domain.speech.stt.provider.openai;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class OpenAiRealtimeRateLimitGate {
+    private static final Pattern RETRY_AFTER_PATTERN = Pattern.compile("(\\d+(?:\\.\\d+)?)(ms|h|m|s)");
+    private static final long DEFAULT_COOLDOWN_MS = Duration.ofSeconds(30).toMillis();
+    private static final long COOLDOWN_PADDING_MS = 500L;
+
+    private final AtomicLong blockedUntilEpochMs = new AtomicLong();
+    private final LongSupplier currentTimeMillis;
+
+    OpenAiRealtimeRateLimitGate() {
+        this(System::currentTimeMillis);
+    }
+
+    OpenAiRealtimeRateLimitGate(LongSupplier currentTimeMillis) {
+        this.currentTimeMillis = currentTimeMillis;
+    }
+
+    boolean isBlocked() {
+        return remainingMillis() > 0;
+    }
+
+    long remainingMillis() {
+        return Math.max(0L, blockedUntilEpochMs.get() - currentTimeMillis.getAsLong());
+    }
+
+    void recordIfRateLimited(Throwable throwable) {
+        String message = throwable == null ? null : throwable.getMessage();
+        if (message == null || !message.toLowerCase(Locale.ROOT).contains("rate limit")) {
+            return;
+        }
+
+        long retryAfterMs = parseRetryAfterMillis(message);
+        long nextBlockedUntil = currentTimeMillis.getAsLong() + retryAfterMs + COOLDOWN_PADDING_MS;
+        blockedUntilEpochMs.accumulateAndGet(nextBlockedUntil, Math::max);
+    }
+
+    IllegalStateException blockedException(String sessionId) {
+        return new IllegalStateException("OpenAI Realtime rate limit cooldown is active. sessionId="
+                + sessionId
+                + ", retryAfterMs="
+                + remainingMillis());
+    }
+
+    private long parseRetryAfterMillis(String message) {
+        int retryIndex = message.toLowerCase(Locale.ROOT).indexOf("try again in");
+        if (retryIndex < 0) {
+            return DEFAULT_COOLDOWN_MS;
+        }
+
+        Matcher matcher = RETRY_AFTER_PATTERN.matcher(message.substring(retryIndex));
+        long totalMillis = 0L;
+        while (matcher.find()) {
+            double value = Double.parseDouble(matcher.group(1));
+            String unit = matcher.group(2);
+            totalMillis += switch (unit) {
+                case "ms" -> Math.round(value);
+                case "s" -> Math.round(value * 1_000L);
+                case "m" -> Math.round(value * 60_000L);
+                case "h" -> Math.round(value * 3_600_000L);
+                default -> 0L;
+            };
+        }
+        return totalMillis > 0 ? totalMillis : DEFAULT_COOLDOWN_MS;
+    }
+}

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
@@ -51,6 +51,12 @@ public class OpenAiSttProvider implements SttProvider {
     @Override
     public void startSession(String sessionId, String speakerId, SttListener listener) {
         SttListener nonNullListener = Objects.requireNonNull(listener);
+        if (eventHandler.rateLimitGate().isBlocked()) {
+            IllegalStateException exception = eventHandler.rateLimitGate().blockedException(sessionId);
+            nonNullListener.onError(sessionId, exception);
+            throw exception;
+        }
+
         OpenAiSttSessionState newSession = new OpenAiSttSessionState(sessionId, speakerId, nonNullListener);
 
         OpenAiSttSessionState oldSession = sessions.put(sessionId, newSession);
@@ -62,6 +68,7 @@ public class OpenAiSttProvider implements SttProvider {
             realtimeClient.openSession(newSession, eventHandler);
         } catch (Exception exception) {
             sessions.remove(sessionId, newSession);
+            eventHandler.rateLimitGate().recordIfRateLimited(exception);
             nonNullListener.onError(sessionId, exception);
             throw new IllegalStateException("Failed to open OpenAI STT session. sessionId=" + sessionId, exception);
         }
@@ -71,6 +78,13 @@ public class OpenAiSttProvider implements SttProvider {
     public void sendPcm(String sessionId, byte[] pcm16le, long timestampMs) {
         OpenAiSttSessionState session = sessions.get(sessionId);
         if (session == null || pcm16le == null || pcm16le.length == 0) {
+            return;
+        }
+        if (eventHandler.rateLimitGate().isBlocked()) {
+            sessions.remove(sessionId, session);
+            realtimeClient.closeSessionQuietly(session);
+            session.sttListener()
+                    .onError(sessionId, eventHandler.rateLimitGate().blockedException(sessionId));
             return;
         }
         try {

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
@@ -16,11 +16,16 @@ import com.flodiback.domain.speech.stt.SttProvider;
  * - Realtime 클라이언트 호출
  */
 public class OpenAiSttProvider implements SttProvider {
+    private static final String ENV_OPENAI_REALTIME_APPEND_FLUSH_MS = "OPENAI_REALTIME_APPEND_FLUSH_MS";
+    private static final long DEFAULT_APPEND_FLUSH_MS = 500L;
+    private static final long MIN_APPEND_FLUSH_MS = 100L;
+
     private final Map<String, OpenAiSttSessionState> sessions = new ConcurrentHashMap<>();
     private final OpenAiRealtimeClient realtimeClient;
     private final OpenAiPcmConverter pcmConverter;
     private final OpenAiRealtimeEventHandler eventHandler;
     private final OpenAiPcmDebugDumper pcmDebugDumper;
+    private final long appendFlushIntervalMs;
 
     // 내부에서 필요한 기본 객체들을 직접 만듦
     public OpenAiSttProvider() {
@@ -28,7 +33,8 @@ public class OpenAiSttProvider implements SttProvider {
                 new OpenAiRealtimeClient(),
                 new OpenAiPcmConverter(),
                 new OpenAiRealtimeEventHandler(),
-                new OpenAiPcmDebugDumper());
+                new OpenAiPcmDebugDumper(),
+                appendFlushIntervalMsFromEnv());
     }
 
     // 외부에서 객체를 주입할 수 있는 생성자 (테스트 용이성 향상)
@@ -36,11 +42,13 @@ public class OpenAiSttProvider implements SttProvider {
             OpenAiRealtimeClient realtimeClient,
             OpenAiPcmConverter pcmConverter,
             OpenAiRealtimeEventHandler eventHandler,
-            OpenAiPcmDebugDumper pcmDebugDumper) {
+            OpenAiPcmDebugDumper pcmDebugDumper,
+            long appendFlushIntervalMs) {
         this.realtimeClient = Objects.requireNonNull(realtimeClient);
         this.pcmConverter = Objects.requireNonNull(pcmConverter);
         this.eventHandler = Objects.requireNonNull(eventHandler);
         this.pcmDebugDumper = Objects.requireNonNull(pcmDebugDumper);
+        this.appendFlushIntervalMs = Math.max(MIN_APPEND_FLUSH_MS, appendFlushIntervalMs);
     }
 
     @Override
@@ -94,7 +102,11 @@ public class OpenAiSttProvider implements SttProvider {
             }
             pcmDebugDumper.capture(sessionId, pcm16le, realtimePcm);
             session.recordSentPcm(realtimePcm.length, timestampMs);
-            realtimeClient.appendAudio(session, realtimePcm, timestampMs);
+            byte[] bufferedPcm =
+                    session.appendBufferedPcmAndDrainIfDue(realtimePcm, timestampMs, appendFlushIntervalMs);
+            if (bufferedPcm.length > 0) {
+                realtimeClient.appendAudio(session, bufferedPcm, timestampMs);
+            }
         } catch (Exception exception) {
             session.sttListener().onError(sessionId, exception);
         }
@@ -108,12 +120,28 @@ public class OpenAiSttProvider implements SttProvider {
         }
         try {
             session.markEndRequested();
+            byte[] remainingPcm = session.drainBufferedPcm();
+            if (remainingPcm.length > 0) {
+                realtimeClient.appendAudio(session, remainingPcm, session.lastAudioAtMs());
+            }
             realtimeClient.commitAndClose(session);
         } catch (Exception exception) {
             session.sttListener().onError(sessionId, exception);
             realtimeClient.closeSessionQuietly(session);
         } finally {
             pcmDebugDumper.flushSession(sessionId);
+        }
+    }
+
+    private static long appendFlushIntervalMsFromEnv() {
+        String value = System.getenv(ENV_OPENAI_REALTIME_APPEND_FLUSH_MS);
+        if (value == null || value.isBlank()) {
+            return DEFAULT_APPEND_FLUSH_MS;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException ignored) {
+            return DEFAULT_APPEND_FLUSH_MS;
         }
     }
 }

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttProvider.java
@@ -19,6 +19,9 @@ public class OpenAiSttProvider implements SttProvider {
     private static final String ENV_OPENAI_REALTIME_APPEND_FLUSH_MS = "OPENAI_REALTIME_APPEND_FLUSH_MS";
     private static final long DEFAULT_APPEND_FLUSH_MS = 500L;
     private static final long MIN_APPEND_FLUSH_MS = 100L;
+    private static final long MAX_APPEND_FLUSH_MS = 5_000L;
+    private static final int REALTIME_PCM_BYTES_PER_MS = 48;
+    private static final int MAX_BUFFERED_PCM_BYTES = Math.toIntExact(MAX_APPEND_FLUSH_MS * REALTIME_PCM_BYTES_PER_MS);
 
     private final Map<String, OpenAiSttSessionState> sessions = new ConcurrentHashMap<>();
     private final OpenAiRealtimeClient realtimeClient;
@@ -102,8 +105,8 @@ public class OpenAiSttProvider implements SttProvider {
             }
             pcmDebugDumper.capture(sessionId, pcm16le, realtimePcm);
             session.recordSentPcm(realtimePcm.length, timestampMs);
-            byte[] bufferedPcm =
-                    session.appendBufferedPcmAndDrainIfDue(realtimePcm, timestampMs, appendFlushIntervalMs);
+            byte[] bufferedPcm = session.appendBufferedPcmAndDrainIfDue(
+                    realtimePcm, timestampMs, appendFlushIntervalMs, MAX_BUFFERED_PCM_BYTES);
             if (bufferedPcm.length > 0) {
                 realtimeClient.appendAudio(session, bufferedPcm, timestampMs);
             }
@@ -139,7 +142,8 @@ public class OpenAiSttProvider implements SttProvider {
             return DEFAULT_APPEND_FLUSH_MS;
         }
         try {
-            return Long.parseLong(value.trim());
+            long parsed = Long.parseLong(value.trim());
+            return Math.min(parsed, MAX_APPEND_FLUSH_MS);
         } catch (NumberFormatException ignored) {
             return DEFAULT_APPEND_FLUSH_MS;
         }

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttSessionState.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttSessionState.java
@@ -85,7 +85,7 @@ final class OpenAiSttSessionState {
         return lastAudioAtMs.get();
     }
 
-    byte[] appendBufferedPcmAndDrainIfDue(byte[] pcm, long timestampMs, long flushIntervalMs) {
+    byte[] appendBufferedPcmAndDrainIfDue(byte[] pcm, long timestampMs, long flushIntervalMs, int maxBufferedPcmBytes) {
         if (pcm == null || pcm.length == 0) {
             return new byte[0];
         }
@@ -95,7 +95,9 @@ final class OpenAiSttSessionState {
                 bufferedPcmStartedAtMs = normalizedTimestampMs;
             }
             bufferedPcm.writeBytes(pcm);
-            if (normalizedTimestampMs - bufferedPcmStartedAtMs < flushIntervalMs) {
+            boolean intervalReached = normalizedTimestampMs - bufferedPcmStartedAtMs >= flushIntervalMs;
+            boolean bufferLimitReached = bufferedPcm.size() >= maxBufferedPcmBytes;
+            if (!intervalReached && !bufferLimitReached) {
                 return new byte[0];
             }
             return drainBufferedPcmLocked();

--- a/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttSessionState.java
+++ b/src/main/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiSttSessionState.java
@@ -1,5 +1,6 @@
 package com.flodiback.domain.speech.stt.provider.openai;
 
+import java.io.ByteArrayOutputStream;
 import java.net.http.WebSocket;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -33,6 +34,10 @@ final class OpenAiSttSessionState {
     private final AtomicLong lastAudioAtMs = new AtomicLong();
     // endSession이 호출되었는지 상태 플래그
     private final AtomicBoolean endRequested = new AtomicBoolean(false);
+    // OpenAI Realtime append 요청 수를 줄이기 위한 PCM 배치 버퍼
+    private final Object bufferedPcmLock = new Object();
+    private final ByteArrayOutputStream bufferedPcm = new ByteArrayOutputStream();
+    private long bufferedPcmStartedAtMs = 0L;
 
     // OpenAI item_id별 delta 누적 버퍼
     private final Map<String, StringBuilder> partialByItemId = new ConcurrentHashMap<>();
@@ -78,6 +83,36 @@ final class OpenAiSttSessionState {
 
     long lastAudioAtMs() {
         return lastAudioAtMs.get();
+    }
+
+    byte[] appendBufferedPcmAndDrainIfDue(byte[] pcm, long timestampMs, long flushIntervalMs) {
+        if (pcm == null || pcm.length == 0) {
+            return new byte[0];
+        }
+        long normalizedTimestampMs = timestampMs > 0 ? timestampMs : System.currentTimeMillis();
+        synchronized (bufferedPcmLock) {
+            if (bufferedPcmStartedAtMs == 0L) {
+                bufferedPcmStartedAtMs = normalizedTimestampMs;
+            }
+            bufferedPcm.writeBytes(pcm);
+            if (normalizedTimestampMs - bufferedPcmStartedAtMs < flushIntervalMs) {
+                return new byte[0];
+            }
+            return drainBufferedPcmLocked();
+        }
+    }
+
+    byte[] drainBufferedPcm() {
+        synchronized (bufferedPcmLock) {
+            return drainBufferedPcmLocked();
+        }
+    }
+
+    private byte[] drainBufferedPcmLocked() {
+        byte[] drained = bufferedPcm.toByteArray();
+        bufferedPcm.reset();
+        bufferedPcmStartedAtMs = 0L;
+        return drained;
     }
 
     void markEndRequested() {

--- a/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandlerTest.java
+++ b/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandlerTest.java
@@ -70,6 +70,30 @@ class OpenAiRealtimeEventHandlerTest {
         assertThat(rateLimitGate.isBlocked()).isFalse();
     }
 
+    @Test
+    void appendBufferedPcmAndDrainIfDue_batchesSmallAudioFrames() {
+        OpenAiSttSessionState session = new OpenAiSttSessionState("session-1", "speaker-1", new CapturingSttListener());
+
+        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {1, 2}, 1_000L, 500L))
+                .isEmpty();
+        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {3, 4}, 1_240L, 500L))
+                .isEmpty();
+
+        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {5, 6}, 1_500L, 500L))
+                .containsExactly(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    void drainBufferedPcm_flushesRemainingAudioBeforeCommit() {
+        OpenAiSttSessionState session = new OpenAiSttSessionState("session-1", "speaker-1", new CapturingSttListener());
+
+        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {1, 2}, 1_000L, 500L))
+                .isEmpty();
+
+        assertThat(session.drainBufferedPcm()).containsExactly(1, 2);
+        assertThat(session.drainBufferedPcm()).isEmpty();
+    }
+
     private static final class CapturingSttListener implements SttListener {
         private final List<SttResult> results = new ArrayList<>();
         private final List<Throwable> errors = new ArrayList<>();

--- a/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandlerTest.java
+++ b/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandlerTest.java
@@ -74,20 +74,31 @@ class OpenAiRealtimeEventHandlerTest {
     void appendBufferedPcmAndDrainIfDue_batchesSmallAudioFrames() {
         OpenAiSttSessionState session = new OpenAiSttSessionState("session-1", "speaker-1", new CapturingSttListener());
 
-        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {1, 2}, 1_000L, 500L))
+        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {1, 2}, 1_000L, 500L, 10))
                 .isEmpty();
-        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {3, 4}, 1_240L, 500L))
+        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {3, 4}, 1_240L, 500L, 10))
                 .isEmpty();
 
-        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {5, 6}, 1_500L, 500L))
+        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {5, 6}, 1_500L, 500L, 10))
                 .containsExactly(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    void appendBufferedPcmAndDrainIfDue_flushesWhenBufferLimitReached() {
+        OpenAiSttSessionState session = new OpenAiSttSessionState("session-1", "speaker-1", new CapturingSttListener());
+
+        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {1, 2}, 1_000L, 5_000L, 4))
+                .isEmpty();
+
+        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {3, 4}, 1_020L, 5_000L, 4))
+                .containsExactly(1, 2, 3, 4);
     }
 
     @Test
     void drainBufferedPcm_flushesRemainingAudioBeforeCommit() {
         OpenAiSttSessionState session = new OpenAiSttSessionState("session-1", "speaker-1", new CapturingSttListener());
 
-        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {1, 2}, 1_000L, 500L))
+        assertThat(session.appendBufferedPcmAndDrainIfDue(new byte[] {1, 2}, 1_000L, 500L, 10))
                 .isEmpty();
 
         assertThat(session.drainBufferedPcm()).containsExactly(1, 2);

--- a/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandlerTest.java
+++ b/src/test/java/com/flodiback/domain/speech/stt/provider/openai/OpenAiRealtimeEventHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,8 +49,30 @@ class OpenAiRealtimeEventHandlerTest {
         assertThat(result.audioDurationMs()).isEqualTo(200L);
     }
 
+    @Test
+    void onError_recordsRealtimeRateLimitCooldown() {
+        AtomicLong now = new AtomicLong(1_000L);
+        OpenAiRealtimeRateLimitGate rateLimitGate = new OpenAiRealtimeRateLimitGate(now::get);
+        OpenAiRealtimeEventHandler rateLimitedEventHandler = new OpenAiRealtimeEventHandler(rateLimitGate);
+        CapturingSttListener listener = new CapturingSttListener();
+        OpenAiSttSessionState session = new OpenAiSttSessionState("session-1", "speaker-1", listener);
+
+        rateLimitedEventHandler.onError(
+                session,
+                new RuntimeException(
+                        "Rate limit reached for gpt-realtime on requests per day. Please try again in 1m26.4s."));
+
+        assertThat(rateLimitGate.remainingMillis()).isEqualTo(86_900L);
+        assertThat(listener.onlyError().getMessage()).contains("Rate limit reached");
+
+        now.addAndGet(86_901L);
+
+        assertThat(rateLimitGate.isBlocked()).isFalse();
+    }
+
     private static final class CapturingSttListener implements SttListener {
         private final List<SttResult> results = new ArrayList<>();
+        private final List<Throwable> errors = new ArrayList<>();
 
         @Override
         public void onResult(SttResult result) {
@@ -58,12 +81,17 @@ class OpenAiRealtimeEventHandlerTest {
 
         @Override
         public void onError(String sessionId, Throwable throwable) {
-            throw new AssertionError("Unexpected STT error", throwable);
+            errors.add(throwable);
         }
 
         private SttResult onlyResult() {
             assertThat(results).hasSize(1);
             return results.get(0);
+        }
+
+        private Throwable onlyError() {
+            assertThat(errors).hasSize(1);
+            return errors.get(0);
         }
     }
 }


### PR DESCRIPTION
## 개요
OpenAI Realtime STT에서 짧은 오디오 프레임을 너무 자주 전송하면서 RPM/RPD 한도에 빠지는 문제를 줄입니다.

운영 로그에서는 `Rate limit reached ... requests per min (RPM): Limit 200, Used 200`와 `requests per day (RPD): Limit 1000, Used 1000`가 반복됐습니다. 기존 구현은 이 오류를 일반 STT 오류로만 넘겨서, 한도 초과 상태에서도 새 세션이나 추가 전송을 계속 시도할 수 있었습니다.

Closes #99

## 변경 내용
- OpenAI Realtime rate limit 메시지를 감지하는 `OpenAiRealtimeRateLimitGate`를 추가했습니다.
- OpenAI가 알려준 `Please try again in ...` 값을 파싱해서 공유 쿨다운을 기록합니다.
- 쿨다운 중에는 새 STT 세션 생성과 추가 오디오 전송을 막아 불필요한 재시도와 로그 폭주를 줄입니다.
- 20ms 단위로 들어오는 PCM을 바로 `appendAudio`하지 않고 기본 500ms 단위로 모아 보냅니다.
- 세션 종료 시 버퍼에 남은 PCM을 먼저 flush한 뒤 commit하도록 처리했습니다.
- `OPENAI_REALTIME_APPEND_FLUSH_MS` 환경변수를 문서에 추가했습니다. 값을 넣지 않으면 기본 500ms로 동작하고, 100ms 미만 값은 100ms로 보정됩니다.

## 왜 필요한가
기존 구조에서는 Discord 음성 프레임이 짧게 들어올 때 OpenAI Realtime append 요청이 매우 촘촘하게 발생할 수 있습니다.

예를 들어 20ms마다 전송하면 화자 1명만 있어도 분당 이론상 최대 3000회 전송이 가능합니다. OpenAI Realtime의 RPM 200 제한에서는 운영 회의처럼 여러 화자와 긴 시간이 겹치면 빠르게 한도에 도달할 수 있습니다.

이번 변경은 STT 세션 자체를 크게 바꾸지 않고, 같은 오디오를 조금 더 큰 단위로 묶어서 보내는 방식입니다. 실시간성은 유지하되 요청 수를 낮추는 목적입니다.

## 검증
- `./gradlew test --tests com.flodiback.domain.speech.stt.provider.openai.OpenAiRealtimeEventHandlerTest`
- `./gradlew spotlessCheck`
- 로컬 Docker 봇 테스트에서 최근 20분 기준 `Rate limit reached` 0회 확인
- 로컬 Docker 봇 테스트에서 `OPENAI/세션열림 -> OPENAI/커밋전송 -> OPENAI/최종전사 -> 전송/성공 -> 소켓종료 statusCode=1000` 흐름 확인

## 참고
- 전체 `./gradlew test`는 로컬 Docker/Testcontainers 환경 문제로 실패한 적이 있어, 이번 변경 범위의 대상 테스트와 포맷 검사를 우선 검증했습니다.
- 이 쿨다운은 애플리케이션 프로세스 메모리 기준입니다. 여러 봇 인스턴스를 동시에 띄우면 인스턴스 간 쿨다운은 공유되지 않습니다.
