### PR TITLE
refactor: glm에서 openai로 교체

### DIFF
--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flodiback.domain.ai.service.AiChatService;
 import com.flodiback.domain.meeting.analysis.dto.AnalysisResult;
 import com.flodiback.domain.meeting.analysis.dto.DecisionItem;
 import com.flodiback.domain.meeting.analysis.dto.WorkLogItem;
@@ -37,7 +38,6 @@ import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository.Sp
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.worklog.entity.WorkLog;
 import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
-import com.flodiback.global.client.GlmClient;
 import com.flodiback.global.exception.ServiceException;
 
 import jakarta.annotation.PostConstruct;
@@ -68,7 +68,7 @@ public class MeetingAnalysisService {
     private final UtteranceRepository utteranceRepository;
     private final WorkLogRepository workLogRepository;
     private final MeetingContextPersistenceService meetingContextPersistenceService;
-    private final GlmClient glmClient;
+    private final AiChatService aiChatService;
     private final ObjectMapper objectMapper;
 
     @Async("analysisExecutor")
@@ -93,10 +93,8 @@ public class MeetingAnalysisService {
         SpeakerDirectory speakerDirectory = buildSpeakerDirectory(meeting);
         // 프로젝트의 기존 작업 로그 조회 (상태 변경 감지용)
         List<WorkLog> existingWorkLogs = workLogRepository.findByProjectIdOrderByCreatedAtDesc(project.getId());
-        // GLM prompt context 생성
         String context = buildContext(meeting, speakerDirectory, existingWorkLogs);
-        // GLM 응답 - GLM은 이름 대신 speaker key 반환
-        AnalysisResult result = callGlm(context);
+        AnalysisResult result = callAi(context);
         UpdateContextRequest request =
                 toUpdateContextRequest(meeting.getId(), result, speakerDirectory, existingWorkLogs);
 
@@ -291,9 +289,9 @@ public class MeetingAnalysisService {
                 .toList();
     }
 
-    private AnalysisResult callGlm(String context) {
+    private AnalysisResult callAi(String context) {
         String prompt = systemPrompt.replace("{today}", LocalDate.now().toString());
-        String raw = glmClient.chat(prompt, context);
+        String raw = aiChatService.generateSummary(prompt, context);
         String json = raw.strip()
                 .replaceAll("^```json\\s*", "")
                 .replaceAll("^```\\s*", "")
@@ -302,7 +300,7 @@ public class MeetingAnalysisService {
         try {
             return objectMapper.readValue(json, AnalysisResult.class);
         } catch (Exception e) {
-            throw new RuntimeException("GLM 응답 파싱 실패: " + raw, e);
+            throw new RuntimeException("AI 응답 파싱 실패: " + raw, e);
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,7 +62,7 @@ ai:
   provider: ${AI_PROVIDER:}
 
 openai:
-  api-key: ${OPENAI_API_KEY}
+  api-key: ${OPENAI_EMBEDDING_API_KEY}
   chat:
     model: ${OPENAI_CHAT_MODEL:gpt-4o-mini}
     base-url: ${OPENAI_CHAT_BASE_URL:https://api.openai.com/v1}

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flodiback.domain.ai.service.AiChatService;
 import com.flodiback.domain.meeting.analysis.dto.AnalysisResult;
 import com.flodiback.domain.meeting.meeting.entity.ContextCache;
 import com.flodiback.domain.meeting.meeting.entity.Meeting;
@@ -42,7 +43,6 @@ import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository.Sp
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.worklog.entity.WorkLog;
 import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
-import com.flodiback.global.client.GlmClient;
 import com.flodiback.global.exception.ServiceException;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,7 +67,7 @@ class MeetingAnalysisServiceTest {
     private MeetingContextPersistenceService meetingContextPersistenceService;
 
     @Mock
-    private GlmClient glmClient;
+    private AiChatService aiChatService;
 
     @Mock(name = "objectMapper")
     private ObjectMapper objectMapper;
@@ -189,7 +189,7 @@ class MeetingAnalysisServiceTest {
         service.analyze(1L);
 
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(glmClient).chat(anyString(), userPromptCaptor.capture());
+        verify(aiChatService).generateSummary(anyString(), userPromptCaptor.capture());
         assertThat(userPromptCaptor.getValue())
                 .contains("[speaker=S1, name=Bob] I can do API.")
                 .contains("[speaker=S2, name=Alice] I can test it.")
@@ -235,14 +235,14 @@ class MeetingAnalysisServiceTest {
                 .willReturn(Optional.empty());
         given(utteranceRepository.findDistinctSpeakersByMeeting(meeting)).willReturn(List.of());
         given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(List.of(utterance));
-        given(glmClient.chat(anyString(), anyString())).willReturn(emptyAnalysisJson());
+        given(aiChatService.generateSummary(anyString(), anyString())).willReturn(emptyAnalysisJson());
         given(objectMapper.readValue(anyString(), any(Class.class)))
                 .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
 
         service.analyze(1L);
 
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(glmClient).chat(anyString(), userPromptCaptor.capture());
+        verify(aiChatService).generateSummary(anyString(), userPromptCaptor.capture());
         assertThat(userPromptCaptor.getValue()).contains("[speaker=unknown, name=Guest] I will check it.");
     }
 
@@ -296,14 +296,14 @@ class MeetingAnalysisServiceTest {
                 .willReturn(List.of(speaker("user-11", "Alice", 11L)));
         given(utteranceRepository.findByMeetingAndIdGreaterThanOrderByIdAsc(meeting, 10L))
                 .willReturn(List.of(later));
-        given(glmClient.chat(anyString(), anyString())).willReturn(emptyAnalysisJson());
+        given(aiChatService.generateSummary(anyString(), anyString())).willReturn(emptyAnalysisJson());
         given(objectMapper.readValue(anyString(), any(Class.class)))
                 .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
 
         service.analyze(1L);
 
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(glmClient).chat(anyString(), userPromptCaptor.capture());
+        verify(aiChatService).generateSummary(anyString(), userPromptCaptor.capture());
         String userPrompt = userPromptCaptor.getValue();
         assertThat(userPrompt).contains("latest summary");
         assertThat(userPrompt).doesNotContain("old summary");
@@ -323,7 +323,7 @@ class MeetingAnalysisServiceTest {
         service.analyze(1L);
 
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(glmClient).chat(anyString(), userPromptCaptor.capture());
+        verify(aiChatService).generateSummary(anyString(), userPromptCaptor.capture());
         assertThat(userPromptCaptor.getValue()).containsSubsequence("first", "second");
     }
 
@@ -377,7 +377,7 @@ class MeetingAnalysisServiceTest {
         service.analyze(1L);
 
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(glmClient).chat(anyString(), userPromptCaptor.capture());
+        verify(aiChatService).generateSummary(anyString(), userPromptCaptor.capture());
         assertThat(userPromptCaptor.getValue())
                 .contains("[프로젝트 기존 작업 항목]")
                 .contains("ID:7")
@@ -403,13 +403,13 @@ class MeetingAnalysisServiceTest {
                 .willReturn(Optional.empty());
         given(utteranceRepository.findDistinctSpeakersByMeeting(meeting)).willReturn(List.of());
         given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(List.of());
-        given(glmClient.chat(anyString(), anyString())).willReturn("not json");
+        given(aiChatService.generateSummary(anyString(), anyString())).willReturn("not json");
         given(objectMapper.readValue(anyString(), any(Class.class)))
                 .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
 
         assertThatThrownBy(() -> service.analyze(1L))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("GLM 응답 파싱 실패");
+                .hasMessageContaining("AI 응답 파싱 실패");
     }
 
     @Test
@@ -422,13 +422,13 @@ class MeetingAnalysisServiceTest {
                 .hasMessageContaining("회의에 연결된 프로젝트가 없습니다.");
     }
 
-    private void givenAnalysisInputs(Meeting meeting, List<Utterance> utterances, String glmResponse) throws Exception {
+    private void givenAnalysisInputs(Meeting meeting, List<Utterance> utterances, String aiResponse) throws Exception {
         given(meetingRepository.findById(1L)).willReturn(Optional.of(meeting));
         given(contextCacheRepository.findTopByMeetingOrderByVersionDesc(meeting))
                 .willReturn(Optional.empty());
         given(utteranceRepository.findDistinctSpeakersByMeeting(meeting)).willReturn(speakersFrom(utterances));
         given(utteranceRepository.findByMeetingOrderByIdAsc(meeting)).willReturn(utterances);
-        given(glmClient.chat(anyString(), anyString())).willReturn(glmResponse);
+        given(aiChatService.generateSummary(anyString(), anyString())).willReturn(aiResponse);
         given(objectMapper.readValue(anyString(), any(Class.class)))
                 .willAnswer(inv -> realMapper.readValue((String) inv.getArgument(0), AnalysisResult.class));
     }


### PR DESCRIPTION
glm에서 openai로 교체

변경 사항:

1. MeetingAnalysisService.java: GlmClient 직접 주입 → AiChatService 추상화로 교체. callGlm() → callAi()로 이름
변경하고 내부에서 aiChatService.generateSummary() 호출.
2. MeetingAnalysisServiceTest.java: @Mock GlmClient → @Mock AiChatService, glmClient.chat(...) 스텁/검증 →
aiChatService.generateSummary(...) 으로 전부 교체.

OpenAI로 전환하려면 .env에 아래 설정만 하면 됩니다:

AI_PROVIDER=openai
OPENAI_API_KEY=sk-...
OPENAI_CHAT_MODEL=gpt-4o-mini   # 또는 gpt-4o 등

RollingSummaryService는 이미 AiChatService를 쓰고 있었으므로 이 설정 하나로 meetingSummary와 rollingSummary 둘 다 OpenAI로 전환됩니다.