### PR TITLE
리다이렉트 설정

### DIFF
--- a/src/main/java/com/flodiback/api/auth/AuthController.java
+++ b/src/main/java/com/flodiback/api/auth/AuthController.java
@@ -29,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
     static final String JWT_COOKIE = "jwt";
+    private static final String DEFAULT_LOGIN_REDIRECT = "/projects";
 
     private final DiscordOAuthService discordOAuthService;
     private final JwtProvider jwtProvider;
@@ -38,15 +39,17 @@ public class AuthController {
 
     /** Discord OAuth 인증 페이지로 리다이렉트 */
     @GetMapping("/discord")
-    public ResponseEntity<Void> redirectToDiscord() {
+    public ResponseEntity<Void> redirectToDiscord(@RequestParam(required = false) String redirect) {
+        String safeRedirect = safeRedirectPathOrDefault(redirect);
         return ResponseEntity.status(302)
-                .location(URI.create(discordOAuthService.buildAuthorizationUrl()))
+                .location(URI.create(discordOAuthService.buildAuthorizationUrl(safeRedirect)))
                 .build();
     }
 
     /** Discord 콜백: code → JWT 발급 → httpOnly 쿠키 설정 → 프론트로 리다이렉트 */
     @GetMapping("/discord/callback")
-    public ResponseEntity<Void> handleCallback(@RequestParam String code) {
+    public ResponseEntity<Void> handleCallback(
+            @RequestParam String code, @RequestParam(required = false) String state) {
         String accessToken = discordOAuthService.exchangeToken(code);
         DiscordUser user = discordOAuthService.fetchUser(accessToken);
         List<String> userGuildIds = discordOAuthService.fetchGuildIds(accessToken);
@@ -64,7 +67,7 @@ public class AuthController {
 
         return ResponseEntity.status(302)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .location(URI.create(frontendOrigin + "/projects"))
+                .location(URI.create(frontendOrigin + safeRedirectPathOrDefault(state)))
                 .build();
     }
 
@@ -100,6 +103,26 @@ public class AuthController {
                 .path("/")
                 .maxAge(maxAge)
                 .build();
+    }
+
+    static String safeRedirectPathOrDefault(String redirect) {
+        if (redirect == null || redirect.isBlank()) {
+            return DEFAULT_LOGIN_REDIRECT;
+        }
+        if (redirect.length() > 2048
+                || !redirect.startsWith("/")
+                || redirect.startsWith("//")
+                || redirect.regionMatches(true, 0, "http://", 0, "http://".length())
+                || redirect.regionMatches(true, 0, "https://", 0, "https://".length())) {
+            return DEFAULT_LOGIN_REDIRECT;
+        }
+        for (int i = 0; i < redirect.length(); i++) {
+            char ch = redirect.charAt(i);
+            if (ch < 0x20 || ch == 0x7f) {
+                return DEFAULT_LOGIN_REDIRECT;
+            }
+        }
+        return redirect;
     }
 
     public record MeResponse(String userId, List<String> guildIds) {}

--- a/src/main/java/com/flodiback/domain/auth/DiscordOAuthService.java
+++ b/src/main/java/com/flodiback/domain/auth/DiscordOAuthService.java
@@ -47,11 +47,18 @@ public class DiscordOAuthService {
 
     /** Discord OAuth 인증 페이지 URL을 생성한다. */
     public String buildAuthorizationUrl() {
+        return buildAuthorizationUrl(null);
+    }
+
+    public String buildAuthorizationUrl(String state) {
+        String stateParam =
+                state == null || state.isBlank() ? "" : "&state=" + URLEncoder.encode(state, StandardCharsets.UTF_8);
         return "https://discord.com/oauth2/authorize"
                 + "?client_id=" + clientId
                 + "&response_type=code"
                 + "&redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8)
-                + "&scope=identify%20guilds";
+                + "&scope=identify%20guilds"
+                + stateParam;
     }
 
     /** Authorization code를 access token으로 교환한다. */

--- a/src/test/java/com/flodiback/api/auth/AuthControllerTest.java
+++ b/src/test/java/com/flodiback/api/auth/AuthControllerTest.java
@@ -1,0 +1,29 @@
+package com.flodiback.api.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuthControllerTest {
+
+    @Test
+    void safeRedirectPathOrDefault_allowsRelativeDashboardPathWithQuery() {
+        assertThat(AuthController.safeRedirectPathOrDefault("/channels/123/dashboard?server_id=1&guild_id=1"))
+                .isEqualTo("/channels/123/dashboard?server_id=1&guild_id=1");
+    }
+
+    @Test
+    void safeRedirectPathOrDefault_fallsBackForBlankOrExternalUrls() {
+        assertThat(AuthController.safeRedirectPathOrDefault(null)).isEqualTo("/projects");
+        assertThat(AuthController.safeRedirectPathOrDefault("")).isEqualTo("/projects");
+        assertThat(AuthController.safeRedirectPathOrDefault("https://evil.example"))
+                .isEqualTo("/projects");
+        assertThat(AuthController.safeRedirectPathOrDefault("//evil.example")).isEqualTo("/projects");
+    }
+
+    @Test
+    void safeRedirectPathOrDefault_fallsBackForControlCharacters() {
+        assertThat(AuthController.safeRedirectPathOrDefault("/channels/123\nSet-Cookie:bad"))
+                .isEqualTo("/projects");
+    }
+}

--- a/src/test/java/com/flodiback/domain/auth/DiscordOAuthServiceTest.java
+++ b/src/test/java/com/flodiback/domain/auth/DiscordOAuthServiceTest.java
@@ -1,0 +1,35 @@
+package com.flodiback.domain.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import com.flodiback.domain.server.server.repository.DiscordServerRepository;
+
+class DiscordOAuthServiceTest {
+
+    @Test
+    void buildAuthorizationUrl_includesEncodedStateWhenProvided() {
+        DiscordOAuthService service = new DiscordOAuthService(
+                "client-id",
+                "client-secret",
+                "https://api.example/auth/v1/discord/callback",
+                mock(DiscordServerRepository.class));
+
+        String url = service.buildAuthorizationUrl("/channels/123/dashboard?server_id=1&guild_id=1");
+
+        assertThat(url).contains("state=%2Fchannels%2F123%2Fdashboard%3Fserver_id%3D1%26guild_id%3D1");
+    }
+
+    @Test
+    void buildAuthorizationUrl_omitsStateWhenNotProvided() {
+        DiscordOAuthService service = new DiscordOAuthService(
+                "client-id",
+                "client-secret",
+                "https://api.example/auth/v1/discord/callback",
+                mock(DiscordServerRepository.class));
+
+        assertThat(service.buildAuthorizationUrl()).doesNotContain("state=");
+    }
+}


### PR DESCRIPTION
**수정**
[AuthController.java](C:/Users/c/Desktop/devcourse/INT1-Project-Team02/src/main/java/com/flodiback/api/auth/AuthController.java)

- `/auth/v1/discord`가 이제 optional `redirect` 파라미터를 받습니다.
- 받은 redirect를 검증한 뒤 Discord OAuth URL의 `state`로 넘깁니다.
- `/auth/v1/discord/callback`이 Discord에서 돌아온 `state`를 받습니다.
- 로그인 성공 후 기존처럼 무조건 `/projects`가 아니라, 안전한 `state`가 있으면 그 경로로 리다이렉트합니다.
- 악성 redirect 방지를 위해 `safeRedirectPathOrDefault`를 추가했습니다.
  - `/channels/...` 같은 상대 경로는 허용
  - `https://evil.com`, `//evil.com`, 제어문자 포함 값은 `/projects`로 fallback

[DiscordOAuthService.java](C:/Users/c/Desktop/devcourse/INT1-Project-Team02/src/main/java/com/flodiback/domain/auth/DiscordOAuthService.java)

- 기존 `buildAuthorizationUrl()`은 유지했습니다.
- 새로 `buildAuthorizationUrl(String state)`를 추가했습니다.
- state가 있으면 Discord authorize URL에 URL-encoded `state=...`를 붙입니다.
- state가 없으면 기존과 동일하게 동작합니다.

**추가**
[AuthControllerTest.java](C:/Users/c/Desktop/devcourse/INT1-Project-Team02/src/test/java/com/flodiback/api/auth/AuthControllerTest.java)

- `/channels/123/dashboard?server_id=1&guild_id=1` 같은 상대 redirect가 허용되는지 테스트
- `https://evil.example`, `//evil.example`, 빈 값, 제어문자 포함 값이 `/projects`로 fallback되는지 테스트

[DiscordOAuthServiceTest.java](C:/Users/c/Desktop/devcourse/INT1-Project-Team02/src/test/java/com/flodiback/domain/auth/DiscordOAuthServiceTest.java)

- state가 주어지면 Discord OAuth URL에 인코딩되어 포함되는지 테스트
- state가 없으면 기존처럼 `state=`가 붙지 않는지 테스트