### PR TITLE
[refactor] 회의 분석 파싱 및 작업 로그 갱신 이벤트 수정

### DIFF
--- a/docs/references/internal-api-contracts.md
+++ b/docs/references/internal-api-contracts.md
@@ -177,6 +177,24 @@ Discord 서버 ID로 연결된 프로젝트를 조회합니다.
 ## `POST /internal/v1/meetings/{id}/worklogs`
 추출된 작업 로그를 저장합니다.
 
+## WorkLog WebSocket
+작업 로그가 생성되거나 상태가 변경되면 커밋 이후 프로젝트 작업 로그 변경 이벤트를 발행합니다.
+
+Topic:
+`/topic/projects/{projectId}/work-logs`
+
+Payload:
+```json
+{
+  "type": "worklog.changed",
+  "projectId": 1,
+  "meetingId": 10
+}
+```
+
+- 프론트엔드는 이 이벤트를 받으면 기존 `GET /api/v1/projects/{id}/work-logs`를 다시 호출해 현재 필터에 맞는 목록을 갱신합니다.
+- 작업 로그 변경이 없는 컨텍스트 저장은 이벤트를 발행하지 않습니다.
+
 ## 변경 규칙
 - 계약이 바뀌면 이 문서를 반드시 갱신하고 실행 계획 문서에 변경 내역을 남깁니다.
 - 하위 호환이 깨지는 변경은 마이그레이션 절차와 봇 연동 조정 사항을 함께 기록합니다.

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/AnalysisResult.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/AnalysisResult.java
@@ -2,9 +2,14 @@ package com.flodiback.domain.meeting.analysis.dto;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 public record AnalysisResult(
         String summary,
+
+        @JsonDeserialize(using = UnresolvedItemsDeserializer.class)
         String unresolvedItems,
+
         List<WorkLogItem> worklogs,
         List<WorkLogUpdateItem> worklogUpdates,
         List<DecisionItem> decisions) {}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/dto/UnresolvedItemsDeserializer.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/dto/UnresolvedItemsDeserializer.java
@@ -1,0 +1,47 @@
+package com.flodiback.domain.meeting.analysis.dto;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+class UnresolvedItemsDeserializer extends JsonDeserializer<String> {
+
+    @Override
+    public String deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        JsonToken token = parser.currentToken();
+        if (token == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        if (token == JsonToken.VALUE_STRING) {
+            return parser.getValueAsString();
+        }
+        if (token == JsonToken.START_ARRAY) {
+            return joinArray(parser.readValueAsTree());
+        }
+        return (String) context.handleUnexpectedToken(String.class, parser);
+    }
+
+    private String joinArray(JsonNode node) {
+        List<String> items = new ArrayList<>();
+        node.forEach(item -> {
+            if (item == null || item.isNull()) {
+                return;
+            }
+            String value = item.asText(null);
+            if (value == null) {
+                return;
+            }
+            String stripped = value.strip();
+            if (!stripped.isBlank()) {
+                items.add(stripped);
+            }
+        });
+        return items.isEmpty() ? null : String.join("\n", items);
+    }
+}

--- a/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceService.java
+++ b/src/main/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceService.java
@@ -1,5 +1,6 @@
 package com.flodiback.domain.meeting.analysis.service;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -19,6 +20,7 @@ import com.flodiback.domain.meeting.meetinglog.service.MeetingSummaryEmbeddingSe
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
 import com.flodiback.domain.project.worklog.entity.WorkLog;
+import com.flodiback.domain.project.worklog.event.WorkLogChangedEvent;
 import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
 import com.flodiback.global.exception.ServiceException;
 
