### PR TITLE
fix: release-please PAT 토큰 사용

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,11 +17,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: RELEASE_PLEASE_TOKEN 확인
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_PLEASE_TOKEN" ]; then
+            echo "::error::RELEASE_PLEASE_TOKEN secret이 필요합니다. repo/org Actions 설정상 GITHUB_TOKEN으로 release PR을 만들 수 없습니다."
+            exit 1
+          fi
+
       - name: PR 제목 정규화 (release-please 전처리)
         # [fix]: / [feat] 등 대괄호 형식 → fix: / feat: 형식으로 변환
         # merge/squash/rebase 병합 방식 모두 커버하기 위해 GitHub API 사용
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
@@ -60,7 +69,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: dev


### PR DESCRIPTION
## 요약
- release-please가 GITHUB_TOKEN 대신 RELEASE_PLEASE_TOKEN secret을 사용하도록 변경했습니다.
- PR 제목 정규화 step도 동일 토큰을 사용하도록 맞췄습니다.
- secret이 없으면 원인을 바로 알 수 있도록 명시적인 오류 메시지를 추가했습니다.

## 배경
조직/저장소 Actions 설정상 GITHUB_TOKEN으로 release PR을 만들 수 없어 Release Please workflow가 실패했습니다.

## 확인
- git diff --check
- Ruby YAML 파싱 확인

Closes #126