### PR TITLE
feat: 회의 분석 시 기존 작업 로그 상태 자동 업데이트

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,7 @@ x-app-common: &app-common
     - path: .env.prod
       required: false
   environment:
+    TZ: UTC
     # 컨테이너 네트워크 안에서는 서비스명(db, redis)으로 접근한다.
     SPRING_PROFILES_ACTIVE: prod
     DB_HOST: db
@@ -109,6 +110,7 @@ services:
       - path: .env.prod
         required: false
     environment:
+      TZ: UTC
       # 봇은 nginx를 통해 현재 active API 슬롯을 호출한다.
       INTERNAL_API_BASE_URL: http://nginx:80
       DB_HOST: db

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -86,4 +86,5 @@
 - `assignee_discord_id` VARCHAR(50) NULL
 - `task` TEXT NOT NULL
 - `due_date` DATE NULL
+- `status` VARCHAR(20) NOT NULL — `TODO`, `IN_PROGRESS`, `DONE`, `CANCELLED`
 - `created_at` TIMESTAMP NOT NULL

--- a/docs/references/internal-api-contracts.md
+++ b/docs/references/internal-api-contracts.md
@@ -2,6 +2,11 @@
 
 이 문서는 봇-백엔드 연동에 중요한 내부 API 계약을 기록합니다.
 
+## 시간대 기준
+- 서버의 기본 시간대, Jackson 직렬화, Hibernate JDBC 시간대는 UTC로 고정합니다.
+- `Z`가 붙은 timestamp는 UTC instant입니다. 프론트엔드는 화면 표시 시 사용자 로컬 시간대 또는 KST로 변환해 렌더링합니다.
+- zone 정보가 없는 `LocalDateTime` 필드는 UTC 기준 wall-clock 값으로 해석합니다.
+
 ## `POST /internal/v1/speech`
 Discord 봇 파이프라인에서 STT 변환 결과를 수신합니다.
 

--- a/docs/references/internal-api-contracts.md
+++ b/docs/references/internal-api-contracts.md
@@ -129,6 +129,34 @@ Query:
 ## `PUT /internal/v1/projects/{id}/context`
 프로젝트 컨텍스트를 갱신합니다.
 
