### PR TITLE
fix: release-please manifest 패키지 설정 수정

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,18 +1,22 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
-  "changelog-sections": [
-    {"type": "feat", "section": "✨ 새 기능"},
-    {"type": "fix", "section": "🐛 버그 수정"},
-    {"type": "refactor", "section": "♻️ 리팩토링"},
-    {"type": "perf", "section": "⚡ 성능 개선"},
-    {"type": "chore", "section": "🔧 기타", "hidden": true}
-  ],
-  "extra-files": [
-    {
-      "type": "generic",
-      "path": "build.gradle.kts",
-      "version-regex": "^version = \"(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "changelog-sections": [
+        {"type": "feat", "section": "✨ 새 기능"},
+        {"type": "fix", "section": "🐛 버그 수정"},
+        {"type": "refactor", "section": "♻️ 리팩토링"},
+        {"type": "perf", "section": "⚡ 성능 개선"},
+        {"type": "chore", "section": "🔧 기타", "hidden": true}
+      ],
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "build.gradle.kts",
+          "version-regex": "^version = \"(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        }
+      ]
     }
-  ]
+  }
 }


### PR DESCRIPTION
## 요약
- release-please config를 manifest 모드에 맞게 packages["."] 구조로 수정했습니다.
- 기존 changelog section과 build.gradle.kts 버전 갱신 extra-files 설정은 유지했습니다.

## 원인
- .release-please-manifest.json은 루트 패키지 "."를 선언하지만 release-please-config.json에는 해당 패키지 설정이 없었습니다.
- 최신 Release Please 로그에서 `Found release tag with component '', but not configured in manifest`, `Splitting 0 commits by path`가 확인됐습니다.

## 검증
- `jq . release-please-config.json`
- `jq -e '.packages["."]."release-type" == "simple" and (.packages["."]."extra-files" | length == 1)' release-please-config.json`
- `jq -e 'has(".") and .["."] == "0.1.0"' .release-please-manifest.json`
- `git diff --check`
- `./gradlew spotlessCheck`

Closes #121