### PR TITLE
fix: 여러 Discord 서버 소속 시 회의 목록 403 오류 수정

### DIFF
--- a/src/main/java/com/flodiback/api/meeting/MeetingController.java
+++ b/src/main/java/com/flodiback/api/meeting/MeetingController.java
@@ -27,7 +27,8 @@ public class MeetingController {
     @GetMapping
     public RsData<List<MeetingDetailResponse>> getMeetings(
             @RequestParam Long projectId, @RequestHeader(name = "X-Guild-Id", required = false) String guildId) {
-        return RsData.of("200-1", "회의 목록 조회 성공.", service.getByProjectId(projectId, guildId));
+        return RsData.of("200-1", "회의 목록 조회 성공.", service.getByProjectId(
+                projectId, guildId != null ? List.of(guildId) : List.of()));
     }
 
     @PutMapping("/{id}/end")

--- a/src/main/java/com/flodiback/api/meeting/MeetingController.java
+++ b/src/main/java/com/flodiback/api/meeting/MeetingController.java
@@ -27,8 +27,10 @@ public class MeetingController {
     @GetMapping
     public RsData<List<MeetingDetailResponse>> getMeetings(
             @RequestParam Long projectId, @RequestHeader(name = "X-Guild-Id", required = false) String guildId) {
-        return RsData.of("200-1", "회의 목록 조회 성공.", service.getByProjectId(
-                projectId, guildId != null ? List.of(guildId) : List.of()));
+        return RsData.of(
+                "200-1",
+                "회의 목록 조회 성공.",
+                service.getByProjectId(projectId, guildId != null ? List.of(guildId) : List.of()));
     }
 
     @PutMapping("/{id}/end")

--- a/src/main/java/com/flodiback/api/meeting/WebMeetingController.java
+++ b/src/main/java/com/flodiback/api/meeting/WebMeetingController.java
@@ -26,8 +26,7 @@ public class WebMeetingController {
     @GetMapping("/api/v1/projects/{projectId}/meetings")
     public ResponseEntity<RsData<List<MeetingDetailResponse>>> getMeetingsByProject(@PathVariable Long projectId) {
         List<String> guildIds = SecurityContextUtil.getGuildIds();
-        List<MeetingDetailResponse> meetings =
-                meetingService.getByProjectId(projectId, guildIds.isEmpty() ? null : guildIds.getFirst());
+        List<MeetingDetailResponse> meetings = meetingService.getByProjectId(projectId, guildIds);
         return ResponseEntity.ok(RsData.of("200-1", "회의 목록 조회 성공.", meetings));
     }
 

--- a/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meeting/service/MeetingService.java
@@ -93,10 +93,14 @@ public class MeetingService {
     }
 
     @Transactional(readOnly = true)
-    public List<MeetingDetailResponse> getByProjectId(Long projectId, String guildId) {
+    public List<MeetingDetailResponse> getByProjectId(Long projectId, List<String> guildIds) {
         Project project =
                 projectRepository.findById(projectId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
-        checkReadPermission(project, guildId);
+        if (project.getServer() != null
+                && !guildIds.isEmpty()
+                && !guildIds.contains(project.getServer().getGuildId())) {
+            throw new ServiceException("403-1", "권한이 없습니다.");
+        }
         return meetingRepository.findByProjectId(projectId).stream()
                 .map(this::toDetailResponse)
                 .toList();


### PR DESCRIPTION
closes #116

## 문제 상황

사용자가 Discord 서버 3개에 들어가 있다고 가정합니다:

```
내 Discord 서버 목록: [팀02 서버, 테스트 서버, 개인 서버]
```

`GET /api/v1/projects/{id}/meetings` 요청 시 기존 코드:

```java
// ❌ 기존 코드 (버그)
meetingService.getByProjectId(projectId, guildIds.getFirst()); // 첫 번째만 꺼냄

// MeetingService 내부
체크할 서버 = "팀02 서버"   ← 목록[0]만 뽑음
프로젝트 서버 = "테스트 서버"
"팀02 서버" == "테스트 서버" ? → NO → 403 에러 💥
```

## 수정 방향

```java
// ✅ 수정 후
meetingService.getByProjectId(projectId, guildIds); // 전체 리스트 넘김

// MeetingService 내부
내 서버 목록 [팀02 서버, 테스트 서버, 개인 서버] 중에
"테스트 서버" 있나? → YES → 통과 ✅
```

## 변경 내용

| 파일 | 변경 |
|------|------|
| `MeetingService.getByProjectId()` | `String guildId` → `List<String> guildIds`, `equals()` → `contains()` |
| `WebMeetingController` | `guildIds.getFirst()` → `guildIds` 전체 전달 |
| `MeetingController` (내부 API) | `guildId` → `List.of(guildId)` 래핑 |

## 검증

- spotlessCheck ✅
- compileJava / compileTestJava ✅