@@ -35,6 +37,7 @@ public class MeetingContextPersistenceService {
     private final DecisionRepository decisionRepository;
     private final DecisionEmbeddingService decisionEmbeddingService;
     private final MeetingSummaryEmbeddingService meetingSummaryEmbeddingService;
+    private final ApplicationEventPublisher eventPublisher;
     private final TransactionTemplate derivedItemsTransactionTemplate;
 
     public MeetingContextPersistenceService(
@@ -45,6 +48,7 @@ public class MeetingContextPersistenceService {
             DecisionRepository decisionRepository,
             DecisionEmbeddingService decisionEmbeddingService,
             MeetingSummaryEmbeddingService meetingSummaryEmbeddingService,
+            ApplicationEventPublisher eventPublisher,
             PlatformTransactionManager transactionManager) {
         this.meetingRepository = meetingRepository;
         this.meetingSummaryRepository = meetingSummaryRepository;
@@ -53,6 +57,7 @@ public class MeetingContextPersistenceService {
         this.decisionRepository = decisionRepository;
         this.decisionEmbeddingService = decisionEmbeddingService;
         this.meetingSummaryEmbeddingService = meetingSummaryEmbeddingService;
+        this.eventPublisher = eventPublisher;
         this.derivedItemsTransactionTemplate = new TransactionTemplate(transactionManager);
         this.derivedItemsTransactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
     }
@@ -110,29 +115,38 @@ public class MeetingContextPersistenceService {
             });
         }
 
+        boolean workLogsChanged = false;
         if (req.actionItems() != null) {
-            req.actionItems()
-                    .forEach(item -> workLogRepository.save(WorkLog.builder()
-                            .meeting(meeting)
-                            .project(project)
-                            .assigneeName(item.assigneeName())
-                            .assigneeDiscordId(item.assigneeDiscordId())
-                            .task(item.task())
-                            .dueDate(item.dueDate())
-                            .build()));
+            for (var item : req.actionItems()) {
+                workLogRepository.save(WorkLog.builder()
+                        .meeting(meeting)
+                        .project(project)
+                        .assigneeName(item.assigneeName())
+                        .assigneeDiscordId(item.assigneeDiscordId())
+                        .task(item.task())
+                        .dueDate(item.dueDate())
+                        .build());
+                workLogsChanged = true;
+            }
         }
 
         if (req.worklogUpdates() != null) {
-            req.worklogUpdates().forEach(update -> workLogRepository
-                    .findByIdAndProjectId(update.id(), projectId)
-                    .ifPresent(wl -> {
-                        wl.updateStatus(update.status());
-                        workLogRepository.save(wl);
-                    }));
+            for (var update : req.worklogUpdates()) {
+                var workLog = workLogRepository.findByIdAndProjectId(update.id(), projectId);
+                if (workLog.isPresent()) {
+                    WorkLog wl = workLog.get();
+                    wl.updateStatus(update.status());
+                    workLogRepository.save(wl);
+                    workLogsChanged = true;
+                }
+            }
         }
 
         decisionRepository.flush();
         workLogRepository.flush();
+        if (workLogsChanged) {
+            eventPublisher.publishEvent(new WorkLogChangedEvent(projectId, req.meetingId()));
+        }
     }
 
     private Meeting findMeetingInProject(Long projectId, Long meetingId) {

--- a/src/main/java/com/flodiback/domain/meeting/meetinglog/service/ContextService.java
+++ b/src/main/java/com/flodiback/domain/meeting/meetinglog/service/ContextService.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +33,7 @@ import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
 import com.flodiback.domain.project.worklog.entity.WorkLog;
+import com.flodiback.domain.project.worklog.event.WorkLogChangedEvent;
 import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
 import com.flodiback.global.embedding.OpenAiEmbeddingClient;
 import com.flodiback.global.exception.ServiceException;
@@ -65,6 +67,7 @@ public class ContextService {
     private final DecisionEmbeddingService decisionEmbeddingService;
     private final MeetingSummaryEmbeddingService meetingSummaryEmbeddingService;
     private final MeetingStartContextProvider meetingStartContextProvider;
+    private final ApplicationEventPublisher eventPublisher;
 
     public ContextResponse assemble(Long meetingId, String question) {
         Meeting meeting = meetingRepository
@@ -185,25 +188,35 @@ public class ContextService {
             });
         }
 
+        boolean workLogsChanged = false;
         if (req.actionItems() != null) {
-            req.actionItems()
-                    .forEach(item -> workLogRepository.save(WorkLog.builder()
-                            .meeting(meeting)
-                            .project(project)
-                            .assigneeName(item.assigneeName())
-                            .assigneeDiscordId(item.assigneeDiscordId())
-                            .task(item.task())
-                            .dueDate(item.dueDate())
-                            .build()));
+            for (var item : req.actionItems()) {
+                workLogRepository.save(WorkLog.builder()
+                        .meeting(meeting)
+                        .project(project)
+                        .assigneeName(item.assigneeName())
+                        .assigneeDiscordId(item.assigneeDiscordId())
+                        .task(item.task())
+                        .dueDate(item.dueDate())
+                        .build());
+                workLogsChanged = true;
+            }
         }
 
         if (req.worklogUpdates() != null) {
-            req.worklogUpdates().forEach(update -> workLogRepository
-                    .findByIdAndProjectId(update.id(), projectId)
-                    .ifPresent(wl -> {
-                        wl.updateStatus(update.status());
-                        workLogRepository.save(wl);
-                    }));
+            for (var update : req.worklogUpdates()) {
+                var workLog = workLogRepository.findByIdAndProjectId(update.id(), projectId);
+                if (workLog.isPresent()) {
+                    WorkLog wl = workLog.get();
+                    wl.updateStatus(update.status());
+                    workLogRepository.save(wl);
+                    workLogsChanged = true;
+                }
+            }
+        }
+
+        if (workLogsChanged) {
+            eventPublisher.publishEvent(new WorkLogChangedEvent(projectId, req.meetingId()));
         }
     }
 

