### PR TITLE
feat: GET /api/v1/projects/{id}/work-logs API 추가

### DIFF
--- a/src/main/java/com/flodiback/api/worklog/WebWorkLogController.java
+++ b/src/main/java/com/flodiback/api/worklog/WebWorkLogController.java
@@ -1,0 +1,31 @@
+package com.flodiback.api.worklog;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flodiback.domain.meeting.meetinglog.dto.WorkLogSummary;
+import com.flodiback.domain.project.worklog.service.WorkLogService;
+import com.flodiback.global.rsData.RsData;
+import com.flodiback.global.util.SecurityContextUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class WebWorkLogController {
+
+    private final WorkLogService workLogService;
+
+    @GetMapping("/api/v1/projects/{id}/work-logs")
+    public ResponseEntity<RsData<List<WorkLogSummary>>> getWorkLogs(
+            @PathVariable Long id, @RequestParam(required = false) String status) {
+        List<String> guildIds = SecurityContextUtil.getGuildIds();
+        List<WorkLogSummary> workLogs = workLogService.getByProjectId(id, guildIds, status);
+        return ResponseEntity.ok(RsData.of("200-1", "작업 로그 조회 성공.", workLogs));
+    }
+}

--- a/src/main/java/com/flodiback/domain/project/worklog/repository/WorkLogRepository.java
+++ b/src/main/java/com/flodiback/domain/project/worklog/repository/WorkLogRepository.java
@@ -9,4 +9,8 @@ import com.flodiback.domain.project.worklog.entity.WorkLog;
 public interface WorkLogRepository extends JpaRepository<WorkLog, Long> {
 
     List<WorkLog> findTop5ByProjectIdAndStatusOrderByIdDesc(Long projectId, String status);
+
+    List<WorkLog> findByProjectIdOrderByCreatedAtDesc(Long projectId);
+
+    List<WorkLog> findByProjectIdAndStatusOrderByCreatedAtDesc(Long projectId, String status);
 }

--- a/src/main/java/com/flodiback/domain/project/worklog/service/WorkLogService.java
+++ b/src/main/java/com/flodiback/domain/project/worklog/service/WorkLogService.java
@@ -27,7 +27,6 @@ public class WorkLogService {
                 projectRepository.findById(projectId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
 
         if (project.getServer() != null
-                && !guildIds.isEmpty()
                 && !guildIds.contains(project.getServer().getGuildId())) {
             throw new ServiceException("403-1", "권한이 없습니다.");
         }

--- a/src/main/java/com/flodiback/domain/project/worklog/service/WorkLogService.java
+++ b/src/main/java/com/flodiback/domain/project/worklog/service/WorkLogService.java
@@ -1,0 +1,47 @@
+package com.flodiback.domain.project.worklog.service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flodiback.domain.meeting.meetinglog.dto.WorkLogSummary;
+import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.project.repository.ProjectRepository;
+import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
+import com.flodiback.global.exception.ServiceException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WorkLogService {
+
+    private final WorkLogRepository workLogRepository;
+    private final ProjectRepository projectRepository;
+
+    public List<WorkLogSummary> getByProjectId(Long projectId, List<String> guildIds, String status) {
+        Project project =
+                projectRepository.findById(projectId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 프로젝트입니다."));
+
+        if (project.getServer() != null
+                && !guildIds.isEmpty()
+                && !guildIds.contains(project.getServer().getGuildId())) {
+            throw new ServiceException("403-1", "권한이 없습니다.");
+        }
+
+        if (status != null && !status.isBlank()) {
+            return workLogRepository
+                    .findByProjectIdAndStatusOrderByCreatedAtDesc(projectId, status.toUpperCase())
+                    .stream()
+                    .map(WorkLogSummary::from)
+                    .toList();
+        }
+
+        return workLogRepository.findByProjectIdOrderByCreatedAtDesc(projectId).stream()
+                .map(WorkLogSummary::from)
+                .toList();
+    }
+}


### PR DESCRIPTION
closes #118

## 변경 내용

| 파일 | 변경 |
|------|------|
| `WorkLogRepository` | `findByProjectIdOrderByCreatedAtDesc`, `findByProjectIdAndStatusOrderByCreatedAtDesc` 추가 |
| `WorkLogService` | 프로젝트 권한 확인 후 작업 로그 목록 반환 |
| `WebWorkLogController` | `GET /api/v1/projects/{id}/work-logs` 엔드포인트 추가 |

## API 스펙

```
GET /api/v1/projects/{id}/work-logs
GET /api/v1/projects/{id}/work-logs?status=IN_PROGRESS
```

`status` 파라미터: `TODO` / `IN_PROGRESS` / `DONE` (미입력 시 전체 반환)

## 응답 예시

```json
[
  {
    "id": 1,
    "assigneeName": "chan",
    "assigneeDiscordId": "123456789",
    "task": "Discord OAuth 구현",
    "dueDate": "2026-05-20",
    "status": "IN_PROGRESS"
  },
  {
    "id": 2,
    "assigneeName": "팀원A",
    "assigneeDiscordId": "987654321",
    "task": "WebSocket 연동",
    "dueDate": null,
    "status": "DONE"
  }
]
```

## 검증
- spotlessCheck ✅
- compileJava / compileTestJava ✅