### PR TITLE
feat: ProjectResponse에 channelName 필드 추가

### DIFF
--- a/src/main/java/com/flodiback/api/project/ProjectController.java
+++ b/src/main/java/com/flodiback/api/project/ProjectController.java
@@ -62,8 +62,9 @@ public class ProjectController {
     public RsData<Void> connectChannel(
             @PathVariable Long id,
             @PathVariable String channelId,
+            @RequestParam(required = false) String channelName,
             @RequestHeader(name = "X-Requester-Id", required = false) String requesterId) {
-        projectService.connectChannel(id, channelId, requesterId);
+        projectService.connectChannel(id, channelId, channelName, requesterId);
         return RsData.of("200-1", "채널이 연결되었습니다.");
     }
 

--- a/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
+++ b/src/main/java/com/flodiback/bot/command/DiscordCommandListener.java
@@ -879,9 +879,12 @@ public class DiscordCommandListener extends ListenerAdapter {
                 return;
             }
 
-            // 채널에 프로젝트 연결
+            // 채널에 프로젝트 연결 (channelName을 쿼리 파라미터로 전달)
+            String channelName = java.net.URLEncoder.encode(
+                    event.getChannel().getName(), java.nio.charset.StandardCharsets.UTF_8);
             HttpRequest.Builder connectReq = HttpRequest.newBuilder()
-                    .uri(URI.create(internalBaseUrl + "/internal/v1/projects/" + projectId + "/channel/" + channelId))
+                    .uri(URI.create(internalBaseUrl + "/internal/v1/projects/" + projectId
+                            + "/channel/" + channelId + "?channelName=" + channelName))
                     .PUT(HttpRequest.BodyPublishers.noBody());
             attachInternalApiKey(connectReq);
             attachRequesterHeader(connectReq, event.getAuthor().getId());

--- a/src/main/java/com/flodiback/domain/project/project/dto/ProjectResponse.java
+++ b/src/main/java/com/flodiback/domain/project/project/dto/ProjectResponse.java
@@ -11,4 +11,5 @@ public record ProjectResponse(
         String techStack,
         LocalDateTime createdAt,
         String channelId,
+        String channelName,
         Long activeMeetingId) {}

--- a/src/main/java/com/flodiback/domain/project/project/entity/Project.java
+++ b/src/main/java/com/flodiback/domain/project/project/entity/Project.java
@@ -36,6 +36,9 @@ public class Project {
     @Column(name = "channel_id", length = 50)
     private String channelId;
 
+    @Column(name = "channel_name", length = 100)
+    private String channelName;
+
     @Column(name = "owner_discord_id", length = 50)
     private String ownerDiscordId;
 
@@ -65,12 +68,14 @@ public class Project {
         if (techStack != null) this.techStack = techStack;
     }
 
-    public void connectChannel(String channelId) {
+    public void connectChannel(String channelId, String channelName) {
         this.channelId = channelId;
+        this.channelName = channelName;
     }
 
     public void disconnectChannel() {
         this.channelId = null;
+        this.channelName = null;
     }
 
     public void softDelete() {

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -131,11 +131,11 @@ public class ProjectService {
         return toResponseWithActiveMeeting(project);
     }
 
-    public void connectChannel(Long id, String channelId, String requesterId) {
+    public void connectChannel(Long id, String channelId, String channelName, String requesterId) {
         Project project =
                 projectRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
         checkWritePermission(project, requesterId);
-        project.connectChannel(channelId);
+        project.connectChannel(channelId, channelName);
     }
 
     public void disconnectChannel(Long id, String requesterId) {
@@ -192,6 +192,7 @@ public class ProjectService {
                 project.getTechStack(),
                 project.getCreatedAt(),
                 project.getChannelId(),
+                project.getChannelName(),
                 activeMeetingId);
     }
 }

--- a/src/main/resources/db/migration/V10__project_channel_name.sql
+++ b/src/main/resources/db/migration/V10__project_channel_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE projects
+    ADD COLUMN channel_name VARCHAR(100);


### PR DESCRIPTION
closes #111

## 변경 내용
- `V10__project_channel_name.sql` — `projects` 테이블에 `channel_name VARCHAR(100)` 컬럼 추가
- `Project` — `channelName` 필드 추가, `connectChannel(channelId, channelName)` 시그니처 변경, `disconnectChannel()` 시 channelName도 null 처리
- `ProjectController` — `PUT /{id}/channel/{channelId}`에 `?channelName=` 쿼리 파라미터 추가 (optional)
- `ProjectService` — `connectChannel()` channelName 저장
- `ProjectResponse` — `channelName` 필드 추가
- `DiscordCommandListener` — 채널 연결 시 `event.getChannel().getName()`을 channelName으로 전달

## 응답 예시
```json
{
  "id": 1,
  "serverId": 1,
  "serverName": "우리 팀 서버",
  "name": "Flodi",
  "channelId": "123456789",
  "channelName": "백엔드-개발",
  "activeMeetingId": null
}
```

## 참고
- `channelName`은 채널 연결 시점에 저장되므로 기존 연결된 채널은 null
- 기존 채널 재연결 시 자동으로 channelName이 채워짐
- PR #110(serverName) 위에 스택됨