### PR TITLE
feat: ProjectResponse에 serverName 필드 추가

### DIFF
--- a/src/main/java/com/flodiback/domain/project/project/dto/ProjectResponse.java
+++ b/src/main/java/com/flodiback/domain/project/project/dto/ProjectResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 public record ProjectResponse(
         Long id,
         Long serverId,
+        String serverName,
         String name,
         String description,
         String techStack,

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -186,6 +186,7 @@ public class ProjectService {
         return new ProjectResponse(
                 project.getId(),
                 project.getServer() != null ? project.getServer().getId() : null,
+                project.getServer() != null ? project.getServer().getGuildName() : null,
                 project.getName(),
                 project.getDescription(),
                 project.getTechStack(),


### PR DESCRIPTION
closes #109

## 변경 내용
- `ProjectResponse`에 `serverName` 필드 추가
- `ProjectService.toResponse()`에서 `project.getServer().getGuildName()` 매핑

## 응답 예시
```json
{
  "id": 1,
  "serverId": 1,
  "serverName": "우리 팀 서버",
  "name": "Flodi",
  "channelId": "123456789",
  ...
}
```

## 참고
- `channelName`은 DB에 채널 이름이 없어 Discord API 호출 필요 → 별도 이슈로 분리