### PR TITLE
feat: 프로젝트 생성 시 WebSocket 이벤트 발행

### DIFF
--- a/src/main/java/com/flodiback/domain/project/project/event/ProjectCreatedEvent.java
+++ b/src/main/java/com/flodiback/domain/project/project/event/ProjectCreatedEvent.java
@@ -1,0 +1,3 @@
+package com.flodiback.domain.project.project.event;
+
+public record ProjectCreatedEvent(Long projectId, String guildId) {}

--- a/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
+++ b/src/main/java/com/flodiback/domain/project/project/service/ProjectService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +15,7 @@ import com.flodiback.domain.project.project.dto.CreateProjectRequest;
 import com.flodiback.domain.project.project.dto.ProjectResponse;
 import com.flodiback.domain.project.project.dto.UpdateProjectRequest;
 import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.event.ProjectCreatedEvent;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
 import com.flodiback.domain.server.server.entity.DiscordServer;
 import com.flodiback.domain.server.server.repository.DiscordServerRepository;
@@ -30,6 +32,7 @@ public class ProjectService {
     private final ProjectRepository projectRepository;
     private final DiscordServerRepository discordServerRepository;
     private final MeetingRepository meetingRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public ProjectResponse create(CreateProjectRequest req) {
         if (req.channelId() != null) {
@@ -61,6 +64,8 @@ public class ProjectService {
                 .techStack(req.techStack())
                 .build();
         projectRepository.save(project);
+        eventPublisher.publishEvent(
+                new ProjectCreatedEvent(project.getId(), server != null ? server.getGuildId() : null));
 
         return toResponse(project, null);
     }

--- a/src/main/java/com/flodiback/global/websocket/ProjectWebSocketPublisher.java
+++ b/src/main/java/com/flodiback/global/websocket/ProjectWebSocketPublisher.java
@@ -1,0 +1,26 @@
+package com.flodiback.global.websocket;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.flodiback.domain.project.project.event.ProjectCreatedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectWebSocketPublisher {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onProjectCreated(ProjectCreatedEvent event) {
+        messagingTemplate.convertAndSend(
+                "/topic/projects/status",
+                new ProjectCreatedMessage("project.created", event.projectId(), event.guildId()));
+    }
+
+    record ProjectCreatedMessage(String type, Long projectId, String guildId) {}
+}

--- a/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/flodiback/domain/project/project/service/ProjectServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
@@ -44,6 +45,9 @@ class ProjectServiceTest {
 
     @Mock
     private MeetingRepository meetingRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     // ─── create ───────────────────────────────────────────
 


### PR DESCRIPTION
closes #114

## 변경 내용
- `ProjectCreatedEvent` 레코드 추가 (`projectId`, `guildId`)
- `ProjectService.create()` — 저장 후 `ProjectCreatedEvent` 발행
- `ProjectWebSocketPublisher` — `AFTER_COMMIT` 이후 `/topic/projects/status`로 브로드캐스트

## WebSocket 메시지 형식
```json
{
  "type": "project.created",
  "projectId": 42,
  "guildId": "123456789"
}
```

## 프론트 연동
프론트가 `/topic/projects/status` 구독 → `type === "project.created"` 수신 시 `["projects"]` 쿼리 무효화