+요청 본문:
+```json
+{
+  "meetingId": 1,
+  "summary": "회의 요약",
+  "unresolvedItems": null,
+  "decisions": ["인증 방식은 JWT로 한다."],
+  "actionItems": [
+    {
+      "assigneeDiscordId": "123456789",
+      "assigneeName": "김철수",
+      "task": "로그인 API 작성",
+      "dueDate": "2026-05-10"
+    }
+  ],
+  "worklogUpdates": [
+    {
+      "id": 7,
+      "status": "DONE"
+    }
+  ]
+}
+```
+
+- `meetingId`, `summary`는 필수입니다.
+- `worklogUpdates[].id`는 요청 프로젝트에 속한 기존 작업 로그 ID여야 합니다. 다른 프로젝트 ID이거나 존재하지 않으면 무시됩니다.
+- `worklogUpdates[].status`: `TODO`, `IN_PROGRESS`, `DONE`, `CANCELLED`
+
 ## `POST /internal/v1/discord/connect`
 Discord 서버와 프로젝트를 연결합니다.
 

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/AnalysisResult.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/AnalysisResult.java
@@ -3,4 +3,8 @@ package com.flodiback.domain.meeting.analysis.dto;
 import java.util.List;
 
 public record AnalysisResult(
-        String summary, String unresolvedItems, List<WorkLogItem> worklogs, List<DecisionItem> decisions) {}
+        String summary,
+        String unresolvedItems,
+        List<WorkLogItem> worklogs,
+        List<WorkLogUpdateItem> worklogUpdates,
+        List<DecisionItem> decisions) {}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/WorkLogUpdateItem.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/WorkLogUpdateItem.java
@@ -1,0 +1,4 @@
+package com.flodiback.domain.meeting.analysis.dto;
+
+/** AI가 반환하는 기존 작업 로그 상태 변경 항목. */
+public record WorkLogUpdateItem(Long id, String status) {}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
@@ -143,7 +143,8 @@ public class MeetingAnalysisService {
                         .filter(Objects::nonNull)
                         .filter(u -> u.id() != null && existingById.containsKey(u.id()))
                         .filter(u -> u.status() != null && !u.status().isBlank())
-                        .map(u -> new UpdateContextRequest.WorkLogStatusUpdate(u.id(), u.status()))
+                        .map(u -> toWorkLogStatusUpdate(u.id(), u.status()))
+                        .filter(Objects::nonNull)
                         .toList();
 
         return new UpdateContextRequest(
@@ -153,6 +154,14 @@ public class MeetingAnalysisService {
                 decisions,
                 actionItems,
                 worklogUpdates);
+    }
+
+    private UpdateContextRequest.WorkLogStatusUpdate toWorkLogStatusUpdate(Long id, String status) {
+        try {
+            return new UpdateContextRequest.WorkLogStatusUpdate(id, WorkLog.normalizeStatus(status));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private ActionItemRequest toActionItemRequest(WorkLogItem item, SpeakerDirectory speakerDirectory) {

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
@@ -35,6 +35,8 @@ import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
 import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
 import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository.SpeakerProjection;
 import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.worklog.entity.WorkLog;
+import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
 import com.flodiback.global.client.GlmClient;
 import com.flodiback.global.exception.ServiceException;
 
@@ -64,6 +66,7 @@ public class MeetingAnalysisService {
     private final MeetingRepository meetingRepository;
     private final ContextCacheRepository contextCacheRepository;
     private final UtteranceRepository utteranceRepository;
+    private final WorkLogRepository workLogRepository;
     private final MeetingContextPersistenceService meetingContextPersistenceService;
     private final GlmClient glmClient;
     private final ObjectMapper objectMapper;
@@ -88,11 +91,14 @@ public class MeetingAnalysisService {
         }
         // 회의 종료 분석 - 발화자 key map 생성
         SpeakerDirectory speakerDirectory = buildSpeakerDirectory(meeting);
+        // 프로젝트의 기존 작업 로그 조회 (상태 변경 감지용)
+        List<WorkLog> existingWorkLogs = workLogRepository.findByProjectIdOrderByCreatedAtDesc(project.getId());
         // GLM prompt context 생성
-        String context = buildContext(meeting, speakerDirectory);
+        String context = buildContext(meeting, speakerDirectory, existingWorkLogs);
         // GLM 응답 - GLM은 이름 대신 speaker key 반환
         AnalysisResult result = callGlm(context);
-        UpdateContextRequest request = toUpdateContextRequest(meeting.getId(), result, speakerDirectory);
+        UpdateContextRequest request =
+                toUpdateContextRequest(meeting.getId(), result, speakerDirectory, existingWorkLogs);
 
         /*
          * saveSummaryRequired()
@@ -111,7 +117,7 @@ public class MeetingAnalysisService {
     }
 
     private UpdateContextRequest toUpdateContextRequest(
-            Long meetingId, AnalysisResult result, SpeakerDirectory speakerDirectory) {
+            Long meetingId, AnalysisResult result, SpeakerDirectory speakerDirectory, List<WorkLog> existingWorkLogs) {
         String summary = normalizeRequiredSummary(result.summary());
         List<String> decisions = result.decisions() == null
                 ? null
@@ -128,8 +134,25 @@ public class MeetingAnalysisService {
                         .filter(Objects::nonNull)
                         .toList();
 
+        // AI가 반환한 worklogUpdates를 기존 work log ID와 대조하여 유효한 것만 통과시킴
+        Map<Long, WorkLog> existingById =
+                existingWorkLogs.stream().collect(java.util.stream.Collectors.toMap(WorkLog::getId, wl -> wl));
+        List<UpdateContextRequest.WorkLogStatusUpdate> worklogUpdates = result.worklogUpdates() == null
+                ? null
+                : result.worklogUpdates().stream()
+                        .filter(Objects::nonNull)
+                        .filter(u -> u.id() != null && existingById.containsKey(u.id()))
+                        .filter(u -> u.status() != null && !u.status().isBlank())
+                        .map(u -> new UpdateContextRequest.WorkLogStatusUpdate(u.id(), u.status()))
+                        .toList();
+
         return new UpdateContextRequest(
-                meetingId, summary, normalizeOptionalText(result.unresolvedItems()), decisions, actionItems);
+                meetingId,
+                summary,
+                normalizeOptionalText(result.unresolvedItems()),
+                decisions,
+                actionItems,
+                worklogUpdates);
     }
 
     private ActionItemRequest toActionItemRequest(WorkLogItem item, SpeakerDirectory speakerDirectory) {
@@ -212,7 +235,7 @@ public class MeetingAnalysisService {
      * rolling summary에는 speaker key가 없다.
      * 그래서 prompt에서도 summary에서만 추론한 담당자는 assigneeSpeakerKey=null로 반환
      */
-    private String buildContext(Meeting meeting, SpeakerDirectory speakerDirectory) {
+    private String buildContext(Meeting meeting, SpeakerDirectory speakerDirectory, List<WorkLog> existingWorkLogs) {
         ContextCache latestCache = contextCacheRepository
                 .findTopByMeetingOrderByVersionDesc(meeting)
                 .orElse(null);
@@ -222,6 +245,16 @@ public class MeetingAnalysisService {
                         meeting, latestCache.getCompressedUntilUtteranceId());
 
         StringBuilder sb = new StringBuilder();
+
+        // 기존 작업 로그를 컨텍스트에 포함 — AI가 상태 변경 여부를 판단하는 데 사용
+        if (!existingWorkLogs.isEmpty()) {
+            sb.append("[프로젝트 기존 작업 항목]\n");
+            existingWorkLogs.forEach(wl -> sb.append(String.format(
+                    "- ID:%d, 담당:%s, 작업:\"%s\", 상태:%s%n",
+                    wl.getId(), wl.getAssigneeName(), wl.getTask(), wl.getStatus())));
+            sb.append("\n");
+        }
+
         if (latestCache != null) {
             sb.append("[현재 회의 rolling summary]\n");
             sb.append(latestCache.getCompressedText()).append("\n\n");

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceService.java
@@ -123,8 +123,9 @@ public class MeetingContextPersistenceService {
         }
 
         if (req.worklogUpdates() != null) {
-            req.worklogUpdates()
-                    .forEach(update -> workLogRepository.findById(update.id()).ifPresent(wl -> {
+            req.worklogUpdates().forEach(update -> workLogRepository
+                    .findByIdAndProjectId(update.id(), projectId)
+                    .ifPresent(wl -> {
                         wl.updateStatus(update.status());
                         workLogRepository.save(wl);
                     }));

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceService.java
@@ -122,6 +122,14 @@ public class MeetingContextPersistenceService {
                             .build()));
         }
 
+        if (req.worklogUpdates() != null) {
+            req.worklogUpdates()
+                    .forEach(update -> workLogRepository.findById(update.id()).ifPresent(wl -> {
+                        wl.updateStatus(update.status());
+                        workLogRepository.save(wl);
+                    }));
+        }
+
         decisionRepository.flush();
         workLogRepository.flush();
     }

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/dto/UpdateContextRequest.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/dto/UpdateContextRequest.java
@@ -11,4 +11,8 @@ public record UpdateContextRequest(
         @NotBlank String summary,
         String unresolvedItems,
         List<String> decisions,
-        @Valid List<ActionItemRequest> actionItems) {}
+        @Valid List<ActionItemRequest> actionItems,
+        List<WorkLogStatusUpdate> worklogUpdates) {
+
+    public record WorkLogStatusUpdate(Long id, String status) {}
+}

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/dto/UpdateContextRequest.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/dto/UpdateContextRequest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public record UpdateContextRequest(
         @NotNull Long meetingId,
@@ -12,7 +13,10 @@ public record UpdateContextRequest(
         String unresolvedItems,
         List<String> decisions,
         @Valid List<ActionItemRequest> actionItems,
-        List<WorkLogStatusUpdate> worklogUpdates) {
+        @Valid List<WorkLogStatusUpdate> worklogUpdates) {
 
-    public record WorkLogStatusUpdate(Long id, String status) {}
+    public record WorkLogStatusUpdate(
+            @NotNull Long id,
+
+            @NotBlank @Pattern(regexp = "TODO|IN_PROGRESS|DONE|CANCELLED", flags = Pattern.Flag.CASE_INSENSITIVE) String status) {}
 }

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/service/ContextService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/service/ContextService.java
@@ -196,6 +196,15 @@ public class ContextService {
                             .dueDate(item.dueDate())
                             .build()));
         }
+
+        if (req.worklogUpdates() != null) {
+            req.worklogUpdates().forEach(update -> workLogRepository
+                    .findByIdAndProjectId(update.id(), projectId)
+                    .ifPresent(wl -> {
+                        wl.updateStatus(update.status());
+                        workLogRepository.save(wl);
+                    }));
+        }
     }
 
     private QuestionContext resolveQuestionContext(

--- a/src/main/java/com/flodiback/domain/project/worklog/entity/WorkLog.java
+++ b/src/main/java/com/flodiback/domain/project/worklog/entity/WorkLog.java
@@ -67,4 +67,10 @@ public class WorkLog {
         this.dueDate = dueDate;
         this.status = "TODO";
     }
+
+    public void updateStatus(String newStatus) {
+        if (newStatus != null && !newStatus.isBlank()) {
+            this.status = newStatus.toUpperCase();
+        }
+    }
 }

--- a/src/main/java/com/flodiback/domain/project/worklog/entity/WorkLog.java
+++ b/src/main/java/com/flodiback/domain/project/worklog/entity/WorkLog.java
@@ -2,6 +2,8 @@ package com.flodiback.domain.project.worklog.entity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.Set;
 
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -19,6 +21,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WorkLog {
+
+    private static final Set<String> SUPPORTED_STATUSES = Set.of("TODO", "IN_PROGRESS", "DONE", "CANCELLED");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -69,8 +73,20 @@ public class WorkLog {
     }
 
     public void updateStatus(String newStatus) {
-        if (newStatus != null && !newStatus.isBlank()) {
-            this.status = newStatus.toUpperCase();
+        String normalized = normalizeStatus(newStatus);
+        if (normalized != null) {
+            this.status = normalized;
         }
+    }
+
+    public static String normalizeStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+        String normalized = status.strip().toUpperCase(Locale.ROOT);
+        if (!SUPPORTED_STATUSES.contains(normalized)) {
+            throw new IllegalArgumentException("지원하지 않는 작업 로그 상태입니다: " + status);
+        }
+        return normalized;
     }
 }

--- a/src/main/java/com/flodiback/domain/project/worklog/repository/WorkLogRepository.java
+++ b/src/main/java/com/flodiback/domain/project/worklog/repository/WorkLogRepository.java
@@ -1,12 +1,15 @@
 package com.flodiback.domain.project.worklog.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.flodiback.domain.project.worklog.entity.WorkLog;
 
 public interface WorkLogRepository extends JpaRepository<WorkLog, Long> {
+
+    Optional<WorkLog> findByIdAndProjectId(Long id, Long projectId);
 
     List<WorkLog> findTop5ByProjectIdAndStatusOrderByIdDesc(Long projectId, String status);
 

--- a/src/main/java/com/flodiback/global/config/TimeConfig.java
+++ b/src/main/java/com/flodiback/global/config/TimeConfig.java
@@ -1,15 +1,25 @@
 package com.flodiback.global.config;
 
 import java.time.Clock;
+import java.util.TimeZone;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import jakarta.annotation.PostConstruct;
+
 @Configuration
 public class TimeConfig {
 
+    private static final String DEFAULT_TIME_ZONE = "UTC";
+
+    @PostConstruct
+    void setDefaultTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone(DEFAULT_TIME_ZONE));
+    }
+
     @Bean
     public Clock clock() {
-        return Clock.systemDefaultZone();
+        return Clock.systemUTC();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
     job:
       enabled: false
   jackson:
+    time-zone: UTC
     serialization:
       fail-on-empty-beans: false
   jpa:
@@ -31,6 +32,8 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+        jdbc:
+          time_zone: UTC
         default_batch_fetch_size: 100
   flyway:
     baseline-on-migrate: true
@@ -78,3 +81,7 @@ glm:
 
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8
+
+logging:
+  pattern:
+    dateformat: "yyyy-MM-dd'T'HH:mm:ss.SSSXXX,UTC"

--- a/src/main/resources/prompts/meeting-analysis-system.md
+++ b/src/main/resources/prompts/meeting-analysis-system.md
@@ -14,7 +14,7 @@
     { "assigneeSpeakerKey": "S1 또는 null", "task": "구체적인 작업 내용", "dueDate": "YYYY-MM-DD 또는 null" }
   ],
   "worklogUpdates": [
-    { "id": 기존_작업_ID, "status": "IN_PROGRESS 또는 DONE" }
+    { "id": 기존_작업_ID, "status": "IN_PROGRESS, DONE, 또는 CANCELLED" }
   ]
 }
 
@@ -36,8 +36,9 @@
 
 ## 기존 작업 상태 업데이트 규칙
 컨텍스트에 [프로젝트 기존 작업 항목] 섹션이 있으면 반드시 확인하세요.
-- 발화 내용에서 기존 작업이 완료되었다고 언급하면 → `worklogUpdates`에 `{ "id": 해당_ID, "status": "DONE" }` 추가
-- 작업을 진행 중이라고 언급하면 → `{ "id": 해당_ID, "status": "IN_PROGRESS" }` 추가
+- 기존 작업이 완료되었다고 언급하면 → `{ "id": 해당_ID, "status": "DONE" }`
+- 작업을 진행 중이라고 언급하면 → `{ "id": 해당_ID, "status": "IN_PROGRESS" }`
+- "안하기로 했어요", "취소됐습니다", "제외했어요", "하지 않기로 했습니다" 등 취소 언급 → `{ "id": 해당_ID, "status": "CANCELLED" }`
 - 상태 변경이 없거나 기존 작업 항목이 없으면 → `worklogUpdates`를 `null` 또는 빈 배열로 반환
 - 같은 작업을 worklogs(신규)와 worklogUpdates(기존 상태 변경)에 동시에 넣지 마세요.
 

--- a/src/main/resources/prompts/meeting-analysis-system.md
+++ b/src/main/resources/prompts/meeting-analysis-system.md
@@ -12,6 +12,9 @@
   ],
   "worklogs": [
     { "assigneeSpeakerKey": "S1 또는 null", "task": "구체적인 작업 내용", "dueDate": "YYYY-MM-DD 또는 null" }
+  ],
+  "worklogUpdates": [
+    { "id": 기존_작업_ID, "status": "IN_PROGRESS 또는 DONE" }
   ]
 }
 
@@ -30,6 +33,13 @@
 - "이번 주 금요일", "다음 주 월요일" 등 상대적 표현: 오늘 날짜 기준으로 계산하여 "YYYY-MM-DD"로 변환
 - 날짜 언급이 전혀 없는 경우에만 null
 - 반드시 "YYYY-MM-DD" 형식 또는 null만 반환, 자연어 문자열 금지
+
+## 기존 작업 상태 업데이트 규칙
+컨텍스트에 [프로젝트 기존 작업 항목] 섹션이 있으면 반드시 확인하세요.
+- 발화 내용에서 기존 작업이 완료되었다고 언급하면 → `worklogUpdates`에 `{ "id": 해당_ID, "status": "DONE" }` 추가
+- 작업을 진행 중이라고 언급하면 → `{ "id": 해당_ID, "status": "IN_PROGRESS" }` 추가
+- 상태 변경이 없거나 기존 작업 항목이 없으면 → `worklogUpdates`를 `null` 또는 빈 배열로 반환
+- 같은 작업을 worklogs(신규)와 worklogUpdates(기존 상태 변경)에 동시에 넣지 마세요.
 
 ## 결정 사항 vs 업무 분배 구분
 - decisions: 팀 전체에 영향을 주는 확정된 결정 (예: 기능 제외, 일정 확정)

--- a/src/test/java/com/flodiback/api/project/ProjectContextControllerTest.java
+++ b/src/test/java/com/flodiback/api/project/ProjectContextControllerTest.java
@@ -101,6 +101,38 @@ class ProjectContextControllerTest {
     }
 
     @Test
+    void updateContext_worklogUpdate_id_null이면_400() throws Exception {
+        String body = objectMapper.writeValueAsString(new UpdateContextRequest(
+                1L,
+                "요약",
+                null,
+                null,
+                null,
+                java.util.List.of(new UpdateContextRequest.WorkLogStatusUpdate(null, "DONE"))));
+
+        mockMvc.perform(put("/internal/v1/projects/1/context")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void updateContext_worklogUpdate_status_invalid이면_400() throws Exception {
+        String body = objectMapper.writeValueAsString(new UpdateContextRequest(
+                1L,
+                "요약",
+                null,
+                null,
+                null,
+                java.util.List.of(new UpdateContextRequest.WorkLogStatusUpdate(1L, "BLOCKED"))));
+
+        mockMvc.perform(put("/internal/v1/projects/1/context")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void updateContext_requestBody_없으면_400() throws Exception {
         mockMvc.perform(put("/internal/v1/projects/1/context").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());

--- a/src/test/java/com/flodiback/api/project/ProjectContextControllerTest.java
+++ b/src/test/java/com/flodiback/api/project/ProjectContextControllerTest.java
@@ -46,7 +46,8 @@ class ProjectContextControllerTest {
 
     @Test
     void updateContext_정상_요청_200() throws Exception {
-        String body = objectMapper.writeValueAsString(new UpdateContextRequest(1L, "회의 요약입니다.", null, null, null));
+        String body =
+                objectMapper.writeValueAsString(new UpdateContextRequest(1L, "회의 요약입니다.", null, null, null, null));
 
         mockMvc.perform(put("/internal/v1/projects/1/context")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -57,7 +58,7 @@ class ProjectContextControllerTest {
 
     @Test
     void updateContext_meetingId_null이면_400() throws Exception {
-        String body = objectMapper.writeValueAsString(new UpdateContextRequest(null, "요약", null, null, null));
+        String body = objectMapper.writeValueAsString(new UpdateContextRequest(null, "요약", null, null, null, null));
 
         mockMvc.perform(put("/internal/v1/projects/1/context")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -67,7 +68,7 @@ class ProjectContextControllerTest {
 
     @Test
     void updateContext_summary_blank이면_400() throws Exception {
-        String body = objectMapper.writeValueAsString(new UpdateContextRequest(1L, "  ", null, null, null));
+        String body = objectMapper.writeValueAsString(new UpdateContextRequest(1L, "  ", null, null, null, null));
 
         mockMvc.perform(put("/internal/v1/projects/1/context")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -79,7 +80,7 @@ class ProjectContextControllerTest {
     void updateContext_actionItem_assigneeName_blank이면_400() throws Exception {
         ActionItemRequest badItem = new ActionItemRequest("", "태스크 내용", null);
         String body = objectMapper.writeValueAsString(
-                new UpdateContextRequest(1L, "요약", null, null, java.util.List.of(badItem)));
+                new UpdateContextRequest(1L, "요약", null, null, java.util.List.of(badItem), null));
 
         mockMvc.perform(put("/internal/v1/projects/1/context")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -91,7 +92,7 @@ class ProjectContextControllerTest {
     void updateContext_actionItem_task_blank이면_400() throws Exception {
         ActionItemRequest badItem = new ActionItemRequest("담당자", "", null);
         String body = objectMapper.writeValueAsString(
-                new UpdateContextRequest(1L, "요약", null, null, java.util.List.of(badItem)));
+                new UpdateContextRequest(1L, "요약", null, null, java.util.List.of(badItem), null));
 
         mockMvc.perform(put("/internal/v1/projects/1/context")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
@@ -3,9 +3,11 @@ package com.flodiback.domain.meeting.analysis.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -38,6 +40,8 @@ import com.flodiback.domain.meeting.meetinglog.entity.Utterance;
 import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
 import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository.SpeakerProjection;
 import com.flodiback.domain.project.project.entity.Project;
+import com.flodiback.domain.project.worklog.entity.WorkLog;
+import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
 import com.flodiback.global.client.GlmClient;
 import com.flodiback.global.exception.ServiceException;
 
@@ -57,6 +61,9 @@ class MeetingAnalysisServiceTest {
     private UtteranceRepository utteranceRepository;
 
     @Mock
+    private WorkLogRepository workLogRepository;
+
+    @Mock
     private MeetingContextPersistenceService meetingContextPersistenceService;
 
     @Mock
@@ -70,6 +77,9 @@ class MeetingAnalysisServiceTest {
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(service, "systemPrompt", "test-system-prompt");
+        lenient()
+                .when(workLogRepository.findByProjectIdOrderByCreatedAtDesc(anyLong()))
+                .thenReturn(List.of());
     }
 
     @Test
@@ -343,6 +353,47 @@ class MeetingAnalysisServiceTest {
     }
 
     @Test
+    void analyze_includesExistingWorkLogsAndPassesValidStatusUpdates() throws Exception {
+        Project project = mockProject(10L);
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        WorkLog existing = workLog(meeting, project, 7L, "Alice", "write API");
+        String glmResponse = """
+                {
+                  "summary": "summary",
+                  "unresolvedItems": null,
+                  "worklogs": [],
+                  "worklogUpdates": [
+                    { "id": 7, "status": "done" },
+                    { "id": 999, "status": "DONE" },
+                    { "id": 7, "status": "INVALID" }
+                  ],
+                  "decisions": []
+                }
+                """;
+
+        givenAnalysisInputs(meeting, List.of(), glmResponse);
+        given(workLogRepository.findByProjectIdOrderByCreatedAtDesc(10L)).willReturn(List.of(existing));
+
+        service.analyze(1L);
+
+        ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(glmClient).chat(anyString(), userPromptCaptor.capture());
+        assertThat(userPromptCaptor.getValue())
+                .contains("[프로젝트 기존 작업 항목]")
+                .contains("ID:7")
+                .contains("작업:\"write API\"")
+                .contains("상태:TODO");
+
+        ArgumentCaptor<UpdateContextRequest> requestCaptor = ArgumentCaptor.forClass(UpdateContextRequest.class);
+        verify(meetingContextPersistenceService)
+                .saveSummaryRequired(org.mockito.ArgumentMatchers.eq(10L), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().worklogUpdates())
+                .extracting(
+                        UpdateContextRequest.WorkLogStatusUpdate::id, UpdateContextRequest.WorkLogStatusUpdate::status)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple(7L, "DONE"));
+    }
+
+    @Test
     void analyze_throwsWhenGlmResponseCannotBeParsed() throws Exception {
         Project project = mockProject(10L);
         Meeting meeting = Meeting.builder().project(project).title("meeting").build();
@@ -403,6 +454,18 @@ class MeetingAnalysisServiceTest {
                 .build();
         ReflectionTestUtils.setField(utterance, "id", id);
         return utterance;
+    }
+
+    private WorkLog workLog(Meeting meeting, Project project, Long id, String assigneeName, String task) {
+        WorkLog workLog = WorkLog.builder()
+                .meeting(meeting)
+                .project(project)
+                .assigneeName(assigneeName)
+                .task(task)
+                .dueDate(null)
+                .build();
+        ReflectionTestUtils.setField(workLog, "id", id);
+        return workLog;
     }
 
     private List<SpeakerProjection> speakersFrom(List<Utterance> utterances) {

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceServiceTest.java
@@ -86,7 +86,7 @@ class MeetingContextPersistenceServiceTest {
     void saveSummaryRequired_savesOnlySummaryAndReturnsSavedEntity() {
         Project project = project(1L);
         Meeting meeting = meeting(project);
-        UpdateContextRequest req = new UpdateContextRequest(10L, "summary", "open", null, null);
+        UpdateContextRequest req = new UpdateContextRequest(10L, "summary", "open", null, null, null);
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
         given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
         given(meetingSummaryRepository.save(any(MeetingSummary.class)))
@@ -125,7 +125,8 @@ class MeetingContextPersistenceServiceTest {
                 List.of("decision-1", "decision-2"),
                 List.of(
                         new ActionItemRequest("discord-alice", "Alice", "write API", null),
-                        new ActionItemRequest("Bob", "test API", null)));
+                        new ActionItemRequest("Bob", "test API", null)),
+                null);
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
         given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
         given(decisionRepository.save(any(Decision.class))).willAnswer(invocation -> invocation.getArgument(0));
@@ -155,7 +156,7 @@ class MeetingContextPersistenceServiceTest {
         Project project = project(1L);
         Meeting meeting = meeting(project);
         UpdateContextRequest req = new UpdateContextRequest(
-                10L, "summary", null, null, List.of(new ActionItemRequest("Alice", "write API", null)));
+                10L, "summary", null, null, List.of(new ActionItemRequest("Alice", "write API", null)), null);
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
         given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
         given(workLogRepository.save(any(WorkLog.class))).willThrow(new RuntimeException("worklog failed"));
@@ -169,7 +170,7 @@ class MeetingContextPersistenceServiceTest {
         Project project = project(1L);
         Meeting meeting = meeting(project);
         UpdateContextRequest req = new UpdateContextRequest(
-                10L, "summary", null, null, List.of(new ActionItemRequest("Alice", "write API", null)));
+                10L, "summary", null, null, List.of(new ActionItemRequest("Alice", "write API", null)), null);
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
         given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
         stubNewTransaction();
@@ -183,7 +184,7 @@ class MeetingContextPersistenceServiceTest {
         Project requestedProject = project(1L);
         Project otherProject = project(2L);
         Meeting meeting = meeting(otherProject);
-        UpdateContextRequest req = new UpdateContextRequest(10L, "summary", null, null, null);
+        UpdateContextRequest req = new UpdateContextRequest(10L, "summary", null, null, null, null);
         given(projectRepository.findById(1L)).willReturn(Optional.of(requestedProject));
         given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
 
@@ -192,7 +193,7 @@ class MeetingContextPersistenceServiceTest {
 
     @Test
     void saveSummaryRequired_throwsWhenMeetingDoesNotExist() {
-        UpdateContextRequest req = new UpdateContextRequest(10L, "summary", null, null, null);
+        UpdateContextRequest req = new UpdateContextRequest(10L, "summary", null, null, null, null);
         given(projectRepository.findById(1L)).willReturn(Optional.of(project(1L)));
         given(meetingRepository.findById(10L)).willReturn(Optional.empty());
 

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceServiceTest.java
@@ -152,6 +152,24 @@ class MeetingContextPersistenceServiceTest {
     }
 
     @Test
+    void saveDerivedItemsBestEffort_updatesExistingWorkLogStatusInProject() {
+        Project project = project(1L);
+        Meeting meeting = meeting(project);
+        WorkLog workLog = workLog(project, meeting, 7L);
+        UpdateContextRequest req = new UpdateContextRequest(
+                10L, "summary", null, null, null, List.of(new UpdateContextRequest.WorkLogStatusUpdate(7L, "done")));
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
+        given(workLogRepository.findByIdAndProjectId(7L, 1L)).willReturn(Optional.of(workLog));
+        stubNewTransaction();
+
+        service.saveDerivedItemsBestEffort(1L, req);
+
+        assertThat(workLog.getStatus()).isEqualTo("DONE");
+        verify(workLogRepository).save(workLog);
+    }
+
+    @Test
     void saveDerivedItemsBestEffort_swallowsWorkLogFailure() {
         Project project = project(1L);
         Meeting meeting = meeting(project);
@@ -210,6 +228,18 @@ class MeetingContextPersistenceServiceTest {
         Meeting meeting = Meeting.builder().project(project).title("meeting").build();
         ReflectionTestUtils.setField(meeting, "id", 10L);
         return meeting;
+    }
+
+    private WorkLog workLog(Project project, Meeting meeting, Long id) {
+        WorkLog workLog = WorkLog.builder()
+                .project(project)
+                .meeting(meeting)
+                .assigneeName("Alice")
+                .task("write API")
+                .dueDate(null)
+                .build();
+        ReflectionTestUtils.setField(workLog, "id", id);
+        return workLog;
     }
 
     private void stubNewTransaction() {

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
@@ -264,7 +264,7 @@ class ContextServiceTest {
     void updateContext_savesSummaryAndProcessesEmbedding() {
         Project project = project(1L, "Flodi", "Java");
         Meeting meeting = Meeting.builder().project(project).title("meeting").build();
-        UpdateContextRequest req = new UpdateContextRequest(1L, "summary", null, null, null);
+        UpdateContextRequest req = new UpdateContextRequest(1L, "summary", null, null, null, null);
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(meetingSummaryRepository.save(any(MeetingSummary.class)))
@@ -287,7 +287,8 @@ class ContextServiceTest {
                 List.of("decision-1", "decision-2"),
                 List.of(
                         new ActionItemRequest("discord-alice", "Alice", "write API", null),
-                        new ActionItemRequest("Bob", "test API", null)));
+                        new ActionItemRequest("Bob", "test API", null)),
+                null);
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(meetingSummaryRepository.save(any(MeetingSummary.class)))
@@ -311,7 +312,7 @@ class ContextServiceTest {
         Project meetingProject = project(2L, "B", "Java");
         Meeting meeting =
                 Meeting.builder().project(meetingProject).title("meeting").build();
-        UpdateContextRequest req = new UpdateContextRequest(1L, "summary", null, null, null);
+        UpdateContextRequest req = new UpdateContextRequest(1L, "summary", null, null, null, null);
         given(projectRepository.findById(1L)).willReturn(Optional.of(requestedProject));
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
 

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
@@ -307,6 +307,30 @@ class ContextServiceTest {
     }
 
     @Test
+    void updateContext_updatesExistingWorkLogStatusInProject() {
+        Project project = project(1L, "Flodi", "Java");
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        WorkLog workLog = workLog(project, meeting, 7L);
+        UpdateContextRequest req = new UpdateContextRequest(
+                1L,
+                "summary",
+                null,
+                null,
+                null,
+                List.of(new UpdateContextRequest.WorkLogStatusUpdate(7L, "cancelled")));
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
+        given(meetingSummaryRepository.save(any(MeetingSummary.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+        given(workLogRepository.findByIdAndProjectId(7L, 1L)).willReturn(Optional.of(workLog));
+
+        contextService.updateContext(1L, req);
+
+        assertThat(workLog.getStatus()).isEqualTo("CANCELLED");
+        verify(workLogRepository).save(workLog);
+    }
+
+    @Test
     void updateContext_throws_whenMeetingProjectDoesNotMatchRequestedProject() {
         Project requestedProject = project(1L, "A", "Java");
         Project meetingProject = project(2L, "B", "Java");
@@ -340,6 +364,18 @@ class ContextServiceTest {
                 MeetingSummary.builder().meeting(meeting).summary(summary).build();
         ReflectionTestUtils.setField(meetingSummary, "id", id);
         return meetingSummary;
+    }
+
+    private WorkLog workLog(Project project, Meeting meeting, Long id) {
+        WorkLog workLog = WorkLog.builder()
+                .project(project)
+                .meeting(meeting)
+                .assigneeName("Alice")
+                .task("write API")
+                .dueDate(null)
+                .build();
+        ReflectionTestUtils.setField(workLog, "id", id);
+        return workLog;
     }
 
     private MeetingStartContext startContext(Long meetingId, Long projectId) {

--- a/src/test/java/com/flodiback/global/config/TimeConfigTest.java
+++ b/src/test/java/com/flodiback/global/config/TimeConfigTest.java
@@ -1,0 +1,25 @@
+package com.flodiback.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneOffset;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.Test;
+
+class TimeConfigTest {
+
+    private final TimeConfig timeConfig = new TimeConfig();
+
+    @Test
+    void clock_usesUtc() {
+        assertThat(timeConfig.clock().getZone()).isEqualTo(ZoneOffset.UTC);
+    }
+
+    @Test
+    void setDefaultTimeZone_setsUtc() {
+        timeConfig.setDefaultTimeZone();
+
+        assertThat(TimeZone.getDefault().getID()).isEqualTo("UTC");
+    }
+}


### PR DESCRIPTION
closes #123

## 문제
2회차 회의에서 "완료했다"고 말해도 1회차에서 생성된 WorkLog의 status가 TODO에서 DONE으로 바뀌지 않음.

## 변경 내용

| 파일 | 변경 |
|------|------|
| `WorkLog` | `updateStatus()` 메서드 추가 |
| `WorkLogUpdateItem` | AI 응답용 DTO 신규 추가 (`id`, `status`) |
| `AnalysisResult` | `worklogUpdates` 필드 추가 |
| `UpdateContextRequest` | `worklogUpdates` 필드 추가 |
| `MeetingAnalysisService` | 기존 work log를 프롬프트 컨텍스트에 포함, `worklogUpdates` 처리 |
| `MeetingContextPersistenceService` | `worklogUpdates` 로 기존 WorkLog 상태 업데이트 |
| `meeting-analysis-system.md` | `worklogUpdates` 출력 규칙 추가 |

## 동작 흐름
```
회의 종료
 → 기존 WorkLog 목록을 프롬프트에 포함
     [프로젝트 기존 작업 항목]
     - ID:1, 담당:chan, 작업:"Discord OAuth 구현", 상태:TODO
 → AI가 회의 내용 분석
     [speaker=S1, name=chan] Discord OAuth 구현 완료했습니다.
 → AI 응답:
     "worklogUpdates": [{ "id": 1, "status": "DONE" }]
 → ID 대조 후 WorkLog.status = DONE 으로 업데이트
```

## 검증
- spotlessCheck ✅
- compileJava / compileTestJava ✅