### PR TITLE
feat: rolling summary progress WebSocket push 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,1 @@
-# CLAUDE.md
 
-@AGENTS.md
-
-## Claude Code 메모
-- 기본 진입점은 `AGENTS.md`입니다.
-- 지속적으로 참고할 프로젝트 맥락은 `docs/README.md`와 연결 문서에서 확인합니다.
-- 팀 공통 지침은 저장소 파일에, 개인 취향은 로컬 설정에 둡니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,8 @@
+# CLAUDE.md
 
+@AGENTS.md
+
+## Claude Code 메모
+- 기본 진입점은 `AGENTS.md`입니다.
+- 지속적으로 참고할 프로젝트 맥락은 `docs/README.md`와 연결 문서에서 확인합니다.
+- 팀 공통 지침은 저장소 파일에, 개인 취향은 로컬 설정에 둡니다.

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryProgress.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryProgress.java
@@ -1,0 +1,10 @@
+package com.flodiback.domain.meeting.meetinglog.rolling;
+
+public record RollingSummaryProgress(
+        Long meetingId,
+        long uncompressedTokens,
+        int thresholdTokens,
+        long remainingTokens,
+        int progressPercent,
+        int remainingPercent,
+        boolean compressionTriggered) {}

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryService.java
@@ -13,8 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RollingSummaryService {
 
-    static final int TOKEN_THRESHOLD = 2600;
-    static final int KEEP_TURNS = 18;
+    static final int TOKEN_THRESHOLD = 2200;
+    static final int KEEP_TURNS = 16;
 
     private static final String SYSTEM_PROMPT = """
             당신은 회의 내용을 압축하는 AI 요약기입니다.
@@ -57,5 +57,20 @@ public class RollingSummaryService {
 
     public long calculateUncompressedTokenCount(Long meetingId) {
         return rollingSummaryPersistenceService.calculateUncompressedTokenCount(meetingId);
+    }
+
+    public RollingSummaryProgress getProgress(Long meetingId) {
+        long uncompressedTokens = calculateUncompressedTokenCount(meetingId);
+        int progressPercent = (int) Math.min(100L, uncompressedTokens * 100L / TOKEN_THRESHOLD);
+        int remainingPercent = 100 - progressPercent;
+        long remainingTokens = Math.max(0L, TOKEN_THRESHOLD - uncompressedTokens);
+        return new RollingSummaryProgress(
+                meetingId,
+                uncompressedTokens,
+                TOKEN_THRESHOLD,
+                remainingTokens,
+                progressPercent,
+                remainingPercent,
+                uncompressedTokens >= TOKEN_THRESHOLD);
     }
 }

--- a/src/main/java/com/flodiback/global/config/AsyncConfig.java
+++ b/src/main/java/com/flodiback/global/config/AsyncConfig.java
@@ -44,4 +44,22 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "contextProgressExecutor")
+    public Executor contextProgressExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("context-progress-");
+        executor.setRejectedExecutionHandler((runnable, poolExecutor) -> {
+            ThreadPoolExecutor pool = (ThreadPoolExecutor) poolExecutor;
+            log.warn(
+                    "Context progress task rejected. activeCount={}, queueSize={}",
+                    pool.getActiveCount(),
+                    pool.getQueue().size());
+        });
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/flodiback/global/websocket/RollingSummaryProgressWebSocketPublisher.java
+++ b/src/main/java/com/flodiback/global/websocket/RollingSummaryProgressWebSocketPublisher.java
@@ -1,0 +1,37 @@
+package com.flodiback.global.websocket;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.flodiback.domain.meeting.meetinglog.rolling.RollingSummaryProgress;
+import com.flodiback.domain.meeting.meetinglog.rolling.RollingSummaryService;
+import com.flodiback.domain.meeting.meetinglog.rolling.RollingSummaryUpdatedEvent;
+import com.flodiback.domain.meeting.meetinglog.rolling.UtteranceSavedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RollingSummaryProgressWebSocketPublisher {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final RollingSummaryService rollingSummaryService;
+
+    @Async("contextProgressExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onUtteranceSaved(UtteranceSavedEvent event) {
+        publish(rollingSummaryService.getProgress(event.meetingId()));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onRollingSummaryUpdated(RollingSummaryUpdatedEvent event) {
+        publish(rollingSummaryService.getProgress(event.meetingId()));
+    }
+
+    private void publish(RollingSummaryProgress progress) {
+        messagingTemplate.convertAndSend("/topic/meetings/" + progress.meetingId() + "/context-progress", progress);
+    }
+}

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryPersistenceServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryPersistenceServiceTest.java
@@ -88,7 +88,7 @@ class RollingSummaryPersistenceServiceTest {
 
         assertThat(candidate.expectedVersion()).isNull();
         assertThat(candidate.expectedCompressedUntilUtteranceId()).isNull();
-        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(13L);
+        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(15L);
         assertThat(candidate.userPrompt()).contains("content-1").doesNotContain("content-31");
         assertThat(candidate.userPrompt())
                 .contains("[출력]")
@@ -122,7 +122,7 @@ class RollingSummaryPersistenceServiceTest {
 
         assertThat(candidate.expectedVersion()).isEqualTo(3);
         assertThat(candidate.expectedCompressedUntilUtteranceId()).isEqualTo(5L);
-        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(18L);
+        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(20L);
         assertThat(candidate.userPrompt()).contains("previous summary");
         assertThat(candidate.nextVersion()).isEqualTo(4);
     }
@@ -146,10 +146,10 @@ class RollingSummaryPersistenceServiceTest {
         RollingSummaryPersistenceService.CompressionCandidate candidate =
                 service.prepareCompression(1L).orElseThrow();
 
-        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(15L);
+        assertThat(candidate.compressedUntilUtteranceId()).isEqualTo(17L);
         assertThat(candidate.userPrompt())
                 .contains("content-3")
-                .contains("content-15")
+                .contains("content-17")
                 .doesNotContain("content-33");
     }
 

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/rolling/RollingSummaryServiceTest.java
@@ -103,6 +103,67 @@ class RollingSummaryServiceTest {
         assertThatCode(() -> service.compressIfNeeded(1L)).doesNotThrowAnyException();
     }
 
+    @Test
+    void getProgress_returnsZeroProgress_whenNoUncompressedTokens() {
+        RollingSummaryService service = new RollingSummaryService(rollingSummaryPersistenceService, aiChatService);
+        given(rollingSummaryPersistenceService.calculateUncompressedTokenCount(1L))
+                .willReturn(0L);
+
+        RollingSummaryProgress progress = service.getProgress(1L);
+
+        assertThat(progress.meetingId()).isEqualTo(1L);
+        assertThat(progress.uncompressedTokens()).isZero();
+        assertThat(progress.thresholdTokens()).isEqualTo(2200);
+        assertThat(progress.remainingTokens()).isEqualTo(2200);
+        assertThat(progress.progressPercent()).isZero();
+        assertThat(progress.remainingPercent()).isEqualTo(100);
+        assertThat(progress.compressionTriggered()).isFalse();
+    }
+
+    @Test
+    void getProgress_returnsHalfProgress_beforeThreshold() {
+        RollingSummaryService service = new RollingSummaryService(rollingSummaryPersistenceService, aiChatService);
+        given(rollingSummaryPersistenceService.calculateUncompressedTokenCount(1L))
+                .willReturn(1100L);
+
+        RollingSummaryProgress progress = service.getProgress(1L);
+
+        assertThat(progress.uncompressedTokens()).isEqualTo(1100);
+        assertThat(progress.remainingTokens()).isEqualTo(1100);
+        assertThat(progress.progressPercent()).isEqualTo(50);
+        assertThat(progress.remainingPercent()).isEqualTo(50);
+        assertThat(progress.compressionTriggered()).isFalse();
+    }
+
+    @Test
+    void getProgress_marksCompressionTriggered_atThreshold() {
+        RollingSummaryService service = new RollingSummaryService(rollingSummaryPersistenceService, aiChatService);
+        given(rollingSummaryPersistenceService.calculateUncompressedTokenCount(1L))
+                .willReturn(2200L);
+
+        RollingSummaryProgress progress = service.getProgress(1L);
+
+        assertThat(progress.remainingTokens()).isZero();
+        assertThat(progress.progressPercent()).isEqualTo(100);
+        assertThat(progress.remainingPercent()).isZero();
+        assertThat(progress.compressionTriggered()).isTrue();
+    }
+
+    @Test
+    void getProgress_capsProgressAfterThreshold() {
+        RollingSummaryService service = new RollingSummaryService(rollingSummaryPersistenceService, aiChatService);
+        given(rollingSummaryPersistenceService.calculateUncompressedTokenCount(1L))
+                .willReturn(2300L);
+
+        RollingSummaryProgress progress = service.getProgress(1L);
+
+        assertThat(progress.uncompressedTokens()).isEqualTo(2300);
+        assertThat(progress.remainingTokens()).isZero();
+        assertThat(progress.progressPercent()).isEqualTo(100);
+        assertThat(progress.remainingPercent()).isZero();
+        assertThat(progress.compressionTriggered()).isTrue();
+    }
+
     private RollingSummaryPersistenceService.CompressionCandidate candidate() {
         return new RollingSummaryPersistenceService.CompressionCandidate(1L, null, null, 11L, "prompt");
     }

--- a/src/test/java/com/flodiback/global/config/AsyncConfigTest.java
+++ b/src/test/java/com/flodiback/global/config/AsyncConfigTest.java
@@ -1,0 +1,22 @@
+package com.flodiback.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.Executor;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+class AsyncConfigTest {
+
+    @Test
+    void contextProgressExecutor_usesDedicatedThreadPrefix() {
+        AsyncConfig config = new AsyncConfig();
+
+        Executor executor = config.contextProgressExecutor();
+
+        ThreadPoolTaskExecutor taskExecutor = (ThreadPoolTaskExecutor) executor;
+        assertThat(taskExecutor.getThreadNamePrefix()).isEqualTo("context-progress-");
+        taskExecutor.shutdown();
+    }
+}

--- a/src/test/java/com/flodiback/global/websocket/ContextSummaryWebSocketPublisherTest.java
+++ b/src/test/java/com/flodiback/global/websocket/ContextSummaryWebSocketPublisherTest.java
@@ -1,0 +1,35 @@
+package com.flodiback.global.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.flodiback.domain.meeting.meetinglog.rolling.RollingSummaryUpdatedEvent;
+
+@ExtendWith(MockitoExtension.class)
+class ContextSummaryWebSocketPublisherTest {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Test
+    void onRollingSummaryUpdated_publishesContextSummary() {
+        ContextSummaryWebSocketPublisher publisher = new ContextSummaryWebSocketPublisher(messagingTemplate);
+
+        publisher.onRollingSummaryUpdated(new RollingSummaryUpdatedEvent(1L, "summary", 2));
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(messagingTemplate)
+                .convertAndSend(org.mockito.ArgumentMatchers.eq("/topic/meetings/1/context"), payloadCaptor.capture());
+        Object payload = payloadCaptor.getValue();
+        assertThat(payload).hasFieldOrPropertyWithValue("meetingId", 1L);
+        assertThat(payload).hasFieldOrPropertyWithValue("summary", "summary");
+        assertThat(payload).hasFieldOrPropertyWithValue("version", 2);
+    }
+}

--- a/src/test/java/com/flodiback/global/websocket/RollingSummaryProgressWebSocketPublisherTest.java
+++ b/src/test/java/com/flodiback/global/websocket/RollingSummaryProgressWebSocketPublisherTest.java
@@ -1,0 +1,85 @@
+package com.flodiback.global.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.flodiback.domain.meeting.meetinglog.rolling.RollingSummaryProgress;
+import com.flodiback.domain.meeting.meetinglog.rolling.RollingSummaryService;
+import com.flodiback.domain.meeting.meetinglog.rolling.RollingSummaryUpdatedEvent;
+import com.flodiback.domain.meeting.meetinglog.rolling.UtteranceSavedEvent;
+
+@ExtendWith(MockitoExtension.class)
+class RollingSummaryProgressWebSocketPublisherTest {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private RollingSummaryService rollingSummaryService;
+
+    @Test
+    void onUtteranceSaved_publishesContextProgress() {
+        RollingSummaryProgressWebSocketPublisher publisher =
+                new RollingSummaryProgressWebSocketPublisher(messagingTemplate, rollingSummaryService);
+        RollingSummaryProgress progress = new RollingSummaryProgress(1L, 1100L, 2200, 1100L, 50, 50, false);
+        given(rollingSummaryService.getProgress(1L)).willReturn(progress);
+
+        publisher.onUtteranceSaved(new UtteranceSavedEvent(1L, 100L));
+
+        verify(messagingTemplate).convertAndSend("/topic/meetings/1/context-progress", progress);
+    }
+
+    @Test
+    void onRollingSummaryUpdated_publishesContextProgress() {
+        RollingSummaryProgressWebSocketPublisher publisher =
+                new RollingSummaryProgressWebSocketPublisher(messagingTemplate, rollingSummaryService);
+        RollingSummaryProgress progress = new RollingSummaryProgress(1L, 0L, 2200, 2200L, 0, 100, false);
+        given(rollingSummaryService.getProgress(1L)).willReturn(progress);
+
+        publisher.onRollingSummaryUpdated(new RollingSummaryUpdatedEvent(1L, "summary", 2));
+
+        verify(messagingTemplate).convertAndSend("/topic/meetings/1/context-progress", progress);
+    }
+
+    @Test
+    void onUtteranceSaved_runsAfterCommitWithContextProgressExecutor() throws NoSuchMethodException {
+        Method method =
+                RollingSummaryProgressWebSocketPublisher.class.getMethod("onUtteranceSaved", UtteranceSavedEvent.class);
+
+        Async async = AnnotatedElementUtils.findMergedAnnotation(method, Async.class);
+        TransactionalEventListener eventListener =
+                AnnotatedElementUtils.findMergedAnnotation(method, TransactionalEventListener.class);
+
+        assertThat(async).isNotNull();
+        assertThat(async.value()).isEqualTo("contextProgressExecutor");
+        assertThat(eventListener).isNotNull();
+        assertThat(eventListener.phase()).isEqualTo(TransactionPhase.AFTER_COMMIT);
+    }
+
+    @Test
+    void onRollingSummaryUpdated_runsAfterCommitWithoutAsync() throws NoSuchMethodException {
+        Method method = RollingSummaryProgressWebSocketPublisher.class.getMethod(
+                "onRollingSummaryUpdated", RollingSummaryUpdatedEvent.class);
+
+        Async async = AnnotatedElementUtils.findMergedAnnotation(method, Async.class);
+        TransactionalEventListener eventListener =
+                AnnotatedElementUtils.findMergedAnnotation(method, TransactionalEventListener.class);
+
+        assertThat(async).isNull();
+        assertThat(eventListener).isNotNull();
+        assertThat(eventListener.phase()).isEqualTo(TransactionPhase.AFTER_COMMIT);
+    }
+}


### PR DESCRIPTION
## Summary

발화 저장 후 rolling summary 압축까지 얼마나 남았는지 프론트가 게이지로 표시할 수 있도록 WebSocket push를 추가합니다.

- 발화 저장(\`UtteranceSavedEvent\\`) 시 progress를 계산해 \`/topic/meetings/{meetingId}/context-progress\\`로 push
- 압축 완료(\`RollingSummaryUpdatedEvent\\`) 후 최신 progress를 재발행해 게이지 리셋
- 기존 \`/topic/meetings/{meetingId}/context\\` summary 발행은 그대로 유지

## Changes

- \`RollingSummaryProgress\\` record 추가
- \`RollingSummaryService.getProgress()\\` 추가
- \`RollingSummaryProgressWebSocketPublisher\\` 추가
- \`AsyncConfig\\`에 \`contextProgressExecutor\\` 추가 (core=1, max=2, queue=100, warn+drop on reject)
- \`TOKEN_THRESHOLD\\` 2600 → 2200, \`KEEP_TURNS\\` 18 → 16 조정

## Test plan

- [x]  \`RollingSummaryServiceTest\\` — \`getProgress()\\` 경계값 검증
- [x]  \`RollingSummaryProgressWebSocketPublisherTest\\` — 발행 및 \`@Async\\` 설정 검증
- [x]  \`ContextSummaryWebSocketPublisherTest\\` — 기존 \`/context\\` 발행 유지 확인
- [x]  \`AsyncConfigTest\\` — \`contextProgressExecutor\\` bean 확인
- [x]  \`RollingSummaryPersistenceServiceTest\\` — \`KEEP_TURNS\\` 변경 기대값 수정


# Rolling Summary Progress WebSocket 동작 흐름

## 전체 구조

```java
발화 저장
  │
  ├─► RollingSummaryEventListener      ─► compressIfNeeded()  (압축 담당)
  │     @Async("rollingSummaryExecutor")
  │
  └─► RollingSummaryProgressWebSocketPublisher  (progress 담당)
        @Async("contextProgressExecutor")
          │
          └─► getProgress() → /topic/meetings/{id}/context-progress  push
```

---

### 1단계 — 발화 저장

사용자가 말하면 /speech API가 Utterance를 저장하고 트랜잭션이 커밋됩니다.

커밋 직후 `UtteranceSavedEvent`가 발행됩니다.

---

### 2단계 — 두 리스너가 병렬로 실행

`UtteranceSavedEvent`를 두 컴포넌트가 독립적으로 수신합니다.

`RollingSummaryEventListener` (`rollingSummaryExecutor`)

- `compressIfNeeded()` 호출
- 미압축 토큰이 2200 미만이면 아무것도 안 함
- 2200 이상이면 AI 요약 생성 후 `ContextCache`에 저장 → `RollingSummaryUpdatedEvent` 발행

`RollingSummaryProgressWebSocketPublisher` (`contextProgressExecutor`)

- `getProgress()` 호출 → DB에서 미압축 토큰 합산
- progress 계산 후 프론트에 push

`{ "progressPercent": 50, "remainingPercent": 50, "compressionTriggered": false }`

---

### 3단계 — 압축 완료 후 게이지 리셋

압축이 완료되면 `RollingSummaryUpdatedEvent`가 발행되고 두 publisher가 수신합니다.

`ContextSummaryWebSocketPublisher`

- /topic/meetings/{id}/context로 summary 텍스트 push (기존 동작 유지)

`RollingSummaryProgressWebSocketPublisher`

- getProgress() 다시 호출 → 압축 후 토큰 수 재계산
- /topic/meetings/{id}/context-progress로 리셋된 progress push

`{ "progressPercent": 0, "remainingPercent": 100, "compressionTriggered": false }`

프론트 게이지가 100% 근처에서 멈추지 않고 0으로 돌아옵니다.

---

### 토픽 정리