--- a/src/main/java/com/flodiback/domain/project/worklog/event/WorkLogChangedEvent.java
+++ b/src/main/java/com/flodiback/domain/project/worklog/event/WorkLogChangedEvent.java
@@ -1,0 +1,3 @@
+package com.flodiback.domain.project.worklog.event;
+
+public record WorkLogChangedEvent(Long projectId, Long meetingId) {}

--- a/src/main/java/com/flodiback/global/websocket/WorkLogWebSocketPublisher.java
+++ b/src/main/java/com/flodiback/global/websocket/WorkLogWebSocketPublisher.java
@@ -1,0 +1,26 @@
+package com.flodiback.global.websocket;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.flodiback.domain.project.worklog.event.WorkLogChangedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class WorkLogWebSocketPublisher {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onWorkLogChanged(WorkLogChangedEvent event) {
+        messagingTemplate.convertAndSend(
+                "/topic/projects/" + event.projectId() + "/work-logs",
+                new WorkLogChangedMessage("worklog.changed", event.projectId(), event.meetingId()));
+    }
+
+    record WorkLogChangedMessage(String type, Long projectId, Long meetingId) {}
+}

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingAnalysisServiceTest.java
@@ -178,6 +178,34 @@ class MeetingAnalysisServiceTest {
     }
 
     @Test
+    void analyze_acceptsUnresolvedItemsArrayFromAiResponse() throws Exception {
+        Project project = mockProject(10L);
+        Meeting meeting = Meeting.builder().project(project).title("meeting").build();
+        String aiResponse = """
+                {
+                  "summary": "summary",
+                  "unresolvedItems": [
+                    "비행기 및 배편 가격 확정",
+                    "   ",
+                    null,
+                    "렌터카 예약 여부 확인"
+                  ],
+                  "worklogs": [],
+                  "decisions": []
+                }
+                """;
+
+        givenAnalysisInputs(meeting, List.of(), aiResponse);
+
+        service.analyze(1L);
+
+        ArgumentCaptor<UpdateContextRequest> captor = ArgumentCaptor.forClass(UpdateContextRequest.class);
+        verify(meetingContextPersistenceService)
+                .saveSummaryRequired(org.mockito.ArgumentMatchers.eq(10L), captor.capture());
+        assertThat(captor.getValue().unresolvedItems()).isEqualTo("비행기 및 배편 가격 확정\n렌터카 예약 여부 확인");
+    }
+
+    @Test
     void analyze_assignsSpeakerKeysByFirstUtteranceIdAndFormatsPrompt() throws Exception {
         Project project = mockProject(10L);
         Meeting meeting = Meeting.builder().project(project).title("meeting").build();

--- a/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/analysis/service/MeetingContextPersistenceServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
@@ -37,6 +38,7 @@ import com.flodiback.domain.meeting.meetinglog.service.MeetingSummaryEmbeddingSe
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
 import com.flodiback.domain.project.worklog.entity.WorkLog;
+import com.flodiback.domain.project.worklog.event.WorkLogChangedEvent;
 import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
 import com.flodiback.global.exception.ServiceException;
 
@@ -65,6 +67,9 @@ class MeetingContextPersistenceServiceTest {
     private MeetingSummaryEmbeddingService meetingSummaryEmbeddingService;
 
     @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
     private PlatformTransactionManager transactionManager;
 
     private MeetingContextPersistenceService service;
@@ -79,6 +84,7 @@ class MeetingContextPersistenceServiceTest {
                 decisionRepository,
                 decisionEmbeddingService,
                 meetingSummaryEmbeddingService,
+                eventPublisher,
                 transactionManager);
     }
 
@@ -149,6 +155,7 @@ class MeetingContextPersistenceServiceTest {
         assertThat(workLogCaptor.getAllValues())
                 .extracting(WorkLog::getAssigneeDiscordId)
                 .containsExactly("discord-alice", null);
+        verify(eventPublisher).publishEvent(new WorkLogChangedEvent(1L, 10L));
     }
 
     @Test
@@ -167,6 +174,22 @@ class MeetingContextPersistenceServiceTest {
 
         assertThat(workLog.getStatus()).isEqualTo("DONE");
         verify(workLogRepository).save(workLog);
+        verify(eventPublisher).publishEvent(new WorkLogChangedEvent(1L, 10L));
+    }
+
+    @Test
+    void saveDerivedItemsBestEffort_doesNotPublishWorkLogEventWithoutWorkLogChanges() {
+        Project project = project(1L);
+        Meeting meeting = meeting(project);
+        UpdateContextRequest req = new UpdateContextRequest(10L, "summary", null, List.of("decision"), null, null);
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(meetingRepository.findById(10L)).willReturn(Optional.of(meeting));
+        given(decisionRepository.save(any(Decision.class))).willAnswer(invocation -> invocation.getArgument(0));
+        stubNewTransaction();
+
+        service.saveDerivedItemsBestEffort(1L, req);
+
+        verify(eventPublisher, never()).publishEvent(any(WorkLogChangedEvent.class));
     }
 
     @Test

--- a/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
+++ b/src/test/java/com/flodiback/domain/meeting/meetinglog/service/ContextServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.flodiback.domain.decision.decision.entity.Decision;
@@ -45,6 +46,7 @@ import com.flodiback.domain.meeting.meetinglog.repository.UtteranceRepository;
 import com.flodiback.domain.project.project.entity.Project;
 import com.flodiback.domain.project.project.repository.ProjectRepository;
 import com.flodiback.domain.project.worklog.entity.WorkLog;
+import com.flodiback.domain.project.worklog.event.WorkLogChangedEvent;
 import com.flodiback.domain.project.worklog.repository.WorkLogRepository;
 import com.flodiback.global.embedding.OpenAiEmbeddingClient;
 import com.flodiback.global.exception.ServiceException;
@@ -84,6 +86,9 @@ class ContextServiceTest {
 
     @Mock
     private MeetingStartContextProvider meetingStartContextProvider;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private ContextService contextService;
@@ -304,6 +309,7 @@ class ContextServiceTest {
         assertThat(workLogCaptor.getAllValues())
                 .extracting(WorkLog::getAssigneeDiscordId)
                 .containsExactly("discord-alice", null);
+        verify(eventPublisher).publishEvent(new WorkLogChangedEvent(1L, 1L));
     }
 
     @Test
@@ -328,6 +334,7 @@ class ContextServiceTest {
 
         assertThat(workLog.getStatus()).isEqualTo("CANCELLED");
         verify(workLogRepository).save(workLog);
+        verify(eventPublisher).publishEvent(new WorkLogChangedEvent(1L, 1L));
     }
 
     @Test

--- a/src/test/java/com/flodiback/global/websocket/WorkLogWebSocketPublisherTest.java
+++ b/src/test/java/com/flodiback/global/websocket/WorkLogWebSocketPublisherTest.java
@@ -1,0 +1,52 @@
+package com.flodiback.global.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.flodiback.domain.project.worklog.event.WorkLogChangedEvent;
+
+@ExtendWith(MockitoExtension.class)
+class WorkLogWebSocketPublisherTest {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Test
+    void onWorkLogChanged_publishesProjectWorkLogChange() {
+        WorkLogWebSocketPublisher publisher = new WorkLogWebSocketPublisher(messagingTemplate);
+
+        publisher.onWorkLogChanged(new WorkLogChangedEvent(1L, 10L));
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(messagingTemplate)
+                .convertAndSend(
+                        org.mockito.ArgumentMatchers.eq("/topic/projects/1/work-logs"), payloadCaptor.capture());
+        Object payload = payloadCaptor.getValue();
+        assertThat(payload).hasFieldOrPropertyWithValue("type", "worklog.changed");
+        assertThat(payload).hasFieldOrPropertyWithValue("projectId", 1L);
+        assertThat(payload).hasFieldOrPropertyWithValue("meetingId", 10L);
+    }
+
+    @Test
+    void onWorkLogChanged_runsAfterCommit() throws NoSuchMethodException {
+        Method method = WorkLogWebSocketPublisher.class.getMethod("onWorkLogChanged", WorkLogChangedEvent.class);
+
+        TransactionalEventListener eventListener =
+                AnnotatedElementUtils.findMergedAnnotation(method, TransactionalEventListener.class);
+
+        assertThat(eventListener).isNotNull();
+        assertThat(eventListener.phase()).isEqualTo(TransactionPhase.AFTER_COMMIT);
+    }
+}


### PR DESCRIPTION
## 변경 내용
- 회의 분석 AI 응답의 unresolvedItems가 문자열 또는 배열로 와도 파싱되도록 필드 전용 deserializer를 추가했습니다.
- 작업 로그 생성/상태 변경 후 /topic/projects/{projectId}/work-logs WebSocket 이벤트를 발행하도록 했습니다.
- 작업 로그 변경 이벤트 계약을 문서화하고 회귀 테스트를 추가했습니다.

## 배경
- GPT 응답이 프롬프트와 달리 unresolvedItems를 배열로 반환하면 AnalysisResult 역직렬화가 실패했습니다.
- 작업 로그 목록 화면은 변경 신호가 없어 새로고침 전까지 최신 목록을 알 수 없었습니다.

## 검증
- ./gradlew test --tests com.flodiback.domain.meeting.analysis.service.MeetingAnalysisServiceTest --tests com.flodiback.domain.meeting.analysis.service.MeetingContextPersistenceServiceTest --tests com.flodiback.domain.meeting.meetinglog.service.ContextServiceTest --tests com.flodiback.global.websocket.WorkLogWebSocketPublisherTest
- ./gradlew spotlessCheck
- git diff --check

## 참고
- 전체 ./gradlew test는 로컬 Docker/Testcontainers 초기화 실패로 기존 통합 테스트 15개가 실패합니다.

Closes #146