### PR TITLE
fix: release-please 수동 실행 트리거 추가 (workflow_dispatch)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [ dev ]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## 요약
- `workflow_dispatch` 트리거 추가로 release-please 워크플로를 GitHub Actions UI에서 수동 실행 가능

## 배경
- v0.1.0 태그만 있고 GitHub Release가 없어서 release-please가 기준점을 못 잡던 문제 발견
- GitHub Release를 수동으로 생성한 후 release-please를 재실행할 필요가 있어 추가

## 변경 내용
- `on.workflow_dispatch` 트리거 추가 (기존 `push: branches: [dev]` 유지)