### PR TITLE
fix: 릴리즈 기준 배포 플로우 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,28 +1,37 @@
 name: Deploy
 
 on:
-  push:
-    branches: [ main ]
+  release:
+    types: [ published ]
 
 permissions:
   contents: read
 
 jobs:
   update-code:
-    name: 코드 업데이트
+    name: 릴리즈 태그 체크아웃
     runs-on: ubuntu-latest
     steps:
-      - name: EC2 git pull
+      - name: EC2 release tag checkout
         uses: appleboy/ssh-action@v1
+        env:
+          DEPLOY_TAG: ${{ github.event.release.tag_name }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          envs: DEPLOY_TAG
           script: |
+            set -eu
+            if ! printf '%s' "$DEPLOY_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+              echo "Invalid release tag: $DEPLOY_TAG"
+              exit 1
+            fi
             cd ~/INT1-Project-Team02
-            git fetch origin
-            git checkout main
-            git pull origin main
+            git fetch origin --tags --force
+            DEPLOY_COMMIT=$(git rev-parse --verify "refs/tags/${DEPLOY_TAG}^{commit}")
+            git checkout --force "$DEPLOY_COMMIT"
+            git reset --hard "$DEPLOY_COMMIT"
 
   build:
     name: 빌드 및 헬스체크
@@ -80,12 +89,12 @@ jobs:
         if: ${{ needs.cleanup.result == 'success' }}
         run: |
           curl -s -H "Content-Type: application/json" \
-            -d "{\"embeds\":[{\"title\":\"배포 완료 🚀\",\"description\":\"**브랜치**: main\\n**커밋**: ${{ github.sha }}\",\"color\":3066993}]}" \
+            -d "{\"embeds\":[{\"title\":\"배포 완료 🚀\",\"description\":\"**릴리즈**: ${{ github.event.release.tag_name }}\\n**커밋**: ${{ github.sha }}\",\"color\":3066993}]}" \
             ${{ secrets.DISCORD_WEBHOOK_URL }}
 
       - name: 배포 실패
         if: ${{ contains(needs.*.result, 'failure') }}
         run: |
           curl -s -H "Content-Type: application/json" \
-            -d "{\"embeds\":[{\"title\":\"배포 실패 ❌\",\"description\":\"**브랜치**: main\\n**커밋**: ${{ github.sha }}\",\"color\":15158332}]}" \
+            -d "{\"embeds\":[{\"title\":\"배포 실패 ❌\",\"description\":\"**릴리즈**: ${{ github.event.release.tag_name }}\\n**커밋**: ${{ github.sha }}\",\"color\":15158332}]}" \
             ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: Release Please
 
 on:
   push:
-    branches: [ dev ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -73,7 +73,7 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          target-branch: dev
+          target-branch: main
 
       - name: Discord 알림 (릴리즈 생성)
         if: ${{ steps.release.outputs.release_created }}

--- a/docs/deployment/ec2-docker-compose.md
+++ b/docs/deployment/ec2-docker-compose.md
@@ -32,7 +32,7 @@ newgrp docker
 ```bash
 git clone https://github.com/Programmers-Intern-Program/INT1-Project-Team02.git
 cd INT1-Project-Team02
-git checkout dev
+git checkout main
 
 vi .env.prod
 
@@ -69,12 +69,27 @@ The API is published on port `8000` by default.
 curl http://localhost:8000/actuator/health
 ```
 
+## Release Deploy Flow
+
+운영 배포는 `main`에 직접 push될 때 실행하지 않는다. Release Please가 `main` 기준으로 릴리즈 PR을 만들고, 해당 PR이 `main`에 머지되어 GitHub Release가 publish될 때 배포가 실행된다.
+
+```text
+feature PR -> dev
+dev 검증
+dev -> main
+Release Please -> chore(main): release x.y.z
+chore(main) -> main
+GitHub Release published
+Deploy workflow -> EC2에서 해당 release tag checkout 후 blue-green 배포
+```
+
+EC2의 배포 workflow는 릴리즈 태그를 checkout해서 배포하므로, 배포된 코드와 GitHub Release 버전이 일치한다.
+
 ## Zero-Downtime API Deploy
 
-업데이트 배포는 `docker compose up -d --build`를 직접 실행하지 않고 blue-green 스크립트로 수행한다.
+업데이트 배포는 `docker compose up -d --build`를 직접 실행하지 않고 blue-green 스크립트로 수행한다. 일반 운영 배포에서는 GitHub Actions가 GitHub Release publish 이벤트를 받아 이 스크립트를 실행한다.
 
 ```bash
-git pull
 ./scripts/deploy-blue-green.sh
 ```
 


### PR DESCRIPTION
## 요약
- Release Please를 dev 기준에서 main 기준으로 변경했습니다.
- Deploy workflow를 main push 기준에서 GitHub Release published 기준으로 변경했습니다.
- EC2 배포 시 main을 pull하지 않고 release tag를 checkout한 뒤 blue/green 배포하도록 변경했습니다.
- EC2 Docker Compose 배포 문서를 새 플로우에 맞게 갱신했습니다.

## 목표 플로우
1. 기능 PR들 → dev
2. dev 검증 완료
3. dev → main 머지
4. Release Please가 main 변경사항을 보고 release PR 생성
5. chore(main): release x.y.z → main 머지
6. vX.Y.Z 태그 / GitHub Release 생성
7. GitHub Release published 이벤트 기준으로 EC2 배포

## 확인
- git diff --check
- Ruby YAML 파싱 확인

Closes #133