### PR TITLE
fix: release-please 전처리 토큰 분리

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,8 +29,9 @@ jobs:
       - name: PR 제목 정규화 (release-please 전처리)
         # [fix]: / [feat] 등 대괄호 형식 → fix: / feat: 형식으로 변환
         # merge/squash/rebase 병합 방식 모두 커버하기 위해 GitHub API 사용
+        # release PR 생성만 PAT가 필요하고, 기존 PR 제목 정규화는 GITHUB_TOKEN으로 처리한다.
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 


### PR DESCRIPTION
## 요약
- release PR 생성은 계속 RELEASE_PLEASE_TOKEN secret을 사용합니다.
- PR 제목 정규화 전처리는 GITHUB_TOKEN으로 되돌렸습니다.

## 배경
PR #127 머지 후 classic PAT가 repo scope만 가진 상태에서 gh pr edit GraphQL 호출이 read:org scope를 요구해 Release Please가 전처리 step에서 실패했습니다.

## 확인
- git diff --check
- Ruby YAML 파싱 확인

Closes #128