### PR TITLE
feat: 회의 관련 웹소켓 이벤트 추가

### DIFF
--- a/src/main/java/com/flodiback/domain/meeting/meeting/event/MeetingEndedEvent.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/event/MeetingEndedEvent.java
@@ -1,3 +1,3 @@
 package com.flodiback.domain.meeting.meeting.event;
 
-public record MeetingEndedEvent(Long meetingId) {}
+public record MeetingEndedEvent(Long meetingId, Long projectId, String channelId) {}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/event/MeetingStartedEvent.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/event/MeetingStartedEvent.java
@@ -1,0 +1,3 @@
+package com.flodiback.domain.meeting.meeting.event;
+
+public record MeetingStartedEvent(Long meetingId, Long projectId, String channelId) {}

--- a/src/main/java/com/flodiback/domain/meeting/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/repository/MeetingRepository.java
@@ -25,6 +25,10 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Query("select m.id from Meeting m where m.status = :status")
     List<Long> findIdsByStatus(@Param("status") MeetingStatus status);
 
+    @Query("select m from Meeting m where m.project.id in :projectIds and m.status = :status order by m.startedAt desc")
+    List<Meeting> findActiveByProjectIds(
+            @Param("projectIds") List<Long> projectIds, @Param("status") MeetingStatus status);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select m from Meeting m where m.id = :id")
     Optional<Meeting> findByIdForUpdate(@Param("id") Long id);

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -14,6 +14,7 @@ import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
 import com.flodiback.domain.meeting.meeting.dto.MeetingDetailResponse;
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.meeting.meeting.event.MeetingEndedEvent;
+import com.flodiback.domain.meeting.meeting.event.MeetingStartedEvent;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
@@ -42,6 +43,11 @@ public class MeetingService {
         Meeting meeting = Meeting.builder().project(project).title(req.title()).build();
         meetingRepository.save(meeting);
 
+        if (project != null) {
+            eventPublisher.publishEvent(
+                    new MeetingStartedEvent(meeting.getId(), project.getId(), project.getChannelId()));
+        }
+
         return new CreateMeetingResponse(
                 meeting.getId(),
                 project != null ? project.getId() : null,
@@ -59,7 +65,9 @@ public class MeetingService {
         meeting.end();
         meetingRepository.save(meeting);
 
-        eventPublisher.publishEvent(new MeetingEndedEvent(meeting.getId()));
+        Long projectId = meeting.getProject() != null ? meeting.getProject().getId() : null;
+        String channelId = meeting.getProject() != null ? meeting.getProject().getChannelId() : null;
+        eventPublisher.publishEvent(new MeetingEndedEvent(meeting.getId(), projectId, channelId));
         return toDetailResponse(meeting);
     }
 

--- a/src/main/java/com/flodiback/domain/project/project/dto/ProjectResponse.java
+++ b/src/main/java/com/flodiback/domain/project/project/dto/ProjectResponse.java
@@ -3,4 +3,11 @@ package com.flodiback.domain.project.project.dto;
 import java.time.LocalDateTime;
 
 public record ProjectResponse(
-        Long id, Long serverId, String name, String description, String techStack, LocalDateTime createdAt) {}
+        Long id,
+        Long serverId,
+        String name,
+        String description,
+        String techStack,
+        LocalDateTime createdAt,
+        String channelId,
+        Long activeMeetingId) {}

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -1,11 +1,15 @@
 package com.flodiback.domain.project.project.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.project.project.dto.CreateProjectRequest;
 import com.flodiback.domain.project.project.dto.ProjectResponse;
 import com.flodiback.domain.project.project.dto.UpdateProjectRequest;
@@ -13,6 +17,7 @@ import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
 import com.flodiback.domain.server.server.entity.DiscordServer;
 import com.flodiback.domain.server.server.repository.DiscordServerRepository;
+import com.flodiback.global.enums.MeetingStatus;
 import com.flodiback.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
@@ -24,6 +29,7 @@ public class ProjectService {
 
     private final ProjectRepository projectRepository;
     private final DiscordServerRepository discordServerRepository;
+    private final MeetingRepository meetingRepository;
 
     public ProjectResponse create(CreateProjectRequest req) {
         if (req.channelId() != null) {
@@ -56,18 +62,24 @@ public class ProjectService {
                 .build();
         projectRepository.save(project);
 
-        return toResponse(project);
+        return toResponse(project, null);
     }
 
     @Transactional(readOnly = true)
     public List<ProjectResponse> getAll() {
-        return projectRepository.findAll().stream().map(this::toResponse).toList();
+        List<Project> projects = projectRepository.findAll();
+        Map<Long, Long> activeMeetingIdMap = buildActiveMeetingIdMap(projects);
+        return projects.stream()
+                .map(p -> toResponse(p, activeMeetingIdMap.get(p.getId())))
+                .toList();
     }
 
     @Transactional(readOnly = true)
     public List<ProjectResponse> getByGuildIds(List<String> guildIds) {
-        return projectRepository.findByServerGuildIdIn(guildIds).stream()
-                .map(this::toResponse)
+        List<Project> projects = projectRepository.findByServerGuildIdIn(guildIds);
+        Map<Long, Long> activeMeetingIdMap = buildActiveMeetingIdMap(projects);
+        return projects.stream()
+                .map(p -> toResponse(p, activeMeetingIdMap.get(p.getId())))
                 .toList();
     }
 
@@ -79,7 +91,7 @@ public class ProjectService {
                 && !guildIds.contains(project.getServer().getGuildId())) {
             throw new ServiceException("403-1", "권한이 없습니다.");
         }
-        return toResponse(project);
+        return toResponseWithActiveMeeting(project);
     }
 
     @Transactional(readOnly = true)
@@ -91,7 +103,7 @@ public class ProjectService {
                 && !guildIds.contains(project.getServer().getGuildId())) {
             throw new ServiceException("403-1", "권한이 없습니다.");
         }
-        return toResponse(project);
+        return toResponseWithActiveMeeting(project);
     }
 
     @Transactional(readOnly = true)
@@ -100,7 +112,7 @@ public class ProjectService {
                 .findByChannelId(channelId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
         checkReadPermission(project, guildId);
-        return toResponse(project);
+        return toResponseWithActiveMeeting(project);
     }
 
     @Transactional(readOnly = true)
@@ -108,7 +120,7 @@ public class ProjectService {
         Project project =
                 projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
         checkReadPermission(project, guildId);
-        return toResponse(project);
+        return toResponseWithActiveMeeting(project);
     }
 
     public ProjectResponse update(Long id, UpdateProjectRequest req, String requesterId) {
@@ -116,7 +128,7 @@ public class ProjectService {
                 projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
         checkWritePermission(project, requesterId);
         project.update(req.name(), req.description(), req.techStack());
-        return toResponse(project);
+        return toResponseWithActiveMeeting(project);
     }
 
     public void connectChannel(Long id, String channelId, String requesterId) {
@@ -154,13 +166,31 @@ public class ProjectService {
         }
     }
 
-    ProjectResponse toResponse(Project project) {
+    private Map<Long, Long> buildActiveMeetingIdMap(List<Project> projects) {
+        if (projects.isEmpty()) return Map.of();
+        List<Long> projectIds = projects.stream().map(Project::getId).toList();
+        return meetingRepository.findActiveByProjectIds(projectIds, MeetingStatus.IN_PROGRESS).stream()
+                .collect(Collectors.toMap(
+                        m -> m.getProject().getId(), Meeting::getId, (first, duplicate) -> first)); // 먼저 삽입된 값(최신)을 유지
+    }
+
+    private ProjectResponse toResponseWithActiveMeeting(Project project) {
+        Long activeMeetingId = meetingRepository
+                .findFirstByProjectAndStatusOrderByStartedAtDesc(project, MeetingStatus.IN_PROGRESS)
+                .map(Meeting::getId)
+                .orElse(null);
+        return toResponse(project, activeMeetingId);
+    }
+
+    private ProjectResponse toResponse(Project project, Long activeMeetingId) {
         return new ProjectResponse(
                 project.getId(),
                 project.getServer() != null ? project.getServer().getId() : null,
                 project.getName(),
                 project.getDescription(),
                 project.getTechStack(),
-                project.getCreatedAt());
+                project.getCreatedAt(),
+                project.getChannelId(),
+                activeMeetingId);
     }
 }

--- a/src/main/java/com/flodiback/global/websocket/MeetingStatusWebSocketPublisher.java
+++ b/src/main/java/com/flodiback/global/websocket/MeetingStatusWebSocketPublisher.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.flodiback.domain.meeting.meeting.event.MeetingEndedEvent;
+import com.flodiback.domain.meeting.meeting.event.MeetingStartedEvent;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,11 +17,26 @@ public class MeetingStatusWebSocketPublisher {
     private final SimpMessagingTemplate messagingTemplate;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onMeetingStarted(MeetingStartedEvent event) {
+        if (event.projectId() == null) return;
+        messagingTemplate.convertAndSend(
+                "/topic/projects/" + event.projectId() + "/status",
+                new ProjectStatusMessage("meeting.started", event.meetingId(), event.channelId()));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onMeetingEnded(MeetingEndedEvent event) {
         messagingTemplate.convertAndSend(
                 "/topic/meetings/" + event.meetingId() + "/status",
                 new MeetingStatusMessage("meeting.ended", event.meetingId()));
+        if (event.projectId() != null) {
+            messagingTemplate.convertAndSend(
+                    "/topic/projects/" + event.projectId() + "/status",
+                    new ProjectStatusMessage("meeting.ended", event.meetingId(), event.channelId()));
+        }
     }
+
+    record ProjectStatusMessage(String type, Long meetingId, String channelId) {}
 
     record MeetingStatusMessage(String type, Long meetingId) {}
 }

--- a/src/test/java/com/flodiback/domain/meeting/meeting/context/MeetingStartContextInvalidationListenerTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meeting/context/MeetingStartContextInvalidationListenerTest.java
@@ -18,7 +18,7 @@ class MeetingStartContextInvalidationListenerTest {
         MeetingStartContextProvider provider = org.mockito.Mockito.mock(MeetingStartContextProvider.class);
         MeetingStartContextInvalidationListener listener = new MeetingStartContextInvalidationListener(provider);
 
-        listener.handle(new MeetingEndedEvent(1L));
+        listener.handle(new MeetingEndedEvent(1L, null, null));
 
         verify(provider).invalidate(1L);
     }

--- a/src/test/java/com/flodiback/domain/meeting/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meeting/service/MeetingServiceTest.java
@@ -12,16 +12,19 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingRequest;
 import com.flodiback.domain.meeting.meeting.dto.CreateMeetingResponse;
 import com.flodiback.domain.meeting.meeting.dto.MeetingDetailResponse;
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
 import com.flodiback.domain.meeting.meeting.event.MeetingEndedEvent;
+import com.flodiback.domain.meeting.meeting.event.MeetingStartedEvent;
 import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
@@ -56,6 +59,7 @@ class MeetingServiceTest {
         // then
         verify(projectRepository, never()).findById(any());
         verify(meetingRepository).save(any(Meeting.class));
+        verify(eventPublisher, never()).publishEvent(any());
         assertThat(response.projectId()).isNull();
         assertThat(response.title()).isEqualTo("테스트 회의");
         assertThat(response.status()).isEqualTo(MeetingStatus.IN_PROGRESS);
@@ -66,9 +70,14 @@ class MeetingServiceTest {
     void create_유효한_projectId면_미팅생성() {
         // given
         Project project = Project.builder().name("테스트 프로젝트").build();
+        ReflectionTestUtils.setField(project, "id", 1L);
         CreateMeetingRequest req = new CreateMeetingRequest(1L, "테스트 회의");
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
-        given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> {
+            Meeting m = invocation.getArgument(0);
+            ReflectionTestUtils.setField(m, "id", 10L);
+            return m;
+        });
 
         // when
         CreateMeetingResponse response = meetingService.create(req);
@@ -79,6 +88,12 @@ class MeetingServiceTest {
         assertThat(response.title()).isEqualTo("테스트 회의");
         assertThat(response.status()).isEqualTo(MeetingStatus.IN_PROGRESS);
         assertThat(response.projectConnected()).isTrue();
+
+        ArgumentCaptor<MeetingStartedEvent> captor = ArgumentCaptor.forClass(MeetingStartedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().meetingId()).isEqualTo(10L);
+        assertThat(captor.getValue().projectId()).isEqualTo(1L);
+        assertThat(captor.getValue().channelId()).isNull();
     }
 
     @Test
@@ -145,7 +160,7 @@ class MeetingServiceTest {
     @Test
     void end_유효한_id면_MeetingEndedEvent_발행() {
         // given
-        Meeting meeting = Meeting.builder().title("테스트 회의").build();
+        Meeting meeting = Meeting.builder().title("테스트 회의").build(); // project 없음
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
 
@@ -153,7 +168,29 @@ class MeetingServiceTest {
         meetingService.end(1L, null);
 
         // then
-        verify(eventPublisher).publishEvent(any(MeetingEndedEvent.class));
+        ArgumentCaptor<MeetingEndedEvent> captor = ArgumentCaptor.forClass(MeetingEndedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().projectId()).isNull();
+        assertThat(captor.getValue().channelId()).isNull();
+    }
+
+    @Test
+    void end_project_있는_회의_종료_시_projectId_channelId_채워짐() {
+        // given
+        Project project = Project.builder().channelId("ch-123").build();
+        ReflectionTestUtils.setField(project, "id", 1L);
+        Meeting meeting = Meeting.builder().project(project).title("회의").build();
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        meetingService.end(1L, null);
+
+        // then
+        ArgumentCaptor<MeetingEndedEvent> captor = ArgumentCaptor.forClass(MeetingEndedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().projectId()).isEqualTo(1L);
+        assertThat(captor.getValue().channelId()).isEqualTo("ch-123");
     }
 
     @Test

--- a/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
@@ -17,7 +17,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import com.flodiback.domain.meeting.meeting.entity.Meeting;
+import com.flodiback.domain.meeting.meeting.repository.MeetingRepository;
 import com.flodiback.domain.project.project.dto.CreateProjectRequest;
 import com.flodiback.domain.project.project.dto.ProjectResponse;
 import com.flodiback.domain.project.project.dto.UpdateProjectRequest;
@@ -25,6 +28,7 @@ import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
 import com.flodiback.domain.server.server.entity.DiscordServer;
 import com.flodiback.domain.server.server.repository.DiscordServerRepository;
+import com.flodiback.global.enums.MeetingStatus;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectServiceTest {
@@ -37,6 +41,9 @@ class ProjectServiceTest {
 
     @Mock
     private DiscordServerRepository discordServerRepository;
+
+    @Mock
+    private MeetingRepository meetingRepository;
 
     // ─── create ───────────────────────────────────────────
 
@@ -98,6 +105,7 @@ class ProjectServiceTest {
         Project p1 = Project.builder().name("프로젝트 A").build();
         Project p2 = Project.builder().name("프로젝트 B").build();
         willReturn(List.of(p1, p2)).given(projectRepository).findAll();
+        given(meetingRepository.findActiveByProjectIds(any(), any())).willReturn(List.of());
 
         // when
         List<ProjectResponse> responses = projectService.getAll();
@@ -107,6 +115,24 @@ class ProjectServiceTest {
         assertThat(responses).hasSize(2);
         assertThat(responses.get(0).name()).isEqualTo("프로젝트 A");
         assertThat(responses.get(1).name()).isEqualTo("프로젝트 B");
+    }
+
+    @Test
+    void getAll_활성회의가_있는_프로젝트는_activeMeetingId_반환() {
+        // given
+        Project p1 = Project.builder().name("프로젝트 A").build();
+        ReflectionTestUtils.setField(p1, "id", 1L);
+        Meeting meeting = Meeting.builder().project(p1).title("회의").build();
+        ReflectionTestUtils.setField(meeting, "id", 42L);
+        willReturn(List.of(p1)).given(projectRepository).findAll();
+        given(meetingRepository.findActiveByProjectIds(List.of(1L), MeetingStatus.IN_PROGRESS))
+                .willReturn(List.of(meeting));
+
+        // when
+        List<ProjectResponse> responses = projectService.getAll();
+
+        // then
+        assertThat(responses.get(0).activeMeetingId()).isEqualTo(42L);
     }
 
     // ─── getById ──────────────────────────────────────────
@@ -120,6 +146,8 @@ class ProjectServiceTest {
                 .techStack("Java")
                 .build();
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.findFirstByProjectAndStatusOrderByStartedAtDesc(project, MeetingStatus.IN_PROGRESS))
+                .willReturn(Optional.empty());
 
         // when
         ProjectResponse response = projectService.getById(1L, null);
@@ -153,6 +181,8 @@ class ProjectServiceTest {
                 .build();
         UpdateProjectRequest req = new UpdateProjectRequest("새 이름", "새 설명", "Kotlin");
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.findFirstByProjectAndStatusOrderByStartedAtDesc(project, MeetingStatus.IN_PROGRESS))
+                .willReturn(Optional.empty());
 
         // when
         ProjectResponse response = projectService.update(1L, req, null);


### PR DESCRIPTION
## 변경 개요

  프론트엔드에서 프로젝트별 회의 진행 상태를 실시간으로 구독할 수 있도록
  WebSocket 이벤트 구조를 추가하고, `ProjectResponse`에 상태 필드를 보강합니다.

  ## 변경 내용

  ### 기능

  - `MeetingStartedEvent` 신규 추가 — `meetingId`, `projectId`, `channelId` 포함
  - `MeetingEndedEvent` 필드 확장 — `projectId`, `channelId` 추가 (project 없는 회의는 null)
  - `MeetingService.create()` — project 연결된 회의 생성 시 `MeetingStartedEvent` 발행
  - `MeetingService.end()` — `MeetingEndedEvent`에 project 정보 포함하여 발행
  - `MeetingStatusWebSocketPublisher` — `/topic/projects/{projectId}/status` 토픽 신규 발행
    - `meeting.started` / `meeting.ended` 메시지 전송
    - 기존 `/topic/meetings/{meetingId}/status` (meeting.ended) 유지
  - `ProjectResponse` — `channelId`, `activeMeetingId` 필드 추가

  ### WebSocket 토픽

  | 토픽 | 메시지 | 설명 |
  |---|---|---|
  | `/topic/meetings/{meetingId}/status` | `meeting.ended` | 기존 유지 |
  | `/topic/projects/{projectId}/status` | `meeting.started`, `meeting.ended` | 신규 |

  ### 설계 개선

  - `getAll()` / `getByGuildIds()` — `findActiveByProjectIds` 벌크 조회로 N+1 제거
  - `update()` — `activeMeetingId: null` 고정 버그 수정, 실제 활성 회의 ID 반환
  - `toResponseWithActiveMeeting()` — DB 조회 의도가 드러나도록 메서드명 명시, `private` 접근자 적용
  - `create()` / `update()` 쓰기 경로 불필요 DB 조회 제거

  ## 테스트

  - `MeetingServiceTest` — `MeetingStartedEvent` 세 필드 정확값 검증 (`meetingId`, `projectId`, `channelId`)
  - `MeetingServiceTest` — project 있는 회의 종료 시 `MeetingEndedEvent` 필드 검증 케이스 추가
  - `ProjectServiceTest` — `getAll` 활성 회의 매핑 동작 검증 케이스 추가
  - `ProjectServiceTest` — `update()` strict stubbing 환경 대응 stub